### PR TITLE
[core] add `parseMethod`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .eslintrc.js
 .idea
 .npm
+.npmrc
 .prettierignore
 .yarnclean
 

--- a/package.json
+++ b/package.json
@@ -5,13 +5,12 @@
   "private": true,
   "scripts": {
     "build": "lerna run build",
-    "jest": "lerna run test",
     "lint": "lerna run lint",
     "lint:fix": "lerna run lint:fix",
     "prerelease": "yarn run build",
-    "prepare-release": "git checkout master && git pull --rebase origin master && yarn run test",
+    "prepare-release": "git checkout master && git pull --rebase origin master && lerna bootstrap && yarn run lint && yarn run test",
     "release": "yarn run prepare-release && lerna publish && lerna run gh-pages",
-    "test": "lerna bootstrap && yarn run lint && yarn run jest"
+    "test": "lerna run test"
   },
   "repository": "https://github.com/apache-superset/superset-ui.git",
   "keywords": [

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.12",
+    "@data-ui/build-config": "^0.0.13",
     "fetch-mock": "^6.5.2",
     "node-fetch": "^2.2.0"
   },

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.13",
+    "@data-ui/build-config": "^0.0.14",
     "fetch-mock": "^6.5.2",
     "node-fetch": "^2.2.0"
   },

--- a/packages/superset-ui-core/src/SupersetClient.js
+++ b/packages/superset-ui-core/src/SupersetClient.js
@@ -75,7 +75,7 @@ class SupersetClient {
     );
   }
 
-  get({ host, url, endpoint, mode, credentials, headers, body, timeout, signal }) {
+  get({ body, credentials, headers, host, endpoint, mode, parseMethod, signal, timeout, url }) {
     return this.ensureAuth().then(() =>
       callApi({
         body,
@@ -83,6 +83,7 @@ class SupersetClient {
         headers: { ...this.headers, ...headers },
         method: 'GET',
         mode: mode || this.mode,
+        parseMethod,
         signal,
         timeout: timeout || this.timeout,
         url: url || this.getUrl({ endpoint, host: host || this.host }),
@@ -91,16 +92,17 @@ class SupersetClient {
   }
 
   post({
-    host,
-    endpoint,
-    url,
-    mode,
     credentials,
     headers,
+    host,
+    endpoint,
+    mode,
+    parseMethod,
     postPayload,
-    timeout,
     signal,
     stringify,
+    timeout,
+    url,
   }) {
     return this.ensureAuth().then(() =>
       callApi({
@@ -108,6 +110,7 @@ class SupersetClient {
         headers: { ...this.headers, ...headers },
         method: 'POST',
         mode: mode || this.mode,
+        parseMethod,
         postPayload,
         signal,
         stringify,

--- a/packages/superset-ui-core/src/callApi/callApi.js
+++ b/packages/superset-ui-core/src/callApi/callApi.js
@@ -15,7 +15,6 @@ export default function callApi({
   postPayload,
   stringify = true,
   redirect = 'follow', // manual, follow, error
-  timeoutId,
   signal, // used for aborting
 }) {
   let request = {

--- a/packages/superset-ui-core/src/callApi/callApiAndParseWithTimeout.js
+++ b/packages/superset-ui-core/src/callApi/callApiAndParseWithTimeout.js
@@ -2,7 +2,7 @@ import callApi from './callApi';
 import rejectAfterTimeout from './rejectAfterTimeout';
 import parseResponse from './parseResponse';
 
-export default function callApiAndParseWithTimeout({ timeout, ...rest }) {
+export default function callApiAndParseWithTimeout({ timeout, parseMethod, ...rest }) {
   const apiPromise = callApi(rest);
 
   const racedPromise =
@@ -10,5 +10,5 @@ export default function callApiAndParseWithTimeout({ timeout, ...rest }) {
       ? Promise.race([rejectAfterTimeout(timeout), apiPromise])
       : apiPromise;
 
-  return parseResponse(racedPromise);
+  return parseResponse(racedPromise, parseMethod);
 }

--- a/packages/superset-ui-core/src/callApi/parseResponse.js
+++ b/packages/superset-ui-core/src/callApi/parseResponse.js
@@ -1,35 +1,29 @@
+const PARSERS = {
+  json: response =>
+    // first try to parse as json, and fall back to text (e.g., in the case of HTML stacktrace)
+    // cannot fall back to .text() without cloning the response because body is single-use
+    response
+      .clone()
+      .json()
+      .then(json => ({ json, response }))
+      .catch(() => /* jsonParseError */ response.text().then(text => ({ response, text }))),
+
+  text: response => response.text().then(text => ({ response, text })),
+};
+
 export default function parseResponse(apiPromise, parseMethod = 'json') {
-  return apiPromise.then(response => {
-    let parsedPromise;
-    if (parseMethod === 'json') {
-      // first try to parse as json, and fall back to text (e.g., in the case of HTML stacktrace)
-      // cannot fall back to .text() without cloning the response because body is single-use
-      parsedPromise = response
-        .clone()
-        .json()
-        .catch(() => /* jsonParseError */ response.text().then(textPayload => ({ textPayload })));
-    } else if (parseMethod === 'text') {
-      parsedPromise = response.text().then(textPayload => ({ textPayload }));
-    } else {
-      throw Error(`Unrecognized parseMethod '${parseMethod}', expected 'json' or 'text'`);
+  const responseParser = PARSERS[parseMethod] || PARSERS.json;
+
+  return apiPromise.then(responseParser).then(({ json, text, response }) => {
+    // HTTP 404 or 500 are not rejected, ok is just set to false
+    if (!response.ok) {
+      return Promise.reject({
+        error: response.error || (json && json.error) || text || 'An error occurred',
+        status: response.status,
+        statusText: response.statusText,
+      });
     }
 
-    return parsedPromise
-      .then(maybeJson => ({
-        json: maybeJson.textPayload ? undefined : maybeJson,
-        text: maybeJson.textPayload,
-      }))
-      .then(({ json, text }) => {
-        // HTTP 404 or 500 are not rejected, ok is just set to false
-        if (!response.ok) {
-          return Promise.reject({
-            error: response.error || (json && json.error) || text || 'An error occurred',
-            status: response.status,
-            statusText: response.statusText,
-          });
-        }
-
-        return typeof text === 'undefined' ? { json, response } : { response, text };
-      });
+    return typeof text === 'undefined' ? { json, response } : { response, text };
   });
 }

--- a/packages/superset-ui-core/src/callApi/parseResponse.js
+++ b/packages/superset-ui-core/src/callApi/parseResponse.js
@@ -1,17 +1,26 @@
-export default function parseResponse(apiPromise) {
-  return apiPromise.then(apiResponse =>
-    // first try to parse as json, and fall back to text (e.g., in the case of HTML stacktrace)
-    // cannot fall back to .text() without cloning the response because body is single-use
-    apiResponse
-      .clone()
-      .json()
-      .catch(() => /* jsonParseError */ apiResponse.text().then(textPayload => ({ textPayload })))
+export default function parseResponse(apiPromise, parseMethod = 'json') {
+  return apiPromise.then(response => {
+    let parsedPromise;
+    if (parseMethod === 'json') {
+      // first try to parse as json, and fall back to text (e.g., in the case of HTML stacktrace)
+      // cannot fall back to .text() without cloning the response because body is single-use
+      parsedPromise = response
+        .clone()
+        .json()
+        .catch(() => /* jsonParseError */ response.text().then(textPayload => ({ textPayload })));
+    } else if (parseMethod === 'text') {
+      parsedPromise = response.text().then(textPayload => ({ textPayload }));
+    } else {
+      throw Error(`Unrecognized parseMethod '${parseMethod}', expected 'json' or 'text'`);
+    }
+
+    return parsedPromise
       .then(maybeJson => ({
         json: maybeJson.textPayload ? undefined : maybeJson,
-        response: apiResponse,
         text: maybeJson.textPayload,
       }))
-      .then(({ response, json, text }) => {
+      .then(({ json, text }) => {
+        // HTTP 404 or 500 are not rejected, ok is just set to false
         if (!response.ok) {
           return Promise.reject({
             error: response.error || (json && json.error) || text || 'An error occurred',
@@ -21,6 +30,6 @@ export default function parseResponse(apiPromise) {
         }
 
         return typeof text === 'undefined' ? { json, response } : { response, text };
-      }),
-  );
+      });
+  });
 }

--- a/packages/superset-ui-core/src/callApi/parseResponse.js
+++ b/packages/superset-ui-core/src/callApi/parseResponse.js
@@ -14,7 +14,7 @@ const PARSERS = {
 export default function parseResponse(apiPromise, parseMethod = 'json') {
   const responseParser = PARSERS[parseMethod] || PARSERS.json;
 
-  return apiPromise.then(responseParser).then(({ json, text, response }) => {
+  return apiPromise.then(responseParser).then(({ json, response, text }) => {
     // HTTP 404 or 500 are not rejected, ok is just set to false
     if (!response.ok) {
       return Promise.reject({
@@ -24,6 +24,6 @@ export default function parseResponse(apiPromise, parseMethod = 'json') {
       });
     }
 
-    return typeof text === 'undefined' ? { json, response } : { response, text };
+    return { json, response, text };
   });
 }

--- a/packages/superset-ui-core/test/SupersetClient.test.js
+++ b/packages/superset-ui-core/test/SupersetClient.test.js
@@ -243,11 +243,16 @@ describe('SupersetClient', () => {
       const host = 'HOST';
       const mockGetEndpoint = '/get/url';
       const mockPostEndpoint = '/post/url';
+      const mockTextEndpoint = '/text/endpoint';
       const mockGetUrl = `${protocol}://${host}${mockGetEndpoint}`;
       const mockPostUrl = `${protocol}://${host}${mockPostEndpoint}`;
+      const mockTextUrl = `${protocol}://${host}${mockTextEndpoint}`;
+      const mockTextJsonResponse = '{ "value": 9223372036854775807 }';
 
       fetchMock.get(mockGetUrl, 'Ok');
       fetchMock.post(mockPostUrl, 'Ok');
+      fetchMock.get(mockTextUrl, mockTextJsonResponse);
+      fetchMock.post(mockTextUrl, mockTextJsonResponse);
 
       it('checks for authentication before every get and post request', done => {
         expect.assertions(3);
@@ -313,6 +318,25 @@ describe('SupersetClient', () => {
               ])
                 .then(() => {
                   expect(fetchMock.calls(mockGetUrl)).toHaveLength(2);
+
+                  return done();
+                })
+                .catch(throwIfCalled),
+            )
+            .catch(throwIfCalled);
+        });
+
+        it('supports parsing a response as text', done => {
+          expect.assertions(2);
+          const client = new SupersetClient({ protocol, host });
+          client
+            .init()
+            .then(() =>
+              client
+                .get({ url: mockTextUrl, parseMethod: 'text' })
+                .then(({ text }) => {
+                  expect(fetchMock.calls(mockTextUrl)).toHaveLength(1);
+                  expect(text).toBe(mockTextJsonResponse);
 
                   return done();
                 })
@@ -410,6 +434,25 @@ describe('SupersetClient', () => {
                   expect(fetchRequest.headers).toEqual(
                     expect.objectContaining(overrideConfig.headers),
                   );
+
+                  return done();
+                })
+                .catch(throwIfCalled),
+            )
+            .catch(throwIfCalled);
+        });
+
+        it('supports parsing a response as text', done => {
+          expect.assertions(2);
+          const client = new SupersetClient({ protocol, host });
+          client
+            .init()
+            .then(() =>
+              client
+                .post({ url: mockTextUrl, parseMethod: 'text' })
+                .then(({ text }) => {
+                  expect(fetchMock.calls(mockTextUrl)).toHaveLength(1);
+                  expect(text).toBe(mockTextJsonResponse);
 
                   return done();
                 })

--- a/packages/superset-ui-core/test/callApi/callApi.test.js
+++ b/packages/superset-ui-core/test/callApi/callApi.test.js
@@ -27,23 +27,21 @@ describe('callApi()', () => {
   afterEach(fetchMock.reset);
 
   describe('request config', () => {
-    it('calls the right url with the specified method', done => {
+    it('calls the right url with the specified method', () => {
       expect.assertions(2);
 
-      Promise.all([
+      return Promise.all([
         callApi({ url: mockGetUrl, method: 'GET' }),
         callApi({ url: mockPostUrl, method: 'POST' }),
-      ])
-        .then(() => {
-          expect(fetchMock.calls(mockGetUrl)).toHaveLength(1);
-          expect(fetchMock.calls(mockPostUrl)).toHaveLength(1);
+      ]).then(() => {
+        expect(fetchMock.calls(mockGetUrl)).toHaveLength(1);
+        expect(fetchMock.calls(mockPostUrl)).toHaveLength(1);
 
-          return done();
-        })
-        .catch(throwIfCalled);
+        return Promise.resolve();
+      });
     });
 
-    it('passes along mode, cache, credentials, headers, body, signal, and redirect parameters in the request', done => {
+    it('passes along mode, cache, credentials, headers, body, signal, and redirect parameters in the request', () => {
       expect.assertions(8);
 
       const mockRequest = {
@@ -59,68 +57,62 @@ describe('callApi()', () => {
         body: 'BODY',
       };
 
-      callApi(mockRequest)
-        .then(() => {
-          const calls = fetchMock.calls(mockGetUrl);
-          const fetchParams = calls[0][1];
-          expect(calls).toHaveLength(1);
-          expect(fetchParams.mode).toBe(mockRequest.mode);
-          expect(fetchParams.cache).toBe(mockRequest.cache);
-          expect(fetchParams.credentials).toBe(mockRequest.credentials);
-          expect(fetchParams.headers).toEqual(expect.objectContaining(mockRequest.headers));
-          expect(fetchParams.redirect).toBe(mockRequest.redirect);
-          expect(fetchParams.signal).toBe(mockRequest.signal);
-          expect(fetchParams.body).toBe(mockRequest.body);
+      return callApi(mockRequest).then(() => {
+        const calls = fetchMock.calls(mockGetUrl);
+        const fetchParams = calls[0][1];
+        expect(calls).toHaveLength(1);
+        expect(fetchParams.mode).toBe(mockRequest.mode);
+        expect(fetchParams.cache).toBe(mockRequest.cache);
+        expect(fetchParams.credentials).toBe(mockRequest.credentials);
+        expect(fetchParams.headers).toEqual(expect.objectContaining(mockRequest.headers));
+        expect(fetchParams.redirect).toBe(mockRequest.redirect);
+        expect(fetchParams.signal).toBe(mockRequest.signal);
+        expect(fetchParams.body).toBe(mockRequest.body);
 
-          return done();
-        })
-        .catch(throwIfCalled);
+        return Promise.resolve();
+      });
     });
   });
 
   describe('POST requests', () => {
-    it('encodes key,value pairs from postPayload', done => {
+    it('encodes key,value pairs from postPayload', () => {
       expect.assertions(3);
       const postPayload = { key: 'value', anotherKey: 1237 };
 
-      callApi({ url: mockPostUrl, method: 'POST', postPayload })
-        .then(() => {
-          const calls = fetchMock.calls(mockPostUrl);
-          expect(calls).toHaveLength(1);
+      return callApi({ url: mockPostUrl, method: 'POST', postPayload }).then(() => {
+        const calls = fetchMock.calls(mockPostUrl);
+        expect(calls).toHaveLength(1);
 
-          const fetchParams = calls[0][1];
-          const { body } = fetchParams;
+        const fetchParams = calls[0][1];
+        const { body } = fetchParams;
 
-          Object.keys(postPayload).forEach(key => {
-            expect(body.get(key)).toBe(JSON.stringify(postPayload[key]));
-          });
+        Object.keys(postPayload).forEach(key => {
+          expect(body.get(key)).toBe(JSON.stringify(postPayload[key]));
+        });
 
-          return done();
-        })
-        .catch(throwIfCalled);
+        return Promise.resolve();
+      });
     });
 
     // the reason for this is to omit strings like 'undefined' from making their way to the backend
-    it('omits key,value pairs from postPayload that have undefined values', done => {
+    it('omits key,value pairs from postPayload that have undefined values', () => {
       expect.assertions(3);
       const postPayload = { key: 'value', noValue: undefined };
 
-      callApi({ url: mockPostUrl, method: 'POST', postPayload })
-        .then(() => {
-          const calls = fetchMock.calls(mockPostUrl);
-          expect(calls).toHaveLength(1);
+      return callApi({ url: mockPostUrl, method: 'POST', postPayload }).then(() => {
+        const calls = fetchMock.calls(mockPostUrl);
+        expect(calls).toHaveLength(1);
 
-          const fetchParams = calls[0][1];
-          const { body } = fetchParams;
-          expect(body.get('key')).toBe(JSON.stringify(postPayload.key));
-          expect(body.get('noValue')).toBeNull();
+        const fetchParams = calls[0][1];
+        const { body } = fetchParams;
+        expect(body.get('key')).toBe(JSON.stringify(postPayload.key));
+        expect(body.get('noValue')).toBeNull();
 
-          return done();
-        })
-        .catch(throwIfCalled);
+        return Promise.resolve();
+      });
     });
 
-    it('respects the stringify flag in POST requests', done => {
+    it('respects the stringify flag in POST requests', () => {
       const postPayload = {
         string: 'value',
         number: 1237,
@@ -132,25 +124,35 @@ describe('callApi()', () => {
 
       expect.assertions(1 + 2 * Object.keys(postPayload).length);
 
-      Promise.all([
+      return Promise.all([
         callApi({ url: mockPostUrl, method: 'POST', postPayload }),
         callApi({ url: mockPostUrl, method: 'POST', postPayload, stringify: false }),
-      ])
-        .then(() => {
-          const calls = fetchMock.calls(mockPostUrl);
-          expect(calls).toHaveLength(2);
+      ]).then(() => {
+        const calls = fetchMock.calls(mockPostUrl);
+        expect(calls).toHaveLength(2);
 
-          const stringified = calls[0][1].body;
-          const unstringified = calls[1][1].body;
+        const stringified = calls[0][1].body;
+        const unstringified = calls[1][1].body;
 
-          Object.keys(postPayload).forEach(key => {
-            expect(stringified.get(key)).toBe(JSON.stringify(postPayload[key]));
-            expect(unstringified.get(key)).toBe(String(postPayload[key]));
-          });
+        Object.keys(postPayload).forEach(key => {
+          expect(stringified.get(key)).toBe(JSON.stringify(postPayload[key]));
+          expect(unstringified.get(key)).toBe(String(postPayload[key]));
+        });
 
-          return done();
-        })
-        .catch(throwIfCalled);
+        return Promise.resolve();
+      });
     });
+  });
+
+  it('rejects if the request throws', () => {
+    expect.assertions(3);
+
+    return callApi({ url: mockErrorUrl, method: 'GET' })
+      .then(throwIfCalled)
+      .catch(error => {
+        expect(fetchMock.calls(mockErrorUrl)).toHaveLength(1);
+        expect(error.status).toBe(mockErrorPayload.status);
+        expect(error.statusText).toBe(mockErrorPayload.statusText);
+      });
   });
 });

--- a/packages/superset-ui-core/test/callApi/callApiAndParseWithTimeout.test.js
+++ b/packages/superset-ui-core/test/callApi/callApiAndParseWithTimeout.test.js
@@ -1,4 +1,3 @@
-/* eslint promise/no-callback-in-promise: 'off' */
 import fetchMock from 'fetch-mock';
 
 import callApiAndParseWithTimeout from '../../src/callApi/callApiAndParseWithTimeout';
@@ -80,23 +79,23 @@ describe('callApiAndParseWithTimeout()', () => {
           );
           expect(timeoutError.statusText).toBe('timeout');
 
-          return done();
+          return done(); // eslint-disable-line promise/no-callback-in-promise
         });
 
       jest.runOnlyPendingTimers();
     });
 
-    it('resolves if the request does not exceed the timeout', done => {
+    it('resolves if the request does not exceed the timeout', () => {
       expect.assertions(1);
       jest.useFakeTimers();
 
-      callApiAndParseWithTimeout({ url: mockGetUrl, method: 'GET', timeout: 100 })
-        .then(response => {
+      return callApiAndParseWithTimeout({ url: mockGetUrl, method: 'GET', timeout: 100 }).then(
+        response => {
           expect(response.json).toEqual(expect.objectContaining(mockGetPayload));
 
-          return done();
-        })
-        .catch(throwIfCalled);
+          return Promise.resolve();
+        },
+      );
     });
   });
 });

--- a/packages/superset-ui-core/test/callApi/parseResponse.test.js
+++ b/packages/superset-ui-core/test/callApi/parseResponse.test.js
@@ -72,14 +72,14 @@ describe('parseResponse()', () => {
     expect.assertions(3);
 
     // test with json + bigint to ensure that it was not first parsed as json
-    const mockTextUrl = '/mock/textparse/url';
+    const mockTextParseUrl = '/mock/textparse/url';
     const mockTextJsonResponse = '{ "value": 9223372036854775807 }';
-    fetchMock.get(mockTextUrl, mockTextJsonResponse);
+    fetchMock.get(mockTextParseUrl, mockTextJsonResponse);
 
-    const apiPromise = callApi({ url: mockTextUrl, method: 'GET', parseMethod: 'text' });
-    parseResponse(apiPromise)
+    const apiPromise = callApi({ url: mockTextParseUrl, method: 'GET' });
+    parseResponse(apiPromise, 'text')
       .then(args => {
-        expect(fetchMock.calls(mockTextUrl)).toHaveLength(1);
+        expect(fetchMock.calls(mockTextParseUrl)).toHaveLength(1);
         expect(Object.keys(args)).toEqual(expect.arrayContaining(['response', 'text']));
         expect(args.text).toBe(mockTextJsonResponse);
 

--- a/packages/superset-ui-core/test/callApi/parseResponse.test.js
+++ b/packages/superset-ui-core/test/callApi/parseResponse.test.js
@@ -68,6 +68,26 @@ describe('parseResponse()', () => {
       .catch(throwIfCalled);
   });
 
+  it('resolves to { text, response } if the parseMethod is set to `text`', done => {
+    expect.assertions(3);
+
+    // test with json + bigint to ensure that it was not first parsed as json
+    const mockTextUrl = '/mock/textparse/url';
+    const mockTextJsonResponse = '{ "value": 9223372036854775807 }';
+    fetchMock.get(mockTextUrl, mockTextJsonResponse);
+
+    const apiPromise = callApi({ url: mockTextUrl, method: 'GET', parseMethod: 'text' });
+    parseResponse(apiPromise)
+      .then(args => {
+        expect(fetchMock.calls(mockTextUrl)).toHaveLength(1);
+        expect(Object.keys(args)).toEqual(expect.arrayContaining(['response', 'text']));
+        expect(args.text).toBe(mockTextJsonResponse);
+
+        return done();
+      })
+      .catch(throwIfCalled);
+  });
+
   it('rejects if the request throws', done => {
     expect.assertions(3);
 

--- a/packages/superset-ui-core/test/callApi/parseResponse.test.js
+++ b/packages/superset-ui-core/test/callApi/parseResponse.test.js
@@ -1,4 +1,3 @@
-/* eslint promise/no-callback-in-promise: 'off' */
 import fetchMock from 'fetch-mock';
 import callApi from '../../src/callApi/callApi';
 import parseResponse from '../../src/callApi/parseResponse';
@@ -33,22 +32,20 @@ describe('parseResponse()', () => {
     expect(parsedResponsePromise).toEqual(expect.any(Promise));
   });
 
-  it('resolves to { json, response } if the request succeeds', done => {
+  it('resolves to { json, response } if the request succeeds', () => {
     expect.assertions(3);
     const apiPromise = callApi({ url: mockGetUrl, method: 'GET' });
 
-    parseResponse(apiPromise)
-      .then(args => {
-        expect(fetchMock.calls(mockGetUrl)).toHaveLength(1);
-        expect(Object.keys(args)).toEqual(expect.arrayContaining(['response', 'json']));
-        expect(args.json).toEqual(expect.objectContaining(mockGetPayload));
+    return parseResponse(apiPromise).then(args => {
+      expect(fetchMock.calls(mockGetUrl)).toHaveLength(1);
+      expect(Object.keys(args)).toEqual(expect.arrayContaining(['response', 'json']));
+      expect(args.json).toEqual(expect.objectContaining(mockGetPayload));
 
-        return done();
-      })
-      .catch(throwIfCalled);
+      return Promise.resolve();
+    });
   });
 
-  it('resolves to { text, response } if the request succeeds with text response', done => {
+  it('throws if `parseMethod=json` and .json() fails', () => {
     expect.assertions(3);
 
     const mockTextUrl = '/mock/text/url';
@@ -57,18 +54,19 @@ describe('parseResponse()', () => {
     fetchMock.get(mockTextUrl, mockTextResponse);
 
     const apiPromise = callApi({ url: mockTextUrl, method: 'GET' });
-    parseResponse(apiPromise)
-      .then(args => {
-        expect(fetchMock.calls(mockTextUrl)).toHaveLength(1);
-        expect(Object.keys(args)).toEqual(expect.arrayContaining(['response', 'text']));
-        expect(args.text).toBe(mockTextResponse);
 
-        return done();
-      })
-      .catch(throwIfCalled);
+    return parseResponse(apiPromise, 'json')
+      .then(throwIfCalled)
+      .catch(error => {
+        expect(fetchMock.calls(mockTextUrl)).toHaveLength(1);
+        expect(error.stack).toBeDefined();
+        expect(error.message.includes('Unexpected token')).toBe(true);
+
+        return Promise.resolve();
+      });
   });
 
-  it('resolves to { text, response } if the parseMethod is set to `text`', done => {
+  it('resolves to { text, response } if the `parseMethod=text`', () => {
     expect.assertions(3);
 
     // test with json + bigint to ensure that it was not first parsed as json
@@ -77,28 +75,30 @@ describe('parseResponse()', () => {
     fetchMock.get(mockTextParseUrl, mockTextJsonResponse);
 
     const apiPromise = callApi({ url: mockTextParseUrl, method: 'GET' });
-    parseResponse(apiPromise, 'text')
-      .then(args => {
-        expect(fetchMock.calls(mockTextParseUrl)).toHaveLength(1);
-        expect(Object.keys(args)).toEqual(expect.arrayContaining(['response', 'text']));
-        expect(args.text).toBe(mockTextJsonResponse);
 
-        return done();
-      })
-      .catch(throwIfCalled);
+    return parseResponse(apiPromise, 'text').then(args => {
+      expect(fetchMock.calls(mockTextParseUrl)).toHaveLength(1);
+      expect(Object.keys(args)).toEqual(expect.arrayContaining(['response', 'text']));
+      expect(args.text).toBe(mockTextJsonResponse);
+
+      return Promise.resolve();
+    });
   });
 
-  it('rejects if the request throws', done => {
-    expect.assertions(3);
+  it('resolves to the unmodified `Response` object if `parseMethod=null`', () => {
+    expect.assertions(2);
 
-    callApi({ url: mockErrorUrl, method: 'GET' })
-      .then(throwIfCalled)
-      .catch(error => {
-        expect(fetchMock.calls(mockErrorUrl)).toHaveLength(1);
-        expect(error.status).toBe(mockErrorPayload.status);
-        expect(error.statusText).toBe(mockErrorPayload.statusText);
+    const mockNoParseUrl = '/mock/noparse/url';
+    const mockResponse = new Response('test response');
+    fetchMock.get(mockNoParseUrl, mockResponse);
 
-        return done();
-      });
+    const apiPromise = callApi({ url: mockNoParseUrl, method: 'GET' });
+
+    return parseResponse(apiPromise, null).then(response => {
+      expect(fetchMock.calls(mockNoParseUrl)).toHaveLength(1);
+      expect(response.bodyUsed).toBe(false);
+
+      return Promise.resolve();
+    });
   });
 });

--- a/packages/superset-ui-core/test/utils/throwIfCalled.js
+++ b/packages/superset-ui-core/test/utils/throwIfCalled.js
@@ -1,3 +1,3 @@
-export default function throwIfCalled() {
-  throw new Error('Unexpected call to throwIfCalled()');
+export default function throwIfCalled(args) {
+  throw new Error(`Unexpected call to throwIfCalled(): ${JSON.stringify(args)}`);
 }


### PR DESCRIPTION
🏆 Enhancements
- This adds a `parseMethod` argument to `parseResponse` in order to support both `json` (default) and `text` responses. This is needed to enable custom response parsing in some cases, for example `BigInt`s which was [added to Sqllab recently](https://github.com/apache/incubator-superset/pull/5829).
- Exposes this `parseMethod` as an optional argument to `SupersetClient.get()` and `.post()` calls.

🏠 Internal
- Bumps `@data-ui/build-config` to `0.0.14` which has a stricter `no-unused-args` eslint rule
- adds `.npmrc` to `.gitignore` for local publishing credentials

@kristw @conglei @mistercrunch  