### PR TITLE
[core] support empty `CSRF` token

### DIFF
--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "url-search-params-polyfill": "^4.0.1",
     "whatwg-fetch": "^2.0.4"
   },
   "beemo": {

--- a/packages/superset-ui-core/src/SupersetClient.js
+++ b/packages/superset-ui-core/src/SupersetClient.js
@@ -31,6 +31,8 @@ class SupersetClient {
   }
 
   getCSRFToken() {
+    this.csrfToken = null;
+
     // If we can request this resource successfully, it means that the user has
     // authenticated. If not we throw an error prompting to authenticate.
     this.csrfPromise = callApi({
@@ -46,10 +48,10 @@ class SupersetClient {
       if (response.json) {
         this.csrfToken = response.json.csrf_token;
         this.headers = { ...this.headers, 'X-CSRFToken': this.csrfToken };
-        this.didAuthSuccessfully = !!this.csrfToken;
+        this.didAuthSuccessfully = this.csrfToken !== null && this.csrfPromise !== undefined;
       }
 
-      if (!this.csrfToken) {
+      if (!this.didAuthSuccessfully) {
         return Promise.reject({ error: 'Failed to fetch CSRF token' });
       }
 

--- a/packages/superset-ui-core/src/callApi/callApi.js
+++ b/packages/superset-ui-core/src/callApi/callApi.js
@@ -1,5 +1,4 @@
 import 'whatwg-fetch';
-import 'url-search-params-polyfill';
 
 const DEFAULT_HEADERS = null;
 

--- a/packages/superset-ui-core/src/callApi/parseResponse.js
+++ b/packages/superset-ui-core/src/callApi/parseResponse.js
@@ -11,12 +11,7 @@ export default function parseResponse(apiPromise, parseMethod = 'json') {
   return apiPromise
     .then(response => {
       if (!response.ok) {
-        return Promise.reject({
-          error: response.error || 'An error occurred',
-          response,
-          status: response.status,
-          statusText: response.statusText,
-        });
+        return Promise.reject(response);
       }
 
       return response;

--- a/packages/superset-ui-core/test/SupersetClient.test.js
+++ b/packages/superset-ui-core/test/SupersetClient.test.js
@@ -7,7 +7,7 @@ import { LOGIN_GLOB } from './fixtures/constants';
 
 describe('SupersetClient', () => {
   beforeAll(() => {
-    fetchMock.get(LOGIN_GLOB, { csrf_token: '1234' });
+    fetchMock.get(LOGIN_GLOB, { csrf_token: '' });
   });
 
   afterAll(fetchMock.restore);

--- a/packages/superset-ui-core/test/callApi/callApi.test.js
+++ b/packages/superset-ui-core/test/callApi/callApi.test.js
@@ -14,15 +14,12 @@ describe('callApi()', () => {
 
   const mockGetUrl = '/mock/get/url';
   const mockPostUrl = '/mock/post/url';
-  const mockErrorUrl = '/mock/error/url';
 
   const mockGetPayload = { get: 'payload' };
   const mockPostPayload = { post: 'payload' };
-  const mockErrorPayload = { status: 500, statusText: 'Internal error' };
 
   fetchMock.get(mockGetUrl, mockGetPayload);
   fetchMock.post(mockPostUrl, mockPostPayload);
-  fetchMock.get(mockErrorUrl, () => Promise.reject(mockErrorPayload));
 
   afterEach(fetchMock.reset);
 
@@ -145,6 +142,10 @@ describe('callApi()', () => {
   });
 
   it('rejects if the request throws', () => {
+    const mockErrorUrl = '/mock/error/url';
+    const mockErrorPayload = { status: 500, statusText: 'Internal error' };
+    fetchMock.get(mockErrorUrl, () => Promise.reject(mockErrorPayload));
+
     expect.assertions(3);
 
     return callApi({ url: mockErrorUrl, method: 'GET' })

--- a/packages/superset-ui-core/test/callApi/parseResponse.test.js
+++ b/packages/superset-ui-core/test/callApi/parseResponse.test.js
@@ -101,4 +101,20 @@ describe('parseResponse()', () => {
       return Promise.resolve();
     });
   });
+
+  it('rejects if request.ok=false', () => {
+    const mockNotOkayUrl = '/mock/notokay/url';
+    fetchMock.get(mockNotOkayUrl, 404); // 404s result in not response.ok=false
+
+    expect.assertions(3);
+    const apiPromise = callApi({ url: mockNotOkayUrl, method: 'GET' });
+
+    return parseResponse(apiPromise)
+      .then(throwIfCalled)
+      .catch(response => {
+        expect(fetchMock.calls(mockNotOkayUrl)).toHaveLength(1);
+        expect(response.ok).toBe(false);
+        expect(response.status).toBe(404);
+      });
+  });
 });


### PR DESCRIPTION
🏆 Enhancements
- This PR adds support for `csrf_token=''` to `SupersetClient`, to support the case when the Superset Flask app sets `WTF_CSRF_ENABLED = False`. This is valid configuration and is used in e.g., cypress tests, and when this is set to `False`, the `superset/csrf_token` endpoint returns a `200` with an empty string. Without this support, Cypress tests fail when integrating `SupersetClient`.

🏠 Internal
- removes unneeded polyfill (used previously as another method for encoding `POST` payload form data)
- adds a test to ensure that `parseResponse` rejects when `response.ok=false`

@kristw @michellethomas @graceguo-supercat @conglei 