### PR TITLE
[SupersetClient] allow csrf token to be passed as configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.map
 *.min.js
 
+babel.config.js
 build/
 coverage/
 esm/

--- a/packages/superset-ui-core/README.md
+++ b/packages/superset-ui-core/README.md
@@ -14,9 +14,11 @@ for use within the Superset application, or used to issue `CORS` requests in oth
 a high-level it supports:
 
 - `CSRF` token authentication
-  - queues requests in the case that another request is made before the token is received
-  - it checks for a token before every request, an external app that uses this can detect this by
-    catching errors, or explicitly checking `SupersetClient.isAuthorized()`
+  - a token may be passed at configuration time, else the client will handle fetching and passing
+    the token in all subsequent requests.
+  - queues requests in the case that another request is made before the token is received.
+  - it checks for a token before every request, and will fail if no token was received or if it has
+    expired. In either case the user should be directed to re-authenticate.
 - supports `GET` and `POST` requests (no `PUT` or `DELETE`)
 - timeouts
 - query aborts through the `AbortController` API
@@ -46,12 +48,14 @@ SupersetClient.post(...requestConfig)
 The following flags can be passed in the client config call
 `SupersetClient.configure(...clientConfig);`
 
-- `protocol = 'http'`
+- `protocol = 'http:'`
 - `host`
 - `headers`
 - `credentials = 'same-origin'` (set to `include` for non-Superset apps)
 - `mode = 'same-origin'` (set to `cors` for non-Superset apps)
 - `timeout`
+- `csrfToken` you can configure the client with a CSRF token at configuration time, else the client
+  will attempt to fetch this before any other requests are issued
 
 ##### Per-request Configuration
 

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.22",
+    "@data-ui/build-config": "^0.0.23",
     "fetch-mock": "^6.5.2",
     "node-fetch": "^2.2.0"
   },

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.14",
+    "@data-ui/build-config": "^0.0.20",
     "fetch-mock": "^6.5.2",
     "node-fetch": "^2.2.0"
   },
@@ -65,7 +65,6 @@
       "rules": {
         "prefer-promise-reject-errors": "off"
       }
-    },
-    "jest": {}
+    }
   }
 }

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.20",
+    "@data-ui/build-config": "^0.0.21",
     "fetch-mock": "^6.5.2",
     "node-fetch": "^2.2.0"
   },

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -20,7 +20,6 @@
     "lint:fix": "yarn run prettier --write && yarn run eslint --fix",
     "test": "yarn run jest",
     "prettier": "beemo prettier \"./{src,test}/**/*.{js,jsx,json,md}\"",
-    "sync:gitignore": "beemo sync-dotfiles --filter=gitignore",
     "prepublish": "yarn run build"
   },
   "repository": {
@@ -40,12 +39,12 @@
   },
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.21",
+    "@data-ui/build-config": "^0.0.22",
     "fetch-mock": "^6.5.2",
     "node-fetch": "^2.2.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.1.2",
     "whatwg-fetch": "^2.0.4"
   },
   "beemo": {

--- a/packages/superset-ui-core/test/SupersetClient.test.js
+++ b/packages/superset-ui-core/test/SupersetClient.test.js
@@ -135,16 +135,11 @@ describe('SupersetClient', () => {
 
       it('isAuthenticated() returns true if a token is passed at configuration', () => {
         expect.assertions(2);
-        let client = new SupersetClient({ csrfToken: null });
-        expect(client.isAuthenticated()).toBe(false);
+        const clientWithoutToken = new SupersetClient({ csrfToken: null });
+        const clientWithToken = new SupersetClient({ csrfToken: 'token' });
 
-        client = new SupersetClient({ csrfToken: 'token' });
-
-        return client.init().then(() => {
-          expect(client.isAuthenticated()).toBe(true);
-
-          return Promise.resolve();
-        });
+        expect(clientWithoutToken.isAuthenticated()).toBe(false);
+        expect(clientWithToken.isAuthenticated()).toBe(true);
       });
 
       it('init() throws if superset/csrf_token/ returns an error', () => {


### PR DESCRIPTION
🏆 Enhancements
Adds the ability to pass a `csrf` token at configuration time: 

`SupersetClient.configure({ csrfToken: 'my_token', ... })`

By enabling the user to pass a `csrfToken` at configuration time (which is possible within the Superset application where CSRF token is embedded within the HTML), we can remove an unnecessary auth request. This may be causing slight delays in requests in the Superset app and contributing to integration test flakiness.

@kristw @michellethomas @mistercrunch 