### PR TITLE
[SupersetClient] include csrfToken passed in configuration in headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "lerna run lint:fix",
     "prerelease": "yarn run build",
     "prepare-release": "git checkout master && git pull --rebase origin master && lerna bootstrap && yarn run lint && yarn run test",
-    "release": "yarn run prepare-release && lerna publish && lerna run gh-pages",
+    "release": "yarn run prepare-release && lerna publish",
     "test": "lerna run test"
   },
   "repository": "https://github.com/apache-superset/superset-ui.git",

--- a/packages/superset-ui-core/src/SupersetClient.js
+++ b/packages/superset-ui-core/src/SupersetClient.js
@@ -12,7 +12,7 @@ class SupersetClient {
       csrfToken = null,
     } = config;
 
-    this.headers = headers;
+    this.headers = { ...headers, 'X-CSRFToken': csrfToken };
     this.host = host;
     this.mode = mode;
     this.timeout = timeout;


### PR DESCRIPTION
🤦‍♂️ Bug Fix

Forgot to include `csrfToken`s passed in configuration in the headers sent with requests.

This time I actually linked the package and tested in the `Superset` app.

@kristw 
 