### PR TITLE
[build-config] move to monorepo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .eslintrc.js
 .idea
 .npm
-.npmrc
 .prettierignore
 .yarnclean
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,8 @@ install:
   - npm install
   - npm install -g codecov
 
-env:
-  - PACKAGE=superset-ui-core
-
 script:
-  - cd ./packages/$PACKAGE
   - yarn install
-  - yarn run lint
   - yarn run test
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
 install:
   - npm install
   - npm install -g codecov
+  - lerna bootstrap
 
 script:
-  - yarn install
   - yarn run test
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 
 script:
   - yarn install
-  - yarn run test --debug --no-cache
+  - yarn run test
 
 after_script:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,9 @@ install:
   - npm install
   - npm install -g codecov
 
-env:
-  - PACKAGE=superset-ui-core
-  - PACKAGE=superset-ui-translation
-
 script:
-  - cd ./packages/$PACKAGE
   - yarn install
-  - cd ../..
-  - yarn run test ./packages/$PACKAGE
+  - yarn run test
 
 after_script:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
 install:
   - npm install
   - npm install -g codecov
-  - lerna bootstrap
 
 script:
+  - lerna bootstrap
   - yarn run test
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,15 @@ install:
   - npm install
   - npm install -g codecov
 
+env:
+  - PACKAGE=superset-ui-core
+  - PACKAGE=superset-ui-translation
+
 script:
-  - lerna bootstrap
-  - yarn run test
+  - cd ./packages/$PACKAGE
+  - yarn install
+  - cd ../..
+  - yarn run test ./packages/$PACKAGE
 
 after_script:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 
 script:
   - yarn install
-  - yarn run test
+  - yarn run test --debug --no-cache
 
 after_script:
   - codecov

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "jest": "beemo jest --color --coverage",
     "prepare-release": "git checkout master && git pull --rebase origin master && lerna bootstrap && yarn run test",
     "prerelease": "yarn run build",
-    "pretest": "yarn run lint",
+    "pretest": "yarn run prettier && yarn run lint",
     "prettier": "beemo prettier \"./packages/*/{src,test}/**/*.{js,jsx,json,md}\"",
     "release": "yarn run prepare-release && lerna publish",
     "test": "yarn run jest"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:cjs": "NODE_ENV=production beemo babel ./src --out-dir lib/ --minify --workspaces=*",
     "build:esm": "NODE_ENV=production beemo babel ./src --out-dir esm/ --esm --minify --workspaces=*",
     "lint": "beemo create-config prettier && beemo eslint \"./packages/*/{src,test}/**/*.{js,jsx}\"",
-    "jest": "beemo jest --color --coverage",
+    "jest": "beemo create-config jest && jest --color --coverage",
     "prepare-release": "git checkout master && git pull --rebase origin master && lerna bootstrap && yarn run test",
     "prerelease": "yarn run build",
     "pretest": "yarn run lint",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     }
   },
   "lint-staged": {
-    "./packages/**/*.{js,jsx}": [
+    "./packages/*/{src,test}/**/*.{js,jsx,json,md}": [
       "yarn run prettier --write",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:cjs": "NODE_ENV=production beemo babel ./src --out-dir lib/ --minify --workspaces=*",
     "build:esm": "NODE_ENV=production beemo babel ./src --out-dir esm/ --esm --minify --workspaces=*",
     "lint": "beemo create-config prettier && beemo eslint \"./packages/*/{src,test}/**/*.{js,jsx}\"",
-    "jest": "beemo create-config jest && jest --color --coverage",
+    "jest": "beemo jest --color --coverage",
     "prepare-release": "git checkout master && git pull --rebase origin master && lerna bootstrap && yarn run test",
     "prerelease": "yarn run build",
     "pretest": "yarn run lint",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "pretest": "yarn run prettier && yarn run lint",
     "prettier": "beemo prettier \"./packages/*/{src,test}/**/*.{js,jsx,json,md}\"",
     "release": "yarn run prepare-release && lerna publish",
-    "test": "yarn run jest"
+    "test": "yarn run jest",
+    "test:watch": "beemo create-config jest && jest --watch"
   },
   "repository": "https://github.com/apache-superset/superset-ui.git",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "vx"
   ],
   "license": "Apache-2.0",
-  "dependencies": {
-    "@babel/runtime": "^7.1.2"
-  },
   "devDependencies": {
     "@data-ui/build-config": "^0.0.23",
     "husky": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.23",
+    "@data-ui/build-config": "^0.0.24",
     "husky": "^1.1.2",
     "lerna": "^3.2.1",
     "lint-staged": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.24",
+    "@data-ui/build-config": "^0.0.25",
     "husky": "^1.1.2",
     "lerna": "^3.2.1",
     "lint-staged": "^7.3.0",
@@ -40,9 +40,6 @@
   },
   "engines": {
     "node": ">=8.10.0"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "beemo": {
     "module": "@data-ui/build-config",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,17 @@
   "description": "Superset UI",
   "private": true,
   "scripts": {
-    "build": "lerna run build",
-    "lint": "lerna run lint",
-    "lint:fix": "lerna run lint:fix",
+    "build": "yarn run build:cjs && yarn run build:esm",
+    "build:cjs": "NODE_ENV=production beemo babel ./src --out-dir lib/ --minify --workspaces=*",
+    "build:esm": "NODE_ENV=production beemo babel ./src --out-dir esm/ --esm --minify --workspaces=*",
+    "lint": "beemo eslint \"./packages/*/{src,test}/**/*.{js,jsx,json,md}\"",
+    "jest": "beemo jest --color --coverage",
+    "prepare-release": "git checkout master && git pull --rebase origin master && lerna bootstrap && yarn run test",
     "prerelease": "yarn run build",
-    "prepare-release": "git checkout master && git pull --rebase origin master && lerna bootstrap && yarn run lint && yarn run test",
+    "pretest": "yarn run lint",
+    "prettier": "beemo prettier \"./packages/*/{src,test}/**/*.{js,jsx,json,md}\"",
     "release": "yarn run prepare-release && lerna publish",
-    "test": "lerna run test"
+    "test": "yarn run jest"
   },
   "repository": "https://github.com/apache-superset/superset-ui.git",
   "keywords": [
@@ -26,8 +30,14 @@
     "vx"
   ],
   "license": "Apache-2.0",
+  "dependencies": {
+    "@babel/runtime": "^7.1.2"
+  },
   "devDependencies": {
+    "@data-ui/build-config": "^0.0.23",
+    "husky": "^1.1.2",
     "lerna": "^3.2.1",
+    "lint-staged": "^7.3.0",
     "yarn": "^1.9.4"
   },
   "engines": {
@@ -35,5 +45,38 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "beemo": {
+    "module": "@data-ui/build-config",
+    "drivers": [
+      "babel",
+      "eslint",
+      {
+        "driver": "jest",
+        "env": {
+          "NODE_ENV": "test"
+        }
+      },
+      "prettier"
+    ],
+    "eslint": {
+      "rules": {
+        "prefer-promise-reject-errors": "off"
+      }
+    }
+  },
+  "workspaces": [
+    "./packages/*"
+  ],
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "./packages/**/*.{js,jsx}": [
+      "yarn run prettier --write",
+      "git add"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "build": "yarn run build:cjs && yarn run build:esm",
     "build:cjs": "NODE_ENV=production beemo babel ./src --out-dir lib/ --minify --workspaces=*",
     "build:esm": "NODE_ENV=production beemo babel ./src --out-dir esm/ --esm --minify --workspaces=*",
-    "lint": "beemo eslint \"./packages/*/{src,test}/**/*.{js,jsx,json,md}\"",
+    "lint": "beemo create-config prettier && beemo eslint \"./packages/*/{src,test}/**/*.{js,jsx}\"",
     "jest": "beemo jest --color --coverage",
     "prepare-release": "git checkout master && git pull --rebase origin master && lerna bootstrap && yarn run test",
     "prerelease": "yarn run build",
-    "pretest": "yarn run prettier && yarn run lint",
+    "pretest": "yarn run lint",
     "prettier": "beemo prettier \"./packages/*/{src,test}/**/*.{js,jsx,json,md}\"",
     "release": "yarn run prepare-release && lerna publish",
     "test": "yarn run jest",
@@ -56,12 +56,7 @@
         }
       },
       "prettier"
-    ],
-    "eslint": {
-      "rules": {
-        "prefer-promise-reject-errors": "off"
-      }
-    }
+    ]
   },
   "workspaces": [
     "./packages/*"

--- a/packages/superset-ui-core/.eslintrc
+++ b/packages/superset-ui-core/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "prefer-promise-reject-errors": "off"
+  }
+}

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -30,6 +30,7 @@
     "node-fetch": "^2.2.0"
   },
   "dependencies": {
+    "@babel/runtime": "^7.1.2",
     "whatwg-fetch": "^2.0.4"
   },
   "publishConfig": {

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -9,19 +9,6 @@
     "esm",
     "lib"
   ],
-  "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --esm --minify",
-    "build": "yarn run build:cjs && yarn run build:esm",
-    "dev": "beemo babel --watch ./src --out-dir esm/ --esm",
-    "jest": "beemo jest --color --coverage",
-    "eslint": "beemo eslint \"./{src,test}/**/*.{js,jsx,json,md}\"",
-    "lint": "yarn run prettier && yarn run eslint",
-    "lint:fix": "yarn run prettier --write && yarn run eslint --fix",
-    "test": "yarn run jest",
-    "prettier": "beemo prettier \"./{src,test}/**/*.{js,jsx,json,md}\"",
-    "prepublish": "yarn run build"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apache-superset/superset-ui.git"
@@ -39,32 +26,11 @@
   },
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.23",
     "fetch-mock": "^6.5.2",
     "node-fetch": "^2.2.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.1.2",
     "whatwg-fetch": "^2.0.4"
-  },
-  "beemo": {
-    "module": "@data-ui/build-config",
-    "drivers": [
-      "babel",
-      "eslint",
-      {
-        "driver": "jest",
-        "env": {
-          "NODE_ENV": "test"
-        }
-      },
-      "prettier"
-    ],
-    "eslint": {
-      "rules": {
-        "prefer-promise-reject-errors": "off"
-      }
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -19,7 +19,7 @@
     "core",
     "data"
   ],
-  "author": "",
+  "author": "Superset",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/apache-superset/superset-ui/issues"

--- a/packages/superset-ui-translation/package.json
+++ b/packages/superset-ui-translation/package.json
@@ -9,19 +9,6 @@
     "esm",
     "lib"
   ],
-  "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --esm --minify",
-    "build": "yarn run build:cjs && yarn run build:esm",
-    "dev": "beemo babel --watch ./src --out-dir esm/ --esm",
-    "jest": "beemo jest --color --coverage",
-    "eslint": "beemo eslint \"./{src,test}/**/*.{js,jsx,md}\"",
-    "lint": "yarn run prettier && yarn run eslint",
-    "lint:fix": "yarn run prettier --write && yarn run eslint --fix",
-    "test": "yarn run jest",
-    "prettier": "beemo prettier \"./{src,test}/**/*.{js,jsx,json,md}\"",
-    "prepublish": "yarn run build"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apache-superset/superset-ui.git"


### PR DESCRIPTION
🏠 Internal

With more packages coming, this PR 

- moves the build-config to the monorepo root `package.json` so that package creators don't have to deal with the boilerplate. This will help keep things consistent across packages, too. Note that currently this build config does _not_ support webpack or TS, but we can easily add support for that with `@beemo`. I tested locally with another test package and everything seems to work okay.

- adds a pre-commit hook to run prettier on any staged files ✨ 

- adds a `test:watch` script to support `jest --watch` mode. this isn't easy out of the box with `beemo` because `jest` runs in a subprocess so output is not piped to the command line, but the script provides a workaround

@kristw @xtinec 