### PR TITLE
Make the translation module less strict and won't crash the app if not configured.

### DIFF
--- a/packages/superset-ui-translation/package.json
+++ b/packages/superset-ui-translation/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.23"
+    "@data-ui/build-config": "^0.0.23",
+    "jest-mock-console": "^0.4.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",

--- a/packages/superset-ui-translation/src/TranslatorSingleton.js
+++ b/packages/superset-ui-translation/src/TranslatorSingleton.js
@@ -1,16 +1,22 @@
+/* eslint no-console: 0 */
 import Translator from './Translator';
 
 let singleton;
+let isConfigured = false;
 
 function configure(config) {
   singleton = new Translator(config);
+  isConfigured = true;
 
   return singleton;
 }
 
 function getInstance() {
-  if (!singleton) {
-    throw new Error('You must call configure(...) before calling other methods');
+  if (!isConfigured) {
+    console.warn('You must call configure(...) before calling other methods');
+    if (!singleton) {
+      singleton = new Translator();
+    }
   }
 
   return singleton;

--- a/packages/superset-ui-translation/test/TranslatorSingleton.test.js
+++ b/packages/superset-ui-translation/test/TranslatorSingleton.test.js
@@ -1,3 +1,5 @@
+/* eslint no-console: 0 */
+import mockConsole from 'jest-mock-console';
 import Translator from '../src/Translator';
 import { configure, t, tn } from '../src/TranslatorSingleton';
 import languagePackZh from './languagePacks/zh.json';
@@ -5,13 +7,19 @@ import languagePackZh from './languagePacks/zh.json';
 describe('TranslatorSingleton', () => {
   describe('before configure()', () => {
     describe('t()', () => {
-      it('throws error', () => {
-        expect(() => t('second')).toThrow();
+      it('returns untranslated input and issues a warning', () => {
+        const restoreConsole = mockConsole();
+        expect(t('second')).toEqual('second');
+        expect(console.warn).toHaveBeenCalled();
+        restoreConsole();
       });
     });
     describe('tn()', () => {
-      it('throws error', () => {
-        expect(() => tn('ox', 'oxen', 2)).toThrow();
+      it('returns untranslated input and issues a warning', () => {
+        const restoreConsole = mockConsole();
+        expect(tn('ox', 'oxen', 2)).toEqual('oxen');
+        expect(console.warn).toHaveBeenCalled();
+        restoreConsole();
       });
     });
   });


### PR DESCRIPTION
Change from throwing error to issue warning if `t()` or `tn()` is called before the module is `configure()`.
Translation should be optional after all. 
Changing this to be safer and avoid crashing the entire app because the translation module is not properly setup. 

@williaster @xtinec @conglei 