### PR TITLE
Add generator-superset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ install:
   - npm install -g codecov
   - yarn install
 
-script:
+before_script:
   - yarn run build
-  - yarn run test
+
+script:
+  - yarn test
 
 after_script:
   - codecov

--- a/babel-transformer.js
+++ b/babel-transformer.js
@@ -1,0 +1,9 @@
+const { join, resolve } = require('path');
+const { createTransformer } = require('babel-jest');
+
+const packagePath = resolve('../');
+const packageGlob = join(packagePath, '*');
+
+module.exports = createTransformer({
+  babelrcRoots: packageGlob,
+});

--- a/babel-transformer.js
+++ b/babel-transformer.js
@@ -1,9 +1,0 @@
-const { join, resolve } = require('path');
-const { createTransformer } = require('babel-jest');
-
-const packagePath = resolve('../');
-const packageGlob = join(packagePath, '*');
-
-module.exports = createTransformer({
-  babelrcRoots: packageGlob,
-});

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
           "displayName": "generator-superset",
           "rootDir": "<rootDir>/packages/generator-superset",
           "testMatch": [
-            "<rootDir>/**/?(*.)+(spec|test).{js,jsx}"
+            "<rootDir>/packages/generator-superset/**/?(*.)+(spec|test).{js,jsx}"
           ]
         }
       ]

--- a/package.json
+++ b/package.json
@@ -57,20 +57,18 @@
       "prettier"
     ],
     "jest": {
+      "testPathIgnorePatterns": [
+        "<rootDir>/packages/generator-superset"
+      ],
       "projects": [
+        "<rootDir>",
         {
-          "displayName": "main",
-          "rootDir": "<rootDir>",
-          "testMatch": [
-            "<rootDir>/packages/superset-ui-*/**/?(*.)+(spec|test).{js,jsx}"
-          ]
-        },
-        {
-          "displayName": "generator-superset",
+          "displayName": "node",
           "rootDir": "<rootDir>/packages/generator-superset",
           "testMatch": [
             "<rootDir>/test/**/?(*.)+(spec|test).{js,jsx}"
-          ]
+          ],
+          "testEnvironment": "node"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "yarn run build:cjs && yarn run build:esm",
-    "build:cjs": "NODE_ENV=production beemo babel ./src --out-dir lib/ --minify --workspaces=\"@superset-ui/!(demo)\"",
-    "build:esm": "NODE_ENV=production beemo babel ./src --out-dir esm/ --esm --minify --workspaces=\"@superset-ui/!(demo)\"",
+    "build:cjs": "NODE_ENV=production beemo babel ./src --out-dir lib/ --minify --workspaces=\"@superset-ui/!(demo|generator-superset)\"",
+    "build:esm": "NODE_ENV=production beemo babel ./src --out-dir esm/ --esm --minify --workspaces=\"@superset-ui/!(demo|generator-superset)\"",
     "lint": "beemo create-config prettier && beemo eslint \"./packages/*/{src,test,storybook}/**/*.{js,jsx}\"",
     "jest": "beemo jest --color --coverage",
     "postrelease": "lerna run gh-pages",
@@ -55,7 +55,25 @@
         }
       },
       "prettier"
-    ]
+    ],
+    "jest": {
+      "projects": [
+        {
+          "displayName": "main",
+          "rootDir": "<rootDir>",
+          "testMatch": [
+            "<rootDir>/packages/superset-ui-*/**/?(*.)+(spec|test).{js,jsx}"
+          ]
+        },
+        {
+          "displayName": "generator-superset",
+          "rootDir": "<rootDir>/packages/generator-superset",
+          "testMatch": [
+            "<rootDir>/**/?(*.)+(spec|test).{js,jsx}"
+          ]
+        }
+      ]
+    }
   },
   "workspaces": [
     "./packages/*"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
           "displayName": "generator-superset",
           "rootDir": "<rootDir>/packages/generator-superset",
           "testMatch": [
-            "<rootDir>/packages/generator-superset/**/?(*.)+(spec|test).{js,jsx}"
+            "<rootDir>/test/**/?(*.)+(spec|test).{js,jsx}"
           ]
         }
       ]

--- a/packages/generator-superset/.gitattributes
+++ b/packages/generator-superset/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/packages/generator-superset/README.md
+++ b/packages/generator-superset/README.md
@@ -1,0 +1,32 @@
+# generator-superset
+
+[![Version](https://img.shields.io/npm/v/@superset-ui/generator-superset.svg?style=flat)](https://img.shields.io/npm/v/@superset-ui/generator-superset.svg?style=flat-square)
+[![David (path)](https://img.shields.io/david/apache-superset/superset-ui.svg?path=packages%2Fgenerator-superset&style=flat-square)](https://david-dm.org/apache-superset/superset-ui?path=packages/generator-superset)
+
+> Scaffolder for Superset
+
+## Installation
+
+First, install [Yeoman](http://yeoman.io) and `generator-superset` using [npm](https://www.npmjs.com/) (we assume you have pre-installed [node.js](https://nodejs.org/)).
+
+```bash
+npm install -g yo
+npm install -g @superset-ui/generator-superset
+```
+
+## Usage
+
+Generate a new package in `@superset-ui`
+
+```bash
+cd superset-ui/packages
+mkdir superset-ui-new-package
+cd superset-ui-new-package
+yo @superset-ui/superset
+```
+
+## License
+
+Apache-2.0
+
+[learn more about Yeoman](http://yeoman.io/).

--- a/packages/generator-superset/generators/app/index.js
+++ b/packages/generator-superset/generators/app/index.js
@@ -1,0 +1,12 @@
+const Generator = require('yeoman-generator');
+
+module.exports = class extends Generator {
+  initializing() {
+    // Redirect the default 'app' generator
+    // to 'package' subgenerator
+    // until there are multiple subgenerators
+    // then this can be changed into a menu to select
+    // subgenerator.
+    this.composeWith(require.resolve('../package'));
+  }
+};

--- a/packages/generator-superset/generators/package/index.js
+++ b/packages/generator-superset/generators/package/index.js
@@ -1,0 +1,38 @@
+/* eslint-disable sort-keys */
+
+const Generator = require('yeoman-generator');
+const chalk = require('chalk');
+const yosay = require('yosay');
+
+module.exports = class extends Generator {
+  async prompting() {
+    // Have Yeoman greet the user.
+    this.log(yosay(`Welcome to the rad ${chalk.red('generator-superset')} generator!`));
+
+    this.option('skipInstall');
+
+    this.answers = await this.prompt([
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Package name:',
+        default: this.appname.replace('superset ui ', ''), // Default to current folder name
+      },
+    ]);
+  }
+
+  writing() {
+    this.fs.copyTpl(
+      this.templatePath('package.json'),
+      this.destinationPath('package.json'),
+      this.answers,
+    );
+    this.fs.copyTpl(
+      this.templatePath('README.md'),
+      this.destinationPath('README.md'),
+      this.answers,
+    );
+    this.fs.copy(this.templatePath('src/index.js'), this.destinationPath('src/index.js'));
+    this.fs.copy(this.templatePath('test/index.js'), this.destinationPath('test/index.test.js'));
+  }
+};

--- a/packages/generator-superset/generators/package/templates/README.md
+++ b/packages/generator-superset/generators/package/templates/README.md
@@ -1,0 +1,27 @@
+## @superset-ui/<%= name %>
+
+[![Version](https://img.shields.io/npm/v/@superset-ui/<%= name
+%>.svg?style=flat)](https://img.shields.io/npm/v/@superset-ui/<%= name %>.svg?style=flat)
+[![David (path)](https://img.shields.io/david/apache-superset/superset-ui.svg?path=packages%2Fsuperset-ui-<%=
+name
+%>&style=flat-square)](https://david-dm.org/apache-superset/superset-ui?path=packages/superset-ui-<%=
+name %>)
+
+Description
+
+#### Example usage
+
+```js
+import { xxx } from '@superset-ui/<%= name %>';
+```
+
+#### API
+
+`fn(args)`
+
+- Do something
+
+### Development
+
+`@data-ui/build-config` is used to manage the build configuration for this package including babel
+builds, jest testing, eslint, and prettier.

--- a/packages/generator-superset/generators/package/templates/package.json
+++ b/packages/generator-superset/generators/package/templates/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@superset-ui/<%= name %>",
+  "version": "0.0.0",
+  "description": "Superset UI <%= name %>",
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "files": [
+    "esm",
+    "lib"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apache-superset/superset-ui.git"
+  },
+  "keywords": ["superset"],
+  "author": "Superset",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/apache-superset/superset-ui/issues"
+  },
+  "homepage": "https://github.com/apache-superset/superset-ui#readme",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/generator-superset/generators/package/templates/src/index.js
+++ b/packages/generator-superset/generators/package/templates/src/index.js
@@ -1,0 +1,2 @@
+const x = 1;
+export default x;

--- a/packages/generator-superset/generators/package/templates/test/index.js
+++ b/packages/generator-superset/generators/package/templates/test/index.js
@@ -1,0 +1,5 @@
+describe('My Test', () => {
+  it('tests something', () => {
+    expect(1).toEqual(1);
+  });
+});

--- a/packages/generator-superset/package.json
+++ b/packages/generator-superset/package.json
@@ -33,8 +33,5 @@
     "chalk": "^2.4.1",
     "yosay": "^2.0.2"
   },
-  "jest": {
-    "testEnvironment": "node"
-  },
   "license": "Apache-2.0"
 }

--- a/packages/generator-superset/package.json
+++ b/packages/generator-superset/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "generator-superset",
+  "version": "0.0.0",
+  "description": "Scaffolder for Superset",
+  "bugs": {
+    "url": "https://github.com/apache-superset/superset-ui/issues"
+  },
+  "homepage": "https://github.com/apache-superset/superset-ui#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apache-superset/superset-ui.git"
+  },
+  "author": "Superset",
+  "files": [
+    "generators"
+  ],
+  "main": "generators/index.js",
+  "keywords": [
+    "yeoman",
+    "generator",
+    "superset",
+    "yeoman-generator"
+  ],
+  "devDependencies": {
+    "yeoman-test": "^1.9.1",
+    "yeoman-assert": "^3.1.0"
+  },
+  "engines": {
+    "npm": ">= 4.0.0"
+  },
+  "dependencies": {
+    "yeoman-generator": "^3.1.1",
+    "chalk": "^2.4.1",
+    "yosay": "^2.0.2"
+  },
+  "jest": {
+    "testEnvironment": "node"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/generator-superset/test/app.test.js
+++ b/packages/generator-superset/test/app.test.js
@@ -1,0 +1,12 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+
+describe('generator-superset:app', () => {
+  beforeAll(() =>
+    helpers.run(path.join(__dirname, '../generators/app')).withPrompts({ name: 'my-package' }));
+
+  it('creates files', () => {
+    assert.file(['package.json', 'README.md', 'src/index.js', 'test/index.test.js']);
+  });
+});

--- a/packages/generator-superset/test/app.test.js
+++ b/packages/generator-superset/test/app.test.js
@@ -17,6 +17,17 @@ describe('generator-superset:app', () => {
     assert.file(['package.json', 'README.md', 'src/index.js', 'test/index.test.js']);
   });
 
+  /*
+   * Change working directory back to original working directory
+   * after the test has completed.
+   * yeoman tests switch to tmp directory and write files there.
+   * Usually this is fine for solo package.
+   * However, for a monorepo like this one,
+   * it made jest confuses with current directory
+   * (being in tmp directory instead of superset-ui root)
+   * and interferes with other tests in sibling packages
+   * that are run after the yeoman tests.
+   */
   afterAll(() => {
     process.chdir(dir);
   });

--- a/packages/generator-superset/test/app.test.js
+++ b/packages/generator-superset/test/app.test.js
@@ -3,10 +3,21 @@ const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 
 describe('generator-superset:app', () => {
-  beforeAll(() =>
-    helpers.run(path.join(__dirname, '../generators/app')).withPrompts({ name: 'my-package' }));
+  let dir;
+
+  beforeAll(() => {
+    dir = process.cwd();
+
+    return helpers
+      .run(path.join(__dirname, '../generators/app'))
+      .withPrompts({ name: 'my-package' });
+  });
 
   it('creates files', () => {
     assert.file(['package.json', 'README.md', 'src/index.js', 'test/index.test.js']);
+  });
+
+  afterAll(() => {
+    process.chdir(dir);
   });
 });

--- a/packages/generator-superset/test/package.test.js
+++ b/packages/generator-superset/test/package.test.js
@@ -1,0 +1,15 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+
+describe('generator-superset:package', () => {
+  beforeAll(() =>
+    helpers
+      .run(path.join(__dirname, '../generators/package'))
+      .withPrompts({ name: 'my-package' })
+      .withOptions({ skipInstall: true }));
+
+  it('creates files', () => {
+    assert.file(['package.json', 'README.md', 'src/index.js', 'test/index.test.js']);
+  });
+});

--- a/packages/generator-superset/test/package.test.js
+++ b/packages/generator-superset/test/package.test.js
@@ -18,6 +18,17 @@ describe('generator-superset:package', () => {
     assert.file(['package.json', 'README.md', 'src/index.js', 'test/index.test.js']);
   });
 
+  /*
+   * Change working directory back to original working directory
+   * after the test has completed.
+   * yeoman tests switch to tmp directory and write files there.
+   * Usually this is fine for solo package.
+   * However, for a monorepo like this one,
+   * it made jest confuses with current directory
+   * (being in tmp directory instead of superset-ui root)
+   * and interferes with other tests in sibling packages
+   * that are run after the yeoman tests.
+   */
   afterAll(() => {
     process.chdir(dir);
   });

--- a/packages/generator-superset/test/package.test.js
+++ b/packages/generator-superset/test/package.test.js
@@ -3,13 +3,22 @@ const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 
 describe('generator-superset:package', () => {
-  beforeAll(() =>
-    helpers
+  let dir;
+
+  beforeAll(() => {
+    dir = process.cwd();
+
+    return helpers
       .run(path.join(__dirname, '../generators/package'))
       .withPrompts({ name: 'my-package' })
-      .withOptions({ skipInstall: true }));
+      .withOptions({ skipInstall: true });
+  });
 
   it('creates files', () => {
     assert.file(['package.json', 'README.md', 'src/index.js', 'test/index.test.js']);
+  });
+
+  afterAll(() => {
+    process.chdir(dir);
   });
 });


### PR DESCRIPTION
🏆 Enhancements

- Add `generator-superset` package for scaffolding.
- This package will be published as `@superset-ui/generator-superset`.
- Update build script to skip `babel` tasks for `generator-superset`, as it is a `node` application.
- Use `jest` project configuration to separate `generator-superset` from others and run in `testEnvironment: "node"`. (Although that was not the real issue that demolished CI in the early attempts.)

### Note about yeoman testing and interference with other packages

The key thing to add to `yeoman` tests, which are not normally included even from official yeoman `generator-generator`, is to **change working directory back to original working directory after the test has completed.** `yeoman` tests switch to `tmp` directory and write files there. Usually this is fine for solo package. However, for a monorepo like this one, it made `jest` confuses with current directory (being in `tmp` directory instead of `superset-ui` root) and interferes with other tests in sibling packages that are run after the `yeoman` tests. 

By adding the directory switch in `afterAll()` block. Everything works fine again! 🍾 

![image](https://user-images.githubusercontent.com/1659771/48115122-8f87ce00-e216-11e8-98bf-7fff9d949680.png)


> Many yaks were shaved in the making of this pull request.