### PR TITLE
Use simple js code to create range

### DIFF
--- a/packages/superset-ui-color/src/SequentialScheme.js
+++ b/packages/superset-ui-color/src/SequentialScheme.js
@@ -2,7 +2,12 @@ import { scaleLinear } from 'd3-scale';
 import ColorScheme from './ColorScheme';
 
 function range(count) {
-  return [...Array(count).keys()];
+  const values = [];
+  for (let i = 0; i < count; i += 1) {
+    values.push(i);
+  }
+
+  return values;
 }
 
 export default class SequentialScheme extends ColorScheme {


### PR DESCRIPTION
🐛 Bug Fix

The current code is using `Array(n).keys()` which requires `iterator` polyfill. Switch to plain old js for simplicity. 