### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+# It uses the same pattern rule for gitignore file
+# https://git-scm.com/docs/gitignore#_pattern_format
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# these users/team will be requested for review
+# when someone opens a pull request.
+
+*       @apache-superset/embeddable-charts-team


### PR DESCRIPTION
🏠 Internal

Add `CODEOWNERS` to automatically assign reviewers for pull requests. 
Note that the `Committers` team still have all admin rights. This should only help with assigning reviewers for PRs.

See https://help.github.com/articles/about-codeowners/ for more information.