### PR TITLE
Add ExtensibleFunction class

### DIFF
--- a/packages/superset-ui-core/src/index.js
+++ b/packages/superset-ui-core/src/index.js
@@ -1,3 +1,4 @@
+export { default as ExtensibleFunction } from './models/ExtensibleFunction';
 export { default as Plugin } from './models/Plugin';
 export { default as Preset } from './models/Preset';
 export { default as Registry } from './models/Registry';

--- a/packages/superset-ui-core/src/models/ExtensibleFunction.js
+++ b/packages/superset-ui-core/src/models/ExtensibleFunction.js
@@ -1,0 +1,9 @@
+/**
+ * From https://stackoverflow.com/questions/36871299/how-to-extend-function-with-es6-classes
+ */
+
+export default class ExtensibleFunction extends Function {
+  constructor(fn) {
+    return Object.setPrototypeOf(fn, new.target.prototype);
+  }
+}

--- a/packages/superset-ui-core/test/index.test.js
+++ b/packages/superset-ui-core/test/index.test.js
@@ -1,4 +1,5 @@
 import {
+  ExtensibleFunction,
   Plugin,
   Preset,
   Registry,
@@ -12,6 +13,7 @@ import {
 describe('index', () => {
   it('exports modules', () => {
     [
+      ExtensibleFunction,
       Plugin,
       Preset,
       Registry,

--- a/packages/superset-ui-core/test/models/ExtensibleFunction.test.js
+++ b/packages/superset-ui-core/test/models/ExtensibleFunction.test.js
@@ -1,0 +1,52 @@
+import ExtensibleFunction from '../../src/models/ExtensibleFunction';
+
+describe('ExtensibleFunction', () => {
+  class Func1 extends ExtensibleFunction {
+    constructor(x) {
+      super(() => x); // closure
+    }
+  }
+  class Func2 extends ExtensibleFunction {
+    constructor(x) {
+      super(() => this.x); // arrow function, refer to its own field
+      this.x = x;
+    }
+
+    hi() {
+      return 'hi';
+    }
+  }
+  class Func3 extends ExtensibleFunction {
+    constructor(x) {
+      super(function customName() {
+        return customName.x;
+      }); // named function
+      this.x = x;
+    }
+  }
+
+  it('its subclass is an instance of Function', () => {
+    expect(Func1).toBeInstanceOf(Function);
+    expect(Func2).toBeInstanceOf(Function);
+    expect(Func3).toBeInstanceOf(Function);
+  });
+
+  const func1 = new Func1(100);
+  const func2 = new Func2(100);
+  const func3 = new Func3(100);
+
+  it('an instance of its subclass is executable like regular function', () => {
+    expect(func1()).toEqual(100);
+    expect(func2()).toEqual(100);
+    expect(func3()).toEqual(100);
+  });
+
+  it('its subclass behaves like regular class with its own fields and functions', () => {
+    expect(func2.x).toEqual(100);
+    expect(func2.hi()).toEqual('hi');
+  });
+
+  it('its subclass can set name by passing named function to its constructor', () => {
+    expect(func3.name).toEqual('customName');
+  });
+});


### PR DESCRIPTION
🏆 Enhancements

Add `ExtensibleFunction` class, which was inspired by the need to have classes that are also functions. 

For example, `CategoricalColorScale` or `NumberFormatter` should be functions themselves. Currently `CategoricalColorScale` has an awkward `.toFunction()` that needs to be called to convert to function, and also error-prone if developer forgets to call `.toFunction()`. Current usage in Superset is similar to the example code below.

```js
const colorScale = new CategoricalColorScale(...).toFunction();
colorScale(someValue); // 'green'
```

Would be cleaner if we can call 

```js
const colorScale = new CategoricalColorScale(...);
colorScale(someValue); // 'green'

const format = new NumberFormatter('.2f');
format(100); // 100.00
```

I still want to keep `CategoricalColorScale` and `NumberFormatter` being `class` to add fields and functions in a clean way (Add class-specific functions to `prototype`, rather than creates a function then sticks all the fields and functions to the returned function similar to module pattern that is common pre-es6). The `ExtensibleFunction` base class then provides a nice solution for this scenario. 

The implementation comes from this article. 
https://stackoverflow.com/questions/36871299/how-to-extend-function-with-es6-classes