### PR TITLE
Rename `D3Formatter` to `D3NumberFormatter`

### DIFF
--- a/packages/superset-ui-number-format/src/NumberFormatterRegistry.js
+++ b/packages/superset-ui-number-format/src/NumberFormatterRegistry.js
@@ -1,5 +1,5 @@
 import { RegistryWithDefaultKey } from '@superset-ui/core';
-import D3Formatter from './formatters/D3Formatter';
+import D3NumberFormatter from './formatters/D3NumberFormatter';
 import { SI_3_DIGIT } from './NumberFormats';
 
 const DEFAULT_FORMAT = SI_3_DIGIT;
@@ -20,7 +20,7 @@ export default class NumberFormatterRegistry extends RegistryWithDefaultKey {
     }
 
     // Create new formatter if does not exist
-    const formatter = new D3Formatter(targetFormat);
+    const formatter = new D3NumberFormatter(targetFormat);
     this.registerValue(targetFormat, formatter);
 
     return formatter;

--- a/packages/superset-ui-number-format/src/formatters/D3NumberFormatter.js
+++ b/packages/superset-ui-number-format/src/formatters/D3NumberFormatter.js
@@ -3,15 +3,15 @@ import { format as d3Format } from 'd3-format';
 import { isRequired } from '@superset-ui/core';
 import NumberFormatter from '../NumberFormatter';
 
-export default class D3Formatter extends NumberFormatter {
+export default class D3NumberFormatter extends NumberFormatter {
   /**
    * Pass only the D3 format string to constructor
    *
-   * new D3Formatter('.2f');
+   * new D3NumberFormatter('.2f');
    *
    * or accompany it with human-readable label and description
    *
-   * new D3Formatter({
+   * new D3NumberFormatter({
    *   id: '.2f',
    *   label: 'Float with 2 decimal points',
    *   description: 'lorem ipsum dolor sit amet',
@@ -27,14 +27,16 @@ export default class D3Formatter extends NumberFormatter {
     let formatFunc;
     let isInvalid = false;
 
+    const { id, label, description } = config;
+
     try {
-      formatFunc = d3Format(config.id);
+      formatFunc = d3Format(id);
     } catch (e) {
-      formatFunc = () => `Invalid format: ${config.id}`;
+      formatFunc = () => `Invalid format: ${id}`;
       isInvalid = true;
     }
 
-    super({ ...config, formatFunc });
+    super({ description, formatFunc, id, label });
     this.isInvalid = isInvalid;
   }
 }

--- a/packages/superset-ui-number-format/test/formatters/D3NumberFormatter.test.js
+++ b/packages/superset-ui-number-format/test/formatters/D3NumberFormatter.test.js
@@ -1,26 +1,26 @@
-import D3Formatter from '../../src/formatters/D3Formatter';
+import D3NumberFormatter from '../../src/formatters/D3NumberFormatter';
 
-describe('D3Formatter', () => {
-  describe('new D3Formatter(config)', () => {
+describe('D3NumberFormatter', () => {
+  describe('new D3NumberFormatter(config)', () => {
     it('requires configOrFormatString', () => {
-      expect(() => new D3Formatter()).toThrow();
+      expect(() => new D3NumberFormatter()).toThrow();
     });
     describe('if configOrFormatString is string', () => {
       it('uses the input as d3.format string', () => {
-        const formatter = new D3Formatter('.2f');
+        const formatter = new D3NumberFormatter('.2f');
         expect(formatter.format(100)).toEqual('100.00');
       });
     });
     describe('if configOrFormatString is not string', () => {
       it('requires field config.id', () => {
-        expect(() => new D3Formatter({})).toThrow();
+        expect(() => new D3NumberFormatter({})).toThrow();
       });
       it('uses d3.format(config.id) as format function', () => {
-        const formatter = new D3Formatter({ id: ',.4f' });
+        const formatter = new D3NumberFormatter({ id: ',.4f' });
         expect(formatter.format(12345.67)).toEqual('12,345.6700');
       });
       it('if it is an invalid d3 format, the format function displays error message', () => {
-        const formatter = new D3Formatter({ id: 'i-am-groot' });
+        const formatter = new D3NumberFormatter({ id: 'i-am-groot' });
         expect(formatter.format(12345.67)).toEqual('Invalid format: i-am-groot');
       });
     });


### PR DESCRIPTION
💔 Breaking Changes
fix: Rename `D3Formatter` to `D3NumberFormatter` to avoid ambiguity and naming collision with `D3TimeFormatter`. 

Not really breaking change because `@superset-ui/number-format` has not been published yet.