### PR TITLE
Add overwritePolicy for Registry

### DIFF
--- a/packages/superset-ui-chart/src/registries/ChartBuildQueryRegistrySingleton.js
+++ b/packages/superset-ui-chart/src/registries/ChartBuildQueryRegistrySingleton.js
@@ -2,7 +2,7 @@ import { Registry, makeSingleton } from '@superset-ui/core';
 
 class ChartBuildQueryRegistry extends Registry {
   constructor() {
-    super('ChartBuildQuery');
+    super({ name: 'ChartBuildQuery' });
   }
 }
 

--- a/packages/superset-ui-chart/src/registries/ChartComponentRegistrySingleton.js
+++ b/packages/superset-ui-chart/src/registries/ChartComponentRegistrySingleton.js
@@ -2,7 +2,7 @@ import { Registry, makeSingleton } from '@superset-ui/core';
 
 class ChartComponentRegistry extends Registry {
   constructor() {
-    super('ChartComponent');
+    super({ name: 'ChartComponent' });
   }
 }
 

--- a/packages/superset-ui-chart/src/registries/ChartMetadataRegistrySingleton.js
+++ b/packages/superset-ui-chart/src/registries/ChartMetadataRegistrySingleton.js
@@ -2,7 +2,7 @@ import { Registry, makeSingleton } from '@superset-ui/core';
 
 class ChartMetadataRegistry extends Registry {
   constructor() {
-    super('ChartMetadata');
+    super({ name: 'ChartMetadata' });
   }
 }
 

--- a/packages/superset-ui-chart/src/registries/ChartTransformPropsRegistrySingleton.js
+++ b/packages/superset-ui-chart/src/registries/ChartTransformPropsRegistrySingleton.js
@@ -2,7 +2,7 @@ import { Registry, makeSingleton } from '@superset-ui/core';
 
 class ChartTransformPropsRegistry extends Registry {
   constructor() {
-    super('ChartTransformProps');
+    super({ name: 'ChartTransformProps' });
   }
 }
 

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -25,6 +25,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "jest-mock-console": "^0.4.0"
+  },
   "dependencies": {
     "lodash": "^4.17.11"
   }

--- a/packages/superset-ui-core/src/models/Registry.js
+++ b/packages/superset-ui-core/src/models/Registry.js
@@ -1,7 +1,9 @@
+/* eslint no-console: 0 */
+
 const OverwritePolicy = {
   ALLOW: 'ALLOW',
-  WARN: 'WARN',
   PROHIBIT: 'PROHIBIT',
+  WARN: 'WARN',
 };
 
 export default class Registry {

--- a/packages/superset-ui-core/src/models/Registry.js
+++ b/packages/superset-ui-core/src/models/Registry.js
@@ -1,5 +1,12 @@
+const OverwritePolicy = {
+  ALLOW: 'ALLOW',
+  WARN: 'WARN',
+  PROHIBIT: 'PROHIBIT',
+};
+
 export default class Registry {
-  constructor(name = '') {
+  constructor({ name = '', overwritePolicy = OverwritePolicy.ALLOW } = {}) {
+    this.overwritePolicy = overwritePolicy;
     this.name = name;
     this.items = {};
     this.promises = {};
@@ -20,6 +27,13 @@ export default class Registry {
 
   registerValue(key, value) {
     const item = this.items[key];
+    if (item && item.value !== value) {
+      if (this.overwritePolicy === OverwritePolicy.WARN) {
+        console.warn(`Item with key "${key}" already exists. You are assigning a new value.`);
+      } else if (this.overwritePolicy === OverwritePolicy.PROHIBIT) {
+        throw new Error(`Item with key "${key}" already exists. Cannot overwrite.`);
+      }
+    }
     if (!item || item.value !== value) {
       this.items[key] = { value };
       delete this.promises[key];
@@ -30,6 +44,13 @@ export default class Registry {
 
   registerLoader(key, loader) {
     const item = this.items[key];
+    if (item && item.loader !== loader) {
+      if (this.overwritePolicy === OverwritePolicy.WARN) {
+        console.warn(`Item with key "${key}" already exists. You are assigning a new value.`);
+      } else if (this.overwritePolicy === OverwritePolicy.PROHIBIT) {
+        throw new Error(`Item with key "${key}" already exists. Cannot overwrite.`);
+      }
+    }
     if (!item || item.loader !== loader) {
       this.items[key] = { loader };
       delete this.promises[key];
@@ -122,3 +143,5 @@ export default class Registry {
     return this;
   }
 }
+
+Registry.OverwritePolicy = OverwritePolicy;

--- a/packages/superset-ui-core/src/models/RegistryWithDefaultKey.js
+++ b/packages/superset-ui-core/src/models/RegistryWithDefaultKey.js
@@ -1,8 +1,8 @@
 import Registry from './Registry';
 
 export default class RegistryWithDefaultKey extends Registry {
-  constructor({ name, initialDefaultKey = undefined, setFirstItemAsDefault = false } = {}) {
-    super(name);
+  constructor({ initialDefaultKey = undefined, setFirstItemAsDefault = false, ...rest } = {}) {
+    super(rest);
     this.initialDefaultKey = initialDefaultKey;
     this.defaultKey = initialDefaultKey;
     this.setFirstItemAsDefault = setFirstItemAsDefault;

--- a/packages/superset-ui-core/test/models/Registry.test.js
+++ b/packages/superset-ui-core/test/models/Registry.test.js
@@ -5,12 +5,12 @@ describe('Registry', () => {
     expect(Registry !== undefined).toBe(true);
   });
 
-  describe('new Registry(name)', () => {
-    it('can create a new registry when name is not given', () => {
+  describe('new Registry(config)', () => {
+    it('can create a new registry when config.name is not given', () => {
       const registry = new Registry();
       expect(registry).toBeInstanceOf(Registry);
     });
-    it('can create a new registry when name is given', () => {
+    it('can create a new registry when config.name is given', () => {
       const registry = new Registry({ name: 'abc' });
       expect(registry).toBeInstanceOf(Registry);
       expect(registry.name).toBe('abc');
@@ -264,5 +264,11 @@ describe('Registry', () => {
       registry.registerValue('a', 'testValue');
       expect(registry.remove('a')).toBe(registry);
     });
+  });
+
+  describe('config.overwritePolicy', () => {
+    describe('=ALLOW', () => {});
+    describe('=WARN', () => {});
+    describe('=PROHIBIT', () => {});
   });
 });

--- a/packages/superset-ui-core/test/models/Registry.test.js
+++ b/packages/superset-ui-core/test/models/Registry.test.js
@@ -11,7 +11,7 @@ describe('Registry', () => {
       expect(registry).toBeInstanceOf(Registry);
     });
     it('can create a new registry when name is given', () => {
-      const registry = new Registry('abc');
+      const registry = new Registry({ name: 'abc' });
       expect(registry).toBeInstanceOf(Registry);
       expect(registry.name).toBe('abc');
     });

--- a/packages/superset-ui-core/test/models/Registry.test.js
+++ b/packages/superset-ui-core/test/models/Registry.test.js
@@ -1,3 +1,5 @@
+/* eslint no-console: 0 */
+import mockConsole from 'jest-mock-console';
 import Registry from '../../src/models/Registry';
 
 describe('Registry', () => {
@@ -267,8 +269,77 @@ describe('Registry', () => {
   });
 
   describe('config.overwritePolicy', () => {
-    describe('=ALLOW', () => {});
-    describe('=WARN', () => {});
-    describe('=PROHIBIT', () => {});
+    describe('=ALLOW', () => {
+      describe('.registerValue(key, value)', () => {
+        it('registers normally', () => {
+          const restoreConsole = mockConsole();
+          const registry = new Registry();
+          registry.registerValue('a', 'testValue');
+          expect(() => registry.registerValue('a', 'testValue2')).not.toThrow();
+          expect(registry.get('a')).toEqual('testValue2');
+          expect(console.warn).not.toHaveBeenCalled();
+          restoreConsole();
+        });
+      });
+      describe('.registerLoader(key, loader)', () => {
+        it('registers normally', () => {
+          const restoreConsole = mockConsole();
+          const registry = new Registry();
+          registry.registerLoader('a', () => 'testValue');
+          expect(() => registry.registerLoader('a', () => 'testValue2')).not.toThrow();
+          expect(registry.get('a')).toEqual('testValue2');
+          expect(console.warn).not.toHaveBeenCalled();
+          restoreConsole();
+        });
+      });
+    });
+    describe('=WARN', () => {
+      describe('.registerValue(key, value)', () => {
+        it('warns when overwrite', () => {
+          const restoreConsole = mockConsole();
+          const registry = new Registry({
+            overwritePolicy: Registry.OverwritePolicy.WARN,
+          });
+          registry.registerValue('a', 'testValue');
+          expect(() => registry.registerValue('a', 'testValue2')).not.toThrow();
+          expect(registry.get('a')).toEqual('testValue2');
+          expect(console.warn).toHaveBeenCalled();
+          restoreConsole();
+        });
+      });
+      describe('.registerLoader(key, loader)', () => {
+        it('warns when overwrite', () => {
+          const restoreConsole = mockConsole();
+          const registry = new Registry({
+            overwritePolicy: Registry.OverwritePolicy.WARN,
+          });
+          registry.registerLoader('a', () => 'testValue');
+          expect(() => registry.registerLoader('a', () => 'testValue2')).not.toThrow();
+          expect(registry.get('a')).toEqual('testValue2');
+          expect(console.warn).toHaveBeenCalled();
+          restoreConsole();
+        });
+      });
+    });
+    describe('=PROHIBIT', () => {
+      describe('.registerValue(key, value)', () => {
+        it('throws error when overwrite', () => {
+          const registry = new Registry({
+            overwritePolicy: Registry.OverwritePolicy.PROHIBIT,
+          });
+          registry.registerValue('a', 'testValue');
+          expect(() => registry.registerValue('a', 'testValue2')).toThrow();
+        });
+      });
+      describe('.registerLoader(key, loader)', () => {
+        it('warns when overwrite', () => {
+          const registry = new Registry({
+            overwritePolicy: Registry.OverwritePolicy.PROHIBIT,
+          });
+          registry.registerLoader('a', () => 'testValue');
+          expect(() => registry.registerLoader('a', () => 'testValue2')).toThrow();
+        });
+      });
+    });
   });
 });

--- a/packages/superset-ui-core/test/models/RegistryWithDefaultKey.test.js
+++ b/packages/superset-ui-core/test/models/RegistryWithDefaultKey.test.js
@@ -12,7 +12,7 @@ describe('RegistryWithDefaultKey', () => {
     registry = new RegistryWithDefaultKey();
   });
 
-  describe('new RegistryWithDefaultKey(options)', () => {
+  describe('new RegistryWithDefaultKey(config)', () => {
     it('returns a class that extends from Registry', () => {
       expect(registry).toBeInstanceOf(Registry);
     });
@@ -61,7 +61,7 @@ describe('RegistryWithDefaultKey', () => {
     });
   });
 
-  describe('options.defaultKey', () => {
+  describe('config.defaultKey', () => {
     describe('when not set', () => {
       it(`After creation, default key is undefined`, () => {
         expect(registry.defaultKey).toBeUndefined();
@@ -72,14 +72,14 @@ describe('RegistryWithDefaultKey', () => {
         expect(registry.getDefaultKey()).toBeUndefined();
       });
     });
-    describe('when options.initialDefaultKey is set', () => {
+    describe('when config.initialDefaultKey is set', () => {
       const registry2 = new RegistryWithDefaultKey({
         initialDefaultKey: 'def',
       });
       it(`After creation, default key is undefined`, () => {
         expect(registry2.defaultKey).toEqual('def');
       });
-      it('.clear() reset defaultKey to this options.defaultKey', () => {
+      it('.clear() reset defaultKey to this config.defaultKey', () => {
         registry2.setDefaultKey('abc');
         registry2.clear();
         expect(registry2.getDefaultKey()).toEqual('def');
@@ -87,7 +87,7 @@ describe('RegistryWithDefaultKey', () => {
     });
   });
 
-  describe('options.setFirstItemAsDefault', () => {
+  describe('config.setFirstItemAsDefault', () => {
     describe('when true', () => {
       const registry2 = new RegistryWithDefaultKey({ setFirstItemAsDefault: true });
       beforeEach(() => {


### PR DESCRIPTION
💔 Breaking Changes

BREAKING CHANGE: Change `Registry` constructor API to take object instead of single string `name`. 

This constructor has not been called anywhere in `incubator-superset`. It is only used in other packages in `@superset-ui`, which are also updated in this PR.

🏆 Enhancements

feat: Add `overwritePolicy` for `Registry` so developer can customize whether overwriting is `ALLOW`, `WARN` or `PROHIBIT`. 

🏠 Internal

fix: Change variable name `options` to `config` for consistency. 