### PR TITLE
Changed the default value for buildQuery to null

### DIFF
--- a/packages/superset-ui-chart/src/models/ChartPlugin.js
+++ b/packages/superset-ui-chart/src/models/ChartPlugin.js
@@ -11,7 +11,7 @@ export default class ChartPlugin extends Plugin {
     metadata = isRequired('metadata'),
 
     // use buildQuery for immediate value
-    buildQuery = IDENTITY,
+    buildQuery,
     // use loadBuildQuery for dynamic import (lazy-loading)
     loadBuildQuery,
 
@@ -27,7 +27,7 @@ export default class ChartPlugin extends Plugin {
   } = {}) {
     super();
     this.metadata = metadata;
-    this.loadBuildQuery = loadBuildQuery || (() => buildQuery);
+    this.loadBuildQuery = loadBuildQuery || (buildQuery ? () => buildQuery : null);
     this.loadTransformProps = loadTransformProps || (() => transformProps);
 
     if (loadChart) {

--- a/packages/superset-ui-chart/test/models/ChartPlugin.test.js
+++ b/packages/superset-ui-chart/test/models/ChartPlugin.test.js
@@ -26,7 +26,7 @@ describe('ChartPlugin', () => {
           metadata,
           Chart: 'test',
         });
-        expect(plugin.loadBuildQuery()(FORM_DATA)).toBe(FORM_DATA);
+        expect(plugin.loadBuildQuery).toBeNull();
       });
       it('uses loadBuildQuery field if specified', () => {
         const plugin = new ChartPlugin({


### PR DESCRIPTION
💔 Breaking Changes
None

🏆 Enhancements
During the transition of adding `buildQuery` to each chart, we need to have a flag to indicate if `buildQuery` is implemented.  

This PR is to change the default value of `buildQuery` to None, so that it can be used as the flag. 
📜 Documentation

🐛 Bug Fix

🏠 Internal
