### PR TITLE
Fix typo in unit test description

### DIFF
--- a/packages/superset-ui-number-format/test/factories/createD3NumberFormatter.test.js
+++ b/packages/superset-ui-number-format/test/factories/createD3NumberFormatter.test.js
@@ -1,49 +1,47 @@
 import createD3NumberFormatter from '../../src/factories/createD3NumberFormatter';
 
-describe('D3NumberFormatter', () => {
-  describe('new D3NumberFormatter(config)', () => {
-    it('requires config.formatString', () => {
-      expect(() => createD3NumberFormatter()).toThrow();
+describe('createD3NumberFormatter(config)', () => {
+  it('requires config.formatString', () => {
+    expect(() => createD3NumberFormatter()).toThrow();
+  });
+  describe('config.formatString', () => {
+    it('creates a NumberFormatter with the formatString as id', () => {
+      const formatter = createD3NumberFormatter({ formatString: '.2f' });
+      expect(formatter.id).toEqual('.2f');
     });
-    describe('config.formatString', () => {
-      it('creates a NumberFormatter with the formatString as id', () => {
+    describe('if it is valid d3 formatString', () => {
+      it('uses d3.format(config.formatString) as format function', () => {
         const formatter = createD3NumberFormatter({ formatString: '.2f' });
-        expect(formatter.id).toEqual('.2f');
-      });
-      describe('if it is valid d3 formatString', () => {
-        it('uses d3.format(config.formatString) as format function', () => {
-          const formatter = createD3NumberFormatter({ formatString: '.2f' });
-          expect(formatter.format(100)).toEqual('100.00');
-        });
-      });
-      describe('if it is invalid d3 formatString', () => {
-        it('The format function displays error message', () => {
-          const formatter = createD3NumberFormatter({ formatString: 'i-am-groot' });
-          expect(formatter.format(12345.67)).toEqual('12345.67 (Invalid format: i-am-groot)');
-        });
-        it('also set formatter.isInvalid to true', () => {
-          const formatter = createD3NumberFormatter({ formatString: 'i-am-groot' });
-          expect(formatter.isInvalid).toEqual(true);
-        });
+        expect(formatter.format(100)).toEqual('100.00');
       });
     });
-    describe('config.label', () => {
-      it('set label if specified', () => {
-        const formatter = createD3NumberFormatter({
-          formatString: '.2f',
-          label: 'float formatter',
-        });
-        expect(formatter.label).toEqual('float formatter');
+    describe('if it is invalid d3 formatString', () => {
+      it('The format function displays error message', () => {
+        const formatter = createD3NumberFormatter({ formatString: 'i-am-groot' });
+        expect(formatter.format(12345.67)).toEqual('12345.67 (Invalid format: i-am-groot)');
+      });
+      it('also set formatter.isInvalid to true', () => {
+        const formatter = createD3NumberFormatter({ formatString: 'i-am-groot' });
+        expect(formatter.isInvalid).toEqual(true);
       });
     });
-    describe('config.description', () => {
-      it('set decription if specified', () => {
-        const formatter = createD3NumberFormatter({
-          description: 'lorem ipsum',
-          formatString: '.2f',
-        });
-        expect(formatter.description).toEqual('lorem ipsum');
+  });
+  describe('config.label', () => {
+    it('set label if specified', () => {
+      const formatter = createD3NumberFormatter({
+        formatString: '.2f',
+        label: 'float formatter',
       });
+      expect(formatter.label).toEqual('float formatter');
+    });
+  });
+  describe('config.description', () => {
+    it('set decription if specified', () => {
+      const formatter = createD3NumberFormatter({
+        description: 'lorem ipsum',
+        formatString: '.2f',
+      });
+      expect(formatter.description).toEqual('lorem ipsum');
     });
   });
 });

--- a/packages/superset-ui-number-format/test/factories/createSiAtMostNDigitFormatter.test.js
+++ b/packages/superset-ui-number-format/test/factories/createSiAtMostNDigitFormatter.test.js
@@ -1,51 +1,49 @@
 import NumberFormatter from '../../src/NumberFormatter';
 import createSiAtMostNDigitFormatter from '../../src/factories/createSiAtMostNDigitFormatter';
 
-describe('SiAtMostNDigitFormatter', () => {
-  describe('new SiAtMostNDigitFormatter(n)', () => {
-    it('creates an instance of NumberFormatter', () => {
-      const formatter = createSiAtMostNDigitFormatter({ n: 4 });
-      expect(formatter).toBeInstanceOf(NumberFormatter);
-    });
-    it('when n is specified, it formats number in SI format with at most n significant digits', () => {
-      const formatter = createSiAtMostNDigitFormatter({ n: 2 });
-      expect(formatter(10)).toBe('10');
-      expect(formatter(1)).toBe('1');
-      expect(formatter(1.0)).toBe('1');
-      expect(formatter(10.0)).toBe('10');
-      expect(formatter(10001)).toBe('10k');
-      expect(formatter(10100)).toBe('10k');
-      expect(formatter(111000000)).toBe('110M');
-      expect(formatter(0.23)).toBe('230m');
-      expect(formatter(0)).toBe('0');
-      expect(formatter(-10)).toBe('-10');
-      expect(formatter(-1)).toBe('-1');
-      expect(formatter(-1.0)).toBe('-1');
-      expect(formatter(-10.0)).toBe('-10');
-      expect(formatter(-10001)).toBe('-10k');
-      expect(formatter(-10101)).toBe('-10k');
-      expect(formatter(-111000000)).toBe('-110M');
-      expect(formatter(-0.23)).toBe('-230m');
-    });
-    it('when n is not specified, it defaults to n=3', () => {
-      const formatter = createSiAtMostNDigitFormatter();
-      expect(formatter(10)).toBe('10');
-      expect(formatter(1)).toBe('1');
-      expect(formatter(1.0)).toBe('1');
-      expect(formatter(10.0)).toBe('10');
-      expect(formatter(10001)).toBe('10.0k');
-      expect(formatter(10100)).toBe('10.1k');
-      expect(formatter(111000000)).toBe('111M');
-      expect(formatter(0.23)).toBe('230m');
-      expect(formatter(0)).toBe('0');
-      expect(formatter(-10)).toBe('-10');
-      expect(formatter(-1)).toBe('-1');
-      expect(formatter(-1.0)).toBe('-1');
-      expect(formatter(-10.0)).toBe('-10');
-      expect(formatter(-10001)).toBe('-10.0k');
-      expect(formatter(-10101)).toBe('-10.1k');
-      expect(formatter(-111000000)).toBe('-111M');
-      expect(formatter(-0.23)).toBe('-230m');
-    });
+describe('createSiAtMostNDigitFormatter({ n })', () => {
+  it('creates an instance of NumberFormatter', () => {
+    const formatter = createSiAtMostNDigitFormatter({ n: 4 });
+    expect(formatter).toBeInstanceOf(NumberFormatter);
+  });
+  it('when n is specified, it formats number in SI format with at most n significant digits', () => {
+    const formatter = createSiAtMostNDigitFormatter({ n: 2 });
+    expect(formatter(10)).toBe('10');
+    expect(formatter(1)).toBe('1');
+    expect(formatter(1.0)).toBe('1');
+    expect(formatter(10.0)).toBe('10');
+    expect(formatter(10001)).toBe('10k');
+    expect(formatter(10100)).toBe('10k');
+    expect(formatter(111000000)).toBe('110M');
+    expect(formatter(0.23)).toBe('230m');
+    expect(formatter(0)).toBe('0');
+    expect(formatter(-10)).toBe('-10');
+    expect(formatter(-1)).toBe('-1');
+    expect(formatter(-1.0)).toBe('-1');
+    expect(formatter(-10.0)).toBe('-10');
+    expect(formatter(-10001)).toBe('-10k');
+    expect(formatter(-10101)).toBe('-10k');
+    expect(formatter(-111000000)).toBe('-110M');
+    expect(formatter(-0.23)).toBe('-230m');
+  });
+  it('when n is not specified, it defaults to n=3', () => {
+    const formatter = createSiAtMostNDigitFormatter();
+    expect(formatter(10)).toBe('10');
+    expect(formatter(1)).toBe('1');
+    expect(formatter(1.0)).toBe('1');
+    expect(formatter(10.0)).toBe('10');
+    expect(formatter(10001)).toBe('10.0k');
+    expect(formatter(10100)).toBe('10.1k');
+    expect(formatter(111000000)).toBe('111M');
+    expect(formatter(0.23)).toBe('230m');
+    expect(formatter(0)).toBe('0');
+    expect(formatter(-10)).toBe('-10');
+    expect(formatter(-1)).toBe('-1');
+    expect(formatter(-1.0)).toBe('-1');
+    expect(formatter(-10.0)).toBe('-10');
+    expect(formatter(-10001)).toBe('-10.0k');
+    expect(formatter(-10101)).toBe('-10.1k');
+    expect(formatter(-111000000)).toBe('-111M');
+    expect(formatter(-0.23)).toBe('-230m');
   });
 });

--- a/packages/superset-ui-time-format/test/factories/createMultiFormatter.test.js
+++ b/packages/superset-ui-time-format/test/factories/createMultiFormatter.test.js
@@ -1,6 +1,6 @@
 import createMultiFormatter from '../../src/factories/createMultiFormatter';
 
-describe('createMultiFormatter', () => {
+describe('createMultiFormatter()', () => {
   describe('creates a multi-step formatter', () => {
     const formatter = createMultiFormatter({
       id: 'my_format',


### PR DESCRIPTION
🏠 Internal

- Remove unnecessary nesting of `describe` block and update `describe` description to reflect the code. 