### PR TITLE
Remove leading and trailing space when looking up formatter

### DIFF
--- a/packages/superset-ui-number-format/src/NumberFormatterRegistry.js
+++ b/packages/superset-ui-number-format/src/NumberFormatterRegistry.js
@@ -11,7 +11,7 @@ export default class NumberFormatterRegistry extends RegistryWithDefaultKey {
   }
 
   get(formatterId) {
-    const targetFormat = formatterId || this.defaultKey;
+    const targetFormat = (formatterId || this.defaultKey).trim();
 
     if (this.has(targetFormat)) {
       return super.get(targetFormat);

--- a/packages/superset-ui-number-format/test/NumberFormatterRegistry.test.js
+++ b/packages/superset-ui-number-format/test/NumberFormatterRegistry.test.js
@@ -22,6 +22,17 @@ describe('NumberFormatterRegistry', () => {
       const formatter = registry.get();
       expect(formatter.format(100)).toEqual('100.0');
     });
+    it('removes leading and trailing spaces from format', () => {
+      const formatter = registry.get(' .2f');
+      expect(formatter).toBeInstanceOf(NumberFormatter);
+      expect(formatter.format(100)).toEqual('100.00');
+      const formatter2 = registry.get('.2f ');
+      expect(formatter2).toBeInstanceOf(NumberFormatter);
+      expect(formatter2.format(100)).toEqual('100.00');
+      const formatter3 = registry.get(' .2f ');
+      expect(formatter3).toBeInstanceOf(NumberFormatter);
+      expect(formatter3.format(100)).toEqual('100.00');
+    });
   });
   describe('.format(format, value)', () => {
     it('return the value with the specified format', () => {

--- a/packages/superset-ui-time-format/src/TimeFormatterRegistry.js
+++ b/packages/superset-ui-time-format/src/TimeFormatterRegistry.js
@@ -11,7 +11,7 @@ export default class TimeFormatterRegistry extends RegistryWithDefaultKey {
   }
 
   get(format) {
-    const targetFormat = format || this.defaultKey;
+    const targetFormat = (format || this.defaultKey).trim();
 
     if (this.has(targetFormat)) {
       return super.get(targetFormat);

--- a/packages/superset-ui-time-format/test/TimeFormatterRegistry.test.js
+++ b/packages/superset-ui-time-format/test/TimeFormatterRegistry.test.js
@@ -22,6 +22,11 @@ describe('TimeFormatterRegistry', () => {
       const formatter = registry.get();
       expect(formatter.format(PREVIEW_TIME)).toEqual('14/02/2017');
     });
+    it('removes leading and trailing spaces from format', () => {
+      const formatter = registry.get(' %Y ');
+      expect(formatter).toBeInstanceOf(TimeFormatter);
+      expect(formatter.format(PREVIEW_TIME)).toEqual('2017');
+    });
   });
   describe('.format(format, value)', () => {
     it('return the value with the specified format', () => {


### PR DESCRIPTION
🏆 Enhancements

Remove leading and trailing space when looking up formatter.
- `getNumberFormatter(format)` works the same for `".2f"` and `" .2f "`
- `getTimeFormatter(format)` works the same for `"%Y"` and `" %Y "`

