### PR TITLE
[bugfix][connection] fix client promise

### DIFF
--- a/packages/superset-ui-connection/src/SupersetClient.ts
+++ b/packages/superset-ui-connection/src/SupersetClient.ts
@@ -25,8 +25,8 @@ export interface ClientConfig {
 
 class SupersetClient {
   credentials: Credentials;
-  csrfToken: CsrfToken | undefined;
-  csrfPromise: CsrfPromise;
+  csrfToken?: CsrfToken;
+  csrfPromise?: CsrfPromise;
   protocol: Protocol;
   host: Host;
   headers: Headers;
@@ -49,12 +49,7 @@ class SupersetClient {
     this.protocol = protocol;
     this.credentials = credentials;
     this.csrfToken = csrfToken;
-    this.csrfPromise = Promise.reject({
-      error: `SupersetClient has no CSRF token, ensure it is initialized or
-      try logging into the Superset instance at ${this.getUrl({
-        endpoint: '/login',
-      })}`,
-    });
+    this.csrfPromise = undefined;
 
     if (typeof this.csrfToken === 'string') {
       this.headers = { ...this.headers, 'X-CSRFToken': this.csrfToken };
@@ -132,7 +127,15 @@ class SupersetClient {
   }
 
   ensureAuth() {
-    return this.csrfPromise;
+    return (
+      this.csrfPromise ||
+      Promise.reject({
+        error: `SupersetClient has no CSRF token, ensure it is initialized or
+      try logging into the Superset instance at ${this.getUrl({
+        endpoint: '/login',
+      })}`,
+      })
+    );
   }
 
   async getCSRFToken() {


### PR DESCRIPTION
🐛 Bug Fix

This fixes an error in `@superset-ui/connection@^0.7.0` where it will throw immediately from the rejected promise in the constructor. Even though this doesn't seem to fail in node tests, it looks like it throws in the browser 🙄 

@kristw @xtinec @conglei 