### PR TITLE
Allow metrics arrays in form data

### DIFF
--- a/packages/superset-ui-chart/src/query/FormData.ts
+++ b/packages/superset-ui-chart/src/query/FormData.ts
@@ -1,4 +1,4 @@
-import { AdhocMetric, MetricKey } from './Metric';
+import { FormDataMetric, MetricKey } from './Metric';
 
 // Type signature and utility functions for formData shared by all viz types
 // It will be gradually filled out as we build out the query object
@@ -7,7 +7,7 @@ import { AdhocMetric, MetricKey } from './Metric';
 // https://github.com/Microsoft/TypeScript/issues/13573
 // The Metrics in formData is either a string or a proper metric. It will be
 // unified into a proper Metric type during buildQuery (see `/query/Metrics.ts`).
-type Metrics = Partial<Record<MetricKey, AdhocMetric | string>>;
+type Metrics = Partial<Record<MetricKey, FormDataMetric | FormDataMetric[]>>;
 
 type BaseFormData = {
   datasource: string;

--- a/packages/superset-ui-chart/test/query/Metric.test.ts
+++ b/packages/superset-ui-chart/test/query/Metric.test.ts
@@ -102,4 +102,13 @@ describe('Metrics', () => {
     });
     expect(metrics.getLabels()[0].length).toBeLessThanOrEqual(LABEL_MAX_LENGTH);
   });
+
+  it('should handle metrics arrays in form data', () => {
+    metrics = new Metrics({
+      ...formData,
+      metrics: ['sum__num'],
+    });
+    expect(metrics.getMetrics()).toEqual([{ label: 'sum__num' }]);
+    expect(metrics.getLabels()).toEqual(['sum__num']);
+  });
 });


### PR DESCRIPTION
🏠 Internal

Metrics can take shape of an array of metrics in form data for a given metrics key. For example, `{ metrics: ['sum__num'] }`. This PR changes Metrics class to handle the array case.
