### PR TITLE
Add SuperChart

### DIFF
--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createSelector } from 'reselect';
-import getChartComponentRegistry from '../registries/ChartBuildQueryRegistrySingleton';
+import getChartComponentRegistry from '../registries/ChartComponentRegistrySingleton';
 import getChartTransformPropsRegistry from '../registries/ChartTransformPropsRegistrySingleton';
 import ChartProps from '../models/ChartProps';
 import createLoadableRenderer, { LoadableRenderer } from './createLoadableRenderer';
@@ -161,7 +161,7 @@ class SuperChart extends React.PureComponent<SuperChartProps, {}> {
         <div className="alert alert-warning" role="alert">
           <strong>ERROR</strong>&nbsp;
           <code>chartType=&quot;{chartType}&quot;</code> &mdash;
-          {JSON.stringify(error)}
+          {error.toString()}
         </div>
       );
     }
@@ -191,8 +191,19 @@ class SuperChart extends React.PureComponent<SuperChartProps, {}> {
       return null;
     }
 
+    const containerProps: {
+      id?: string;
+      className?: string;
+    } = {};
+    if (id) {
+      containerProps.id = id;
+    }
+    if (className) {
+      containerProps.className = className;
+    }
+
     return (
-      <div id={id} className={className}>
+      <div {...containerProps}>
         <Renderer
           preTransformProps={preTransformProps}
           postTransformProps={postTransformProps}

--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createSelector } from 'reselect';
 import getChartComponentRegistry from '../registries/ChartBuildQueryRegistrySingleton';
 import getChartTransformPropsRegistry from '../registries/ChartTransformPropsRegistrySingleton';
-import { ChartProps } from '../models/ChartProps';
+import ChartProps from '../models/ChartProps';
 import createLoadableRenderer, { LoadableRenderer } from './createLoadableRenderer';
 
 const IDENTITY = (x: any) => x;
@@ -13,6 +13,7 @@ const EMPTY = () => null;
 const defaultProps = {
   id: '',
   className: '',
+  chartProps: {},
   preTransformProps: IDENTITY,
   overrideTransformProps: undefined,
   postTransformProps: IDENTITY,
@@ -42,7 +43,7 @@ interface RenderProps {
 export interface SuperChartProps {
   id?: string;
   className?: string;
-  chartProps: ChartProps;
+  chartProps?: ChartProps;
   chartType: string;
   preTransformProps?: TransformFunction;
   overrideTransformProps?: TransformFunction;

--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -1,0 +1,198 @@
+import * as React from 'react';
+import { createSelector } from 'reselect';
+import getChartComponentRegistry from '../registries/ChartBuildQueryRegistrySingleton';
+import getChartTransformPropsRegistry from '../registries/ChartTransformPropsRegistrySingleton';
+import { ChartProps } from '../models/ChartProps';
+import createLoadableRenderer from './createLoadableRenderer';
+
+const IDENTITY = (x: any) => x;
+
+const defaultProps = {
+  id: '',
+  className: '',
+  preTransformProps: IDENTITY,
+  overrideTransformProps: undefined,
+  postTransformProps: IDENTITY,
+  onRenderSuccess() {},
+  onRenderFailure() {},
+};
+
+type TransformFunction = (x: any) => any;
+type HandlerFunction = (...args: any[]) => void;
+
+interface LoadingProps {
+  error: any;
+}
+
+export interface SuperChartProps {
+  id?: string;
+  className?: string;
+  chartProps: ChartProps;
+  chartType: string;
+  preTransformProps?: TransformFunction;
+  overrideTransformProps?: TransformFunction;
+  postTransformProps?: TransformFunction;
+  onRenderSuccess?: HandlerFunction;
+  onRenderFailure?: HandlerFunction;
+}
+
+function getModule<T>(value: any): T {
+  return (value.default ? value.default : value) as T;
+}
+
+class SuperChart extends React.PureComponent<SuperChartProps, {}> {
+  static defaultProps = defaultProps;
+
+  processChartProps: (
+    input: {
+      chartProps: ChartProps;
+      preTransformProps: TransformFunction;
+      transformProps: TransformFunction;
+      postTransformProps: TransformFunction;
+    },
+  ) => any;
+
+  createLoadableRenderer: (
+    input: {
+      chartType: string;
+      overrideTransformProps?: TransformFunction;
+    },
+  ) => React.Component | (() => null);
+
+  constructor(props: SuperChartProps) {
+    super(props);
+
+    this.renderChart = this.renderChart.bind(this);
+    this.renderLoading = this.renderLoading.bind(this);
+
+    // memoized function so it will not recompute
+    // and return previous value
+    // unless one of
+    // - preTransformProps
+    // - transformProps
+    // - postTransformProps
+    // - chartProps
+    // is changed.
+    this.processChartProps = createSelector(
+      input => input.preTransformProps,
+      input => input.transformProps,
+      input => input.postTransformProps,
+      input => input.chartProps,
+      (pre, transform, post, chartProps) => post(transform(pre(chartProps))),
+    );
+
+    const componentRegistry = getChartComponentRegistry();
+    const transformPropsRegistry = getChartTransformPropsRegistry();
+
+    // memoized function so it will not recompute
+    // and return previous value
+    // unless one of
+    // - chartType
+    // - overrideTransformProps
+    // is changed.
+    this.createLoadableRenderer = createSelector(
+      input => input.chartType,
+      input => input.overrideTransformProps,
+      (chartType, overrideTransformProps) => {
+        if (chartType) {
+          const LoadableRenderer = createLoadableRenderer({
+            loader: {
+              Chart: () => componentRegistry.getAsPromise(chartType),
+              transformProps: overrideTransformProps
+                ? () => Promise.resolve(overrideTransformProps)
+                : () => transformPropsRegistry.getAsPromise(chartType),
+            },
+            loading: (loadingProps: LoadingProps) => this.renderLoading(loadingProps, chartType),
+            render: this.renderChart,
+          });
+
+          // Trigger preloading.
+          LoadableRenderer.preload();
+
+          return LoadableRenderer;
+        }
+        return () => null;
+      },
+    );
+  }
+
+  renderChart(
+    loaded: {
+      Chart: React.Component | { default: React.Component };
+      transformProps: TransformFunction | { default: TransformFunction };
+    },
+    props: {
+      chartProps: ChartProps;
+      preTransformProps: TransformFunction;
+      postTransformProps: TransformFunction;
+    },
+  ) {
+    const Chart = getModule<React.Component>(loaded.Chart);
+    const transformProps = getModule<TransformFunction>(loaded.transformProps);
+    const { chartProps, preTransformProps, postTransformProps } = props;
+
+    return (
+      <Chart
+        {...this.processChartProps({
+          preTransformProps,
+          transformProps,
+          postTransformProps,
+          chartProps,
+        })}
+      />
+    );
+  }
+
+  renderLoading(loadingProps: LoadingProps, chartType: string) {
+    const { error } = loadingProps;
+
+    if (error) {
+      return (
+        <div className="alert alert-warning" role="alert">
+          <strong>ERROR</strong>&nbsp;
+          <code>chartType="{chartType}"</code> &mdash;
+          {JSON.stringify(error)}
+        </div>
+      );
+    }
+
+    return null;
+  }
+
+  render() {
+    const {
+      id,
+      className,
+      preTransformProps,
+      postTransformProps,
+      chartProps,
+      onRenderSuccess,
+      onRenderFailure,
+    } = this.props;
+
+    // Create LoadableRenderer and start preloading
+    // the lazy-loaded Chart components
+    const LoadableRenderer = this.createLoadableRenderer(this.props);
+
+    // Do not render if chartProps is not available.
+    // but the pre-loading has been started in this.createLoadableRenderer
+    // to prepare for rendering once chartProps becomes available.
+    if (!chartProps) {
+      return null;
+    }
+
+    return (
+      <div id={id} className={className}>
+        <LoadableRenderer
+          preTransformProps={preTransformProps}
+          postTransformProps={postTransformProps}
+          chartProps={chartProps}
+          onRenderSuccess={onRenderSuccess}
+          onRenderFailure={onRenderFailure}
+        />
+      </div>
+    );
+  }
+}
+
+export default SuperChart;

--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -57,7 +57,7 @@ function getModule<T>(value: any): T {
   return (value.default ? value.default : value) as T;
 }
 
-class SuperChart extends React.PureComponent<SuperChartProps, {}> {
+export default class SuperChart extends React.PureComponent<SuperChartProps, {}> {
   static defaultProps = defaultProps;
 
   constructor(props: SuperChartProps) {
@@ -80,7 +80,7 @@ class SuperChart extends React.PureComponent<SuperChartProps, {}> {
       input => input.postTransformProps,
       input => input.chartProps,
       (pre = IDENTITY, transform = IDENTITY, post = IDENTITY, chartProps) =>
-        chartProps ? post(transform(pre(chartProps))) : chartProps,
+        post(transform(pre(chartProps))),
     );
 
     const componentRegistry = getChartComponentRegistry();
@@ -216,5 +216,3 @@ class SuperChart extends React.PureComponent<SuperChartProps, {}> {
     );
   }
 }
-
-export default SuperChart;

--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -13,7 +13,6 @@ const EMPTY = () => null;
 const defaultProps = {
   id: '',
   className: '',
-  chartProps: {},
   preTransformProps: IDENTITY,
   overrideTransformProps: undefined,
   postTransformProps: IDENTITY,
@@ -40,10 +39,12 @@ interface RenderProps {
   postTransformProps?: TransformFunction;
 }
 
+const BLANK_CHART_PROPS = new ChartProps();
+
 export interface SuperChartProps {
   id?: string;
   className?: string;
-  chartProps?: ChartProps;
+  chartProps?: ChartProps | null;
   chartType: string;
   preTransformProps?: TransformFunction;
   overrideTransformProps?: TransformFunction;
@@ -79,7 +80,7 @@ class SuperChart extends React.PureComponent<SuperChartProps, {}> {
       input => input.postTransformProps,
       input => input.chartProps,
       (pre = IDENTITY, transform = IDENTITY, post = IDENTITY, chartProps) =>
-        post(transform(pre(chartProps))),
+        chartProps ? post(transform(pre(chartProps))) : chartProps,
     );
 
     const componentRegistry = getChartComponentRegistry();
@@ -175,7 +176,7 @@ class SuperChart extends React.PureComponent<SuperChartProps, {}> {
       className,
       preTransformProps,
       postTransformProps,
-      chartProps,
+      chartProps = BLANK_CHART_PROPS,
       onRenderSuccess,
       onRenderFailure,
     } = this.props;
@@ -184,10 +185,10 @@ class SuperChart extends React.PureComponent<SuperChartProps, {}> {
     // the lazy-loaded Chart components
     const Renderer = this.createLoadableRenderer(this.props);
 
-    // Do not render if chartProps is not available.
+    // Do not render if chartProps is set to null.
     // but the pre-loading has been started in this.createLoadableRenderer
     // to prepare for rendering once chartProps becomes available.
-    if (!chartProps) {
+    if (chartProps === null) {
       return null;
     }
 

--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -21,11 +21,15 @@ const defaultProps = {
 };
 /* eslint-enable sort-keys */
 
-type TransformFunction = (x: any) => any;
+type TransformFunction<Input = PlainProps, Output = PlainProps> = (x: Input) => Output;
 type HandlerFunction = (...args: any[]) => void;
 
 interface LoadingProps {
   error: any;
+}
+
+interface PlainProps {
+  [key: string]: any;
 }
 
 interface LoadedModules {
@@ -35,7 +39,7 @@ interface LoadedModules {
 
 interface RenderProps {
   chartProps: ChartProps;
-  preTransformProps?: TransformFunction;
+  preTransformProps?: TransformFunction<ChartProps>;
   postTransformProps?: TransformFunction;
 }
 
@@ -46,7 +50,7 @@ export interface SuperChartProps {
   className?: string;
   chartProps?: ChartProps | null;
   chartType: string;
-  preTransformProps?: TransformFunction;
+  preTransformProps?: TransformFunction<ChartProps>;
   overrideTransformProps?: TransformFunction;
   postTransformProps?: TransformFunction;
   onRenderSuccess?: HandlerFunction;
@@ -122,7 +126,7 @@ export default class SuperChart extends React.PureComponent<SuperChartProps, {}>
   processChartProps: (
     input: {
       chartProps: ChartProps;
-      preTransformProps?: TransformFunction;
+      preTransformProps?: TransformFunction<ChartProps>;
       transformProps?: TransformFunction;
       postTransformProps?: TransformFunction;
     },

--- a/packages/superset-ui-chart/src/index.ts
+++ b/packages/superset-ui-chart/src/index.ts
@@ -1,12 +1,12 @@
 export { ChartClient, ChartClientConfig } from './clients/ChartClient';
-export { ChartMetadata, ChartMetadataConfig } from './models/ChartMetadata';
+export { default as ChartMetadata, ChartMetadataConfig } from './models/ChartMetadata';
 export {
-  ChartPlugin,
+  default as ChartPlugin,
   ChartPluginConfig,
   BuildQueryFunction,
   TransformPropsFunction,
 } from './models/ChartPlugin';
-export { ChartProps, ChartPropsConfig } from './models/ChartProps';
+export { default as ChartProps, ChartPropsConfig } from './models/ChartProps';
 
 export { default as createLoadableRenderer } from './components/createLoadableRenderer';
 export { default as reactify } from './components/reactify';

--- a/packages/superset-ui-chart/src/index.ts
+++ b/packages/superset-ui-chart/src/index.ts
@@ -10,6 +10,7 @@ export { default as ChartProps, ChartPropsConfig } from './models/ChartProps';
 
 export { default as createLoadableRenderer } from './components/createLoadableRenderer';
 export { default as reactify } from './components/reactify';
+export { default as SuperChart } from './components/SuperChart';
 
 export {
   default as getChartBuildQueryRegistry,

--- a/packages/superset-ui-chart/src/models/ChartMetadata.ts
+++ b/packages/superset-ui-chart/src/models/ChartMetadata.ts
@@ -12,7 +12,7 @@ export interface ChartMetadataConfig {
   thumbnail: string;
 }
 
-export class ChartMetadata {
+export default class ChartMetadata {
   name: string;
   credits: Array<string>;
   description: string;

--- a/packages/superset-ui-chart/src/models/ChartPlugin.ts
+++ b/packages/superset-ui-chart/src/models/ChartPlugin.ts
@@ -11,7 +11,7 @@ import getChartTransformPropsRegistry from '../registries/ChartTransformPropsReg
 const IDENTITY = (x: any) => x;
 
 type PromiseOrValue<T> = Promise<T> | T;
-type PromiseOrValueLoader<T> = () => PromiseOrValue<T>;
+type PromiseOrValueLoader<T> = () => PromiseOrValue<T> | PromiseOrValue<{ default: T }>;
 
 export type BuildQueryFunction = (formData: FormData) => QueryContext;
 

--- a/packages/superset-ui-chart/src/models/ChartPlugin.ts
+++ b/packages/superset-ui-chart/src/models/ChartPlugin.ts
@@ -67,7 +67,7 @@ export default class ChartPlugin extends Plugin {
     }
   }
 
-  register(): ChartPlugin {
+  register() {
     const { key = isRequired('config.key') } = this.config;
     getChartMetadataRegistry().registerValue(key, this.metadata);
     getChartBuildQueryRegistry().registerLoader(key, this.loadBuildQuery);
@@ -77,7 +77,9 @@ export default class ChartPlugin extends Plugin {
     return this;
   }
 
-  configure(config: { [key: string]: any }): ChartPlugin {
-    return super.configure(config);
+  configure(config: { [key: string]: any }, replace?: boolean) {
+    super.configure(config, replace);
+
+    return this;
   }
 }

--- a/packages/superset-ui-chart/src/models/ChartPlugin.ts
+++ b/packages/superset-ui-chart/src/models/ChartPlugin.ts
@@ -1,6 +1,6 @@
 import { isRequired, Plugin } from '@superset-ui/core';
-import { ChartMetadata } from './ChartMetadata';
-import { ChartProps } from './ChartProps';
+import ChartMetadata from './ChartMetadata';
+import ChartProps from './ChartProps';
 import { FormData } from '../query/FormData';
 import { QueryContext } from '../query/buildQueryContext';
 import getChartMetadataRegistry from '../registries/ChartMetadataRegistrySingleton';
@@ -37,7 +37,7 @@ export interface ChartPluginConfig {
   loadChart?: PromiseOrValueLoader<Function>;
 }
 
-export class ChartPlugin extends Plugin {
+export default class ChartPlugin extends Plugin {
   metadata: ChartMetadata;
   loadBuildQuery?: PromiseOrValueLoader<BuildQueryFunction>;
   loadTransformProps: PromiseOrValueLoader<TransformPropsFunction>;

--- a/packages/superset-ui-chart/src/models/ChartProps.ts
+++ b/packages/superset-ui-chart/src/models/ChartProps.ts
@@ -19,17 +19,20 @@ export interface ChartPropsConfig {
   annotationData?: AnnotationData;
   datasource?: SnakeCaseDatasource;
   filters?: Filters;
-  formData: SnakeCaseFormData;
-  height: number;
+  formData?: SnakeCaseFormData;
+  height?: number;
   onAddFilter?: HandlerFunction;
   onError?: HandlerFunction;
-  payload: QueryData;
+  payload?: QueryData;
   setControlValue?: HandlerFunction;
   setTooltip?: HandlerFunction;
-  width: number;
+  width?: number;
 }
 
 function NOOP() {}
+
+const DEFAULT_WIDTH = 800;
+const DEFAULT_HEIGHT = 600;
 
 export default class ChartProps {
   static createSelector: () => ChartPropsSelector;
@@ -48,20 +51,33 @@ export default class ChartProps {
   setTooltip: HandlerFunction;
   width: number;
 
-  constructor(config: ChartPropsConfig) {
-    this.width = config.width;
-    this.height = config.height;
-    this.annotationData = config.annotationData || {};
-    this.datasource = convertKeysToCamelCase(config.datasource);
-    this.rawDatasource = config.datasource || {};
-    this.filters = config.filters || [];
-    this.formData = convertKeysToCamelCase(config.formData);
-    this.rawFormData = config.formData;
-    this.onAddFilter = config.onAddFilter || NOOP;
-    this.onError = config.onError || NOOP;
-    this.payload = config.payload;
-    this.setControlValue = config.setControlValue || NOOP;
-    this.setTooltip = config.setTooltip || NOOP;
+  constructor(config: ChartPropsConfig = {}) {
+    const {
+      annotationData = {},
+      datasource = {},
+      filters = [],
+      formData = {},
+      onAddFilter = NOOP,
+      onError = NOOP,
+      payload = {},
+      setControlValue = NOOP,
+      setTooltip = NOOP,
+      width = DEFAULT_WIDTH,
+      height = DEFAULT_HEIGHT,
+    } = config;
+    this.width = width;
+    this.height = height;
+    this.annotationData = annotationData;
+    this.datasource = convertKeysToCamelCase(datasource);
+    this.rawDatasource = datasource;
+    this.filters = filters;
+    this.formData = convertKeysToCamelCase(formData);
+    this.rawFormData = formData;
+    this.onAddFilter = onAddFilter;
+    this.onError = onError;
+    this.payload = payload;
+    this.setControlValue = setControlValue;
+    this.setTooltip = setTooltip;
   }
 }
 

--- a/packages/superset-ui-chart/src/models/ChartProps.ts
+++ b/packages/superset-ui-chart/src/models/ChartProps.ts
@@ -31,7 +31,7 @@ export interface ChartPropsConfig {
 
 function NOOP() {}
 
-export class ChartProps {
+export default class ChartProps {
   static createSelector: () => ChartPropsSelector;
 
   annotationData: AnnotationData;

--- a/packages/superset-ui-chart/test/components/SuperChart.test.jsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SuperChart } from '../../src';
+
+describe('SuperChart', () => {
+  it('does not render if chartType is not set', done => {
+    const wrapper = shallow(<SuperChart />);
+    setTimeout(() => {
+      expect(wrapper.render().children()).toHaveLength(0);
+      done();
+    }, 5);
+  });
+});

--- a/packages/superset-ui-chart/test/components/SuperChart.test.ts
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.ts
@@ -1,0 +1,1 @@
+describe('SuperChart', () => {});

--- a/packages/superset-ui-chart/test/components/SuperChart.test.ts
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.ts
@@ -1,1 +1,0 @@
-describe('SuperChart', () => {});

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import ChartMetadata from '../../src/models/ChartMetadata';
 import ChartPlugin from '../../src/models/ChartPlugin';
 import SuperChart from '../../src/components/SuperChart';
 
 describe('SuperChart', () => {
-  function TestComponent() {
-    return <div className="test-component">test</div>;
-  }
+  const TestComponent = () => <div className="test-component">test-component</div>;
 
   class MyChartPlugin extends ChartPlugin {
     constructor() {
@@ -29,7 +27,7 @@ describe('SuperChart', () => {
           name: 'another-chart',
           thumbnail: '',
         }),
-        Chart: () =>
+        loadChart: () =>
           new Promise(resolve => {
             setTimeout(() => {
               resolve(TestComponent);
@@ -40,29 +38,28 @@ describe('SuperChart', () => {
     }
   }
 
+  new MyChartPlugin().configure({ key: 'my-chart' }).register();
+  new AnotherChartPlugin().configure({ key: 'another-chart' }).register();
+
   it('renders registered chart', done => {
-    new MyChartPlugin().configure({ key: 'my-chart' }).register();
     const wrapper = shallow(<SuperChart chartType="my-chart" />);
     setTimeout(() => {
-      expect(wrapper.find(TestComponent)).toHaveLength(1);
+      expect(wrapper.render().find('div.test-component')).toHaveLength(1);
       done();
-    }, 100);
+    }, 10);
   });
-  it('renders unregistered chart', done => {
-    const wrapper = shallow(<SuperChart chartType="4d-pie-chart" />);
+  it('renders error message for unregistered chart', done => {
+    const wrapper = mount(<SuperChart chartType="4d-pie-chart" />);
     setTimeout(() => {
-      expect(wrapper.find('div')).toHaveLength(1);
+      expect(wrapper.render().find('.alert')).toHaveLength(1);
       done();
     }, 10);
   });
   it('renders loading', done => {
-    new AnotherChartPlugin().configure({ key: 'another-chart' }).register();
     const wrapper = shallow(<SuperChart chartType="another-chart" />);
     setTimeout(() => {
-      const div = wrapper.find('div.alert');
-      console.log('innerHTML', wrapper.html());
-      expect(div).toHaveLength(1);
+      expect(wrapper.render().find('.alert')).toHaveLength(0);
       done();
-    }, 20);
+    }, 10);
   });
 });

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -42,7 +42,7 @@ describe('SuperChart', () => {
           thumbnail: '',
         }),
         loadChart: () =>
-          new Promise(resolve => {
+          new Promise<Function>(resolve => {
             setTimeout(() => {
               resolve(TestComponent);
             }, 1000);
@@ -165,8 +165,8 @@ describe('SuperChart', () => {
       const chart = new SuperChart({
         chartType: 'my-chart',
       });
-      const chartProps = new ChartProps();
-      expect(chart.processChartProps({ chartProps })).toBe(chartProps);
+      const chartProps2 = new ChartProps();
+      expect(chart.processChartProps({ chartProps: chartProps2 })).toBe(chartProps2);
     });
   });
 });

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ChartMetadata from '../../src/models/ChartMetadata';
+import ChartPlugin from '../../src/models/ChartPlugin';
+import SuperChart from '../../src/components/SuperChart';
+
+describe('SuperChart', () => {
+  function TestComponent() {
+    return <div className="test-component">test</div>;
+  }
+
+  class MyChartPlugin extends ChartPlugin {
+    constructor() {
+      super({
+        metadata: new ChartMetadata({
+          name: 'my-chart',
+          thumbnail: '',
+        }),
+        Chart: TestComponent,
+        transformProps: x => x,
+      });
+    }
+  }
+
+  class AnotherChartPlugin extends ChartPlugin {
+    constructor() {
+      super({
+        metadata: new ChartMetadata({
+          name: 'another-chart',
+          thumbnail: '',
+        }),
+        Chart: () =>
+          new Promise(resolve => {
+            setTimeout(() => {
+              resolve(TestComponent);
+            }, 1000);
+          }),
+        transformProps: x => x,
+      });
+    }
+  }
+
+  it('renders registered chart', done => {
+    new MyChartPlugin().configure({ key: 'my-chart' }).register();
+    const wrapper = shallow(<SuperChart chartType="my-chart" />);
+    setTimeout(() => {
+      expect(wrapper.find(TestComponent)).toHaveLength(1);
+      done();
+    }, 100);
+  });
+  it('renders unregistered chart', done => {
+    const wrapper = shallow(<SuperChart chartType="4d-pie-chart" />);
+    setTimeout(() => {
+      expect(wrapper.find('div')).toHaveLength(1);
+      done();
+    }, 10);
+  });
+  it('renders loading', done => {
+    new AnotherChartPlugin().configure({ key: 'another-chart' }).register();
+    const wrapper = shallow(<SuperChart chartType="another-chart" />);
+    setTimeout(() => {
+      const div = wrapper.find('div.alert');
+      console.log('innerHTML', wrapper.html());
+      expect(div).toHaveLength(1);
+      done();
+    }, 20);
+  });
+});

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import ChartMetadata from '../../src/models/ChartMetadata';
-import ChartPlugin from '../../src/models/ChartPlugin';
-import SuperChart from '../../src/components/SuperChart';
+import { ChartProps, ChartMetadata, ChartPlugin, SuperChart } from '../../src';
 
 describe('SuperChart', () => {
   const TestComponent = () => <div className="test-component">test-component</div>;
+  const chartProps = new ChartProps();
 
   class MyChartPlugin extends ChartPlugin {
     constructor() {
@@ -38,27 +37,44 @@ describe('SuperChart', () => {
     }
   }
 
-  new MyChartPlugin().configure({ key: 'my-chart' }).register();
   new AnotherChartPlugin().configure({ key: 'another-chart' }).register();
+  new MyChartPlugin().configure({ key: 'my-chart' }).register();
 
-  it('renders registered chart', done => {
-    const wrapper = shallow(<SuperChart chartType="my-chart" />);
-    setTimeout(() => {
-      expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-      done();
-    }, 10);
+  describe('registered charts', () => {
+    it('renders registered chart', done => {
+      const wrapper = shallow(<SuperChart chartType="my-chart" chartProps={chartProps} />);
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        done();
+      }, 10);
+    });
+    it('renders loading while waiting for Chart code to load', done => {
+      const wrapper = shallow(<SuperChart chartType="another-chart" />);
+      setTimeout(() => {
+        expect(wrapper.render().find('.alert')).toHaveLength(0);
+        done();
+      }, 10);
+    });
+    it('renders if chartProps is not specified', done => {
+      const wrapper = shallow(<SuperChart chartType="my-chart" />);
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        done();
+      }, 10);
+    });
+    it('does not render if chartProps is null', done => {
+      const wrapper = shallow(<SuperChart chartType="my-chart" chartProps={null} />);
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(0);
+        done();
+      }, 10);
+    });
   });
+
   it('renders error message for unregistered chart', done => {
-    const wrapper = mount(<SuperChart chartType="4d-pie-chart" />);
+    const wrapper = mount(<SuperChart chartType="4d-pie-chart" chartProps={chartProps} />);
     setTimeout(() => {
       expect(wrapper.render().find('.alert')).toHaveLength(1);
-      done();
-    }, 10);
-  });
-  it('renders loading', done => {
-    const wrapper = shallow(<SuperChart chartType="another-chart" />);
-    setTimeout(() => {
-      expect(wrapper.render().find('.alert')).toHaveLength(0);
       done();
     }, 10);
   });

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -62,28 +62,28 @@ describe('SuperChart', () => {
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
         done();
-      }, 5);
+      }, 0);
     });
     it('renders registered chart with default export', done => {
       const wrapper = shallow(<SuperChart chartType="second-chart" />);
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
         done();
-      }, 5);
+      }, 0);
     });
     it('adds id to container if specified', done => {
       const wrapper = shallow(<SuperChart chartType="my-chart" id="the-chart" />);
       setTimeout(() => {
         expect(wrapper.render().attr('id')).toEqual('the-chart');
         done();
-      }, 5);
+      }, 0);
     });
     it('adds class to container if specified', done => {
       const wrapper = shallow(<SuperChart chartType="my-chart" className="the-chart" />);
       setTimeout(() => {
         expect(wrapper.hasClass('the-chart')).toBeTruthy();
         done();
-      }, 5);
+      }, 0);
     });
     it('uses overrideTransformProps when specified', done => {
       const wrapper = shallow(
@@ -97,7 +97,7 @@ describe('SuperChart', () => {
             .text(),
         ).toEqual('hulk');
         done();
-      }, 5);
+      }, 0);
     });
     it('uses preTransformProps when specified', done => {
       const wrapper = shallow(
@@ -111,7 +111,7 @@ describe('SuperChart', () => {
             .text(),
         ).toEqual('hulk');
         done();
-      }, 5);
+      }, 0);
     });
     it('uses postTransformProps when specified', done => {
       const wrapper = shallow(
@@ -125,28 +125,28 @@ describe('SuperChart', () => {
             .text(),
         ).toEqual('hulk');
         done();
-      }, 5);
+      }, 0);
     });
     it('renders if chartProps is not specified', done => {
       const wrapper = shallow(<SuperChart chartType="my-chart" />);
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
         done();
-      }, 5);
+      }, 0);
     });
     it('does not render anything while waiting for Chart code to load', done => {
       const wrapper = shallow(<SuperChart chartType="slow-chart" />);
       setTimeout(() => {
         expect(wrapper.render().children()).toHaveLength(0);
         done();
-      }, 5);
+      }, 0);
     });
     it('does not render if chartProps is null', done => {
       const wrapper = shallow(<SuperChart chartType="my-chart" chartProps={null} />);
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(0);
         done();
-      }, 5);
+      }, 0);
     });
   });
 
@@ -156,7 +156,7 @@ describe('SuperChart', () => {
       setTimeout(() => {
         expect(wrapper.render().find('.alert')).toHaveLength(1);
         done();
-      }, 5);
+      }, 0);
     });
   });
 

--- a/packages/superset-ui-chart/test/models/ChartMetadata.test.ts
+++ b/packages/superset-ui-chart/test/models/ChartMetadata.test.ts
@@ -1,4 +1,4 @@
-import { ChartMetadata } from '../../src/models/ChartMetadata';
+import ChartMetadata from '../../src/models/ChartMetadata';
 
 describe('ChartMetadata', () => {
   it('exists', () => {

--- a/packages/superset-ui-chart/test/models/ChartProps.test.ts
+++ b/packages/superset-ui-chart/test/models/ChartProps.test.ts
@@ -1,4 +1,4 @@
-import { ChartProps } from '../../src/models/ChartProps';
+import ChartProps from '../../src/models/ChartProps';
 
 const RAW_FORM_DATA = {
   some_field: 1,


### PR DESCRIPTION
🏆 Enhancements

- Migrate `SuperChart` from `incubator-superset`, convert to TypeScript and add 100% unit tests.
- Add default values for `ChartProps`

🏠 Internal

- Change to `export default` for some modules.