### PR TITLE
Published version v0.8.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.7.2"
+  "version": "0.8.0"
 }

--- a/packages/generator-superset/package.json
+++ b/packages/generator-superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/generator-superset",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Scaffolder for Superset",
   "bugs": {
     "url": "https://github.com/apache-superset/superset-ui/issues"

--- a/packages/superset-ui-chart/package.json
+++ b/packages/superset-ui-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/chart",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "SuperChart and related modules",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/core": "^0.7.0",
+    "@superset-ui/core": "^0.8.0",
     "@types/react": "^16.7.17",
     "@types/react-loadable": "^5.4.2",
     "prop-types": "^15.6.2",
@@ -34,7 +34,7 @@
     "reselect": "^4.0.0"
   },
   "devDependencies": {
-    "@superset-ui/connection": "^0.7.0",
+    "@superset-ui/connection": "^0.8.0",
     "@types/fetch-mock": "^6.0.4",
     "fetch-mock": "^7.2.5",
     "node-fetch": "^2.2.0",

--- a/packages/superset-ui-color/package.json
+++ b/packages/superset-ui-color/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/color",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Superset UI color",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/core": "^0.7.0",
+    "@superset-ui/core": "^0.8.0",
     "@types/d3-scale": "^2.0.2",
     "d3-scale": "^2.1.2"
   }

--- a/packages/superset-ui-connection/package.json
+++ b/packages/superset-ui-connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/connection",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Superset UI connection",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "whatwg-fetch": "^2.0.4",
-    "json-bigint": "^0.3.0"
+    "json-bigint": "^0.3.0",
+    "whatwg-fetch": "^2.0.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Superset UI core",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/superset-ui-demo/package.json
+++ b/packages/superset-ui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/demo",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Storybook for Superset UI ✨",
   "private": true,
   "main": "index.js",
@@ -33,7 +33,7 @@
     "@storybook/addon-knobs": "^4.0.2",
     "@storybook/addon-options": "^4.0.3",
     "@storybook/react": "^4.0.2",
-    "@superset-ui/color": "^0.7.0",
+    "@superset-ui/color": "^0.8.0",
     "babel-loader": "^8.0.4",
     "git-directory-deploy": "^1.5.1",
     "react": "^16.6.0",

--- a/packages/superset-ui-number-format/package.json
+++ b/packages/superset-ui-number-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/number-format",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Superset UI number format",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/core": "^0.7.0",
+    "@superset-ui/core": "^0.8.0",
     "d3-format": "^1.3.2"
   }
 }

--- a/packages/superset-ui-time-format/package.json
+++ b/packages/superset-ui-time-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/time-format",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Superset UI time-format",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/core": "^0.7.0",
+    "@superset-ui/core": "^0.8.0",
     "d3-time": "^1.0.10",
     "d3-time-format": "^2.1.3"
   }

--- a/packages/superset-ui-translation/package.json
+++ b/packages/superset-ui-translation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/translation",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Superset UI translation",
   "sideEffects": false,
   "main": "lib/index.js",


### PR DESCRIPTION
🏠 Internal

Automatically generated during publish process.

to: @conglei @williaster @kristw
cc: @john-bodley