### PR TITLE
Jest/TS config adjustments (allow for debugging tests in WebStorm)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "husky": "^1.1.2",
     "lerna": "^3.2.1",
     "lint-staged": "^8.0.4",
+    "ts-jest": "^23.10.5",
     "yarn": "^1.9.4"
   },
   "engines": {
@@ -60,6 +61,13 @@
       "prettier",
       "typescript"
     ],
+    "typescript": {
+      "include": [
+        "./packages/**/src/**/*",
+        "./packages/**/types/**/*",
+        "./packages/**/test/**/*"
+      ]
+    },
     "jest": {
       "testPathIgnorePatterns": [
         "<rootDir>/packages/generator-superset"
@@ -74,7 +82,11 @@
           ],
           "testEnvironment": "node"
         }
-      ]
+      ],
+      "transform": {
+        "^.+\\.tsx?$": "ts-jest",
+        "^.+\\.jsx?$": "babel-jest"
+      }
     }
   },
   "workspaces": [


### PR DESCRIPTION
🏆 Enhancements 🏠 Internal

These changes are necessary (AFAIK) for setting up a Jest configuration in WebStorm that allows for setting breakpoints while running tests. Tests still work the same from the command line.

Such a config looks like this for one test file:

![image](https://user-images.githubusercontent.com/1847604/51067965-2e8cc580-15cc-11e9-9e63-c425a9a24735.png)

...and for all tests:

![image](https://user-images.githubusercontent.com/1847604/51067973-419f9580-15cc-11e9-82a0-6d45635ce0e6.png)

to: @conglei @kristw @williaster 