### PR TITLE
Include jed TS declaration with translation module

### DIFF
--- a/packages/superset-ui-translation/package.json
+++ b/packages/superset-ui-translation/package.json
@@ -7,7 +7,8 @@
   "module": "esm/index.js",
   "files": [
     "esm",
-    "lib"
+    "lib",
+    "types"
   ],
   "repository": {
     "type": "git",

--- a/packages/superset-ui-translation/src/index.ts
+++ b/packages/superset-ui-translation/src/index.ts
@@ -1,2 +1,4 @@
+import '../types/external.d';
+
 export { configure, t, tn } from './TranslatorSingleton';
 export { TranslatorConfig, LanguagePack } from './Translator';


### PR DESCRIPTION
🏆 Enhancements

- Include and link TypeScript declaration for package `jed` with `@superset-ui/translation` distribution. 

**Rejected alternatives**
- Have every package that uses `@superset-ui/translation` and TypeScript write a Jed declaration. -- impractical.
- Create a complete declaration file for `jed` and publish to `@types/jed`. -- too much work for the use case at the moment. 