### PR TITLE
Add script to copy assets to output folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "build": "yarn run build:cjs && yarn run build:esm && yarn run type:dts",
+    "build": "yarn run build:cjs && yarn run build:esm && yarn run type:dts && yarn run build:assets",
     "build:cjs": "NODE_ENV=production beemo babel --extensions=\".js,.jsx,.ts,.tsx\" ./src --out-dir lib/ --minify --workspaces=\"@superset-ui/!(demo|generator-superset)\"",
     "build:esm": "NODE_ENV=production beemo babel --extensions=\".js,.jsx,.ts,.tsx\" ./src --out-dir esm/ --esm --minify --workspaces=\"@superset-ui/!(demo|generator-superset)\"",
+    "build:assets": "node ./scripts/buildAssets.js",
     "type": "NODE_ENV=production beemo typescript --workspaces=\"@superset-ui/!(demo|generator-superset)\" --noEmit",
     "type:dts": "NODE_ENV=production beemo typescript --workspaces=\"@superset-ui/!(demo|generator-superset)\" --emitDeclarationOnly",
     "lint": "beemo create-config prettier && beemo eslint \"./packages/*/{src,test,storybook}/**/*.{js,jsx,ts,tsx}\"",
@@ -38,6 +39,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@data-ui/build-config": "^0.0.37",
+    "fast-glob": "^2.2.6",
+    "fs-extra": "^7.0.1",
     "husky": "^1.1.2",
     "lerna": "^3.2.1",
     "lint-staged": "^8.0.4",

--- a/scripts/buildAssets.js
+++ b/scripts/buildAssets.js
@@ -1,0 +1,23 @@
+/* eslint-disable import/no-extraneous-dependencies, no-console */
+const fg = require('fast-glob');
+const fs = require('fs-extra');
+
+const packages = fg.sync(['packages/*'], {
+  onlyDirectories: true,
+});
+
+packages.forEach(pkg => {
+  const assets = fg.sync([`${pkg}/src/**/*.{png,gif,jpg,css,geojson}`]);
+  assets.forEach(filePath => {
+    const newPaths = ['lib', 'esm'].map(dir => filePath.replace(`${pkg}/src`, `${pkg}/${dir}`));
+    newPaths.forEach(p => {
+      fs.copy(filePath, p, err => {
+        if (err) {
+          console.error(err);
+        }
+        console.log(`Copy ${filePath}`);
+        console.log(`=> to ${p}`);
+      });
+    });
+  });
+});


### PR DESCRIPTION
🏠 Internal

- Add script to copy assets (`css`, `images`, `json`) to `esm` and `lib` folders