### PR TITLE
Make svg ignore pointer events in getTextDimension

### DIFF
--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -41,6 +41,7 @@ export default function getTextDimension(
   const svg = document.createElementNS(SVG_NS, 'svg');
   svg.style.position = 'absolute'; // so it won't disrupt page layout
   svg.style.opacity = '0'; // and not visible
+  svg.style.pointerEvents = 'none'; // and not capturing mouse events
   svg.appendChild(textNode);
   container.appendChild(svg);
 


### PR DESCRIPTION
🐛 Bug Fix

- Make svg ignore pointer events in getTextDimension