### PR TITLE
Make id optional props for reactify

### DIFF
--- a/packages/superset-ui-chart/src/components/reactify.tsx
+++ b/packages/superset-ui-chart/src/components/reactify.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 // new (reactify(myRender))({ id: 5 }); // error: id has to be string & number
 
 export type ReactifyProps = {
-  id: string;
+  id?: string;
   className?: string;
 };
 


### PR DESCRIPTION
🐛 Bug Fix
`id` should have been optional. This leads to unnecessary error message in Superset console.
