### PR TITLE
Update changelog and pin beemo version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @superset-ui : Change Log
 
+## v0.9.6
+
+### 🛠️ Internal
+
+* Update `@superset-ui/chart` dependency.
+
+## v0.9.5
+
+### 🛠️ Internal
+
+* Remove unnecessary export types and remove warning when using `esm` output in target application.
+
 ## v0.9.4
 
 ### 🐞 Bug fixes

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@data-ui/build-config": "^0.0.40",
-    "@beemo/core": "0.27.0",
-    "@beemo/cli": "0.27.0",
     "fast-glob": "^2.2.6",
     "fs-extra": "^7.0.1",
     "husky": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@data-ui/build-config": "^0.0.40",
+    "@beemo/core": "0.27.0",
+    "@beemo/cli": "0.27.0",
     "fast-glob": "^2.2.6",
     "fs-extra": "^7.0.1",
     "husky": "^1.1.2",


### PR DESCRIPTION
📜 Documentation

- Update `CHANGELOG`

🐛 Bug Fix

- Build fails because of `beemo` updates. I pin older version in case it will fix this.
