### PR TITLE
Feat: Set default color scheme for the color registries

### DIFF
--- a/packages/superset-ui-color/src/CategoricalSchemeRegistrySingleton.ts
+++ b/packages/superset-ui-color/src/CategoricalSchemeRegistrySingleton.ts
@@ -1,8 +1,15 @@
 import { makeSingleton } from '@superset-ui/core';
 import CategoricalScheme from './CategoricalScheme';
 import ColorSchemeRegistry from './ColorSchemeRegistry';
+import schemes from './colorSchemes/categorical/d3';
 
-class CategoricalSchemeRegistry extends ColorSchemeRegistry<CategoricalScheme> {}
+class CategoricalSchemeRegistry extends ColorSchemeRegistry<CategoricalScheme> {
+  constructor() {
+    super();
+
+    this.registerValue('SUPERSET_DEFAULT', schemes[0]);
+  }
+}
 
 const getInstance = makeSingleton(CategoricalSchemeRegistry);
 

--- a/packages/superset-ui-color/src/SequentialSchemeRegistrySingleton.ts
+++ b/packages/superset-ui-color/src/SequentialSchemeRegistrySingleton.ts
@@ -1,8 +1,15 @@
 import { makeSingleton } from '@superset-ui/core';
 import ColorSchemeRegistry from './ColorSchemeRegistry';
 import SequentialScheme from './SequentialScheme';
+import schemes from './colorSchemes/sequential/d3';
 
-class SequentialSchemeRegistry extends ColorSchemeRegistry<SequentialScheme> {}
+class SequentialSchemeRegistry extends ColorSchemeRegistry<SequentialScheme> {
+  constructor() {
+    super();
+
+    this.registerValue('SUPERSET_DEFAULT', schemes[0]);
+  }
+}
 
 const getInstance = makeSingleton(SequentialSchemeRegistry);
 

--- a/packages/superset-ui-color/src/colorSchemes/sequential/d3.ts
+++ b/packages/superset-ui-color/src/colorSchemes/sequential/d3.ts
@@ -4,6 +4,23 @@ import SequentialScheme from '../../SequentialScheme';
 
 const schemes = [
   {
+    id: 'schemeRdBu',
+    label: 'red/blue',
+    isDiverging: true,
+    colors: [
+      '#67001f',
+      '#b2182b',
+      '#d6604d',
+      '#f4a582',
+      '#fddbc7',
+      '#d1e5f0',
+      '#92c5de',
+      '#4393c3',
+      '#2166ac',
+      '#053061',
+    ],
+  },
+  {
     id: 'schemeBrBG',
     label: 'brown/green',
     isDiverging: true,
@@ -69,23 +86,6 @@ const schemes = [
       '#e08214',
       '#b35806',
       '#7f3b08',
-    ],
-  },
-  {
-    id: 'schemeRdBu',
-    label: 'red/blue',
-    isDiverging: true,
-    colors: [
-      '#67001f',
-      '#b2182b',
-      '#d6604d',
-      '#f4a582',
-      '#fddbc7',
-      '#d1e5f0',
-      '#92c5de',
-      '#4393c3',
-      '#2166ac',
-      '#053061',
     ],
   },
   {

--- a/packages/superset-ui-color/test/CategoricalSchemeRegistrySingleton.test.ts
+++ b/packages/superset-ui-color/test/CategoricalSchemeRegistrySingleton.test.ts
@@ -1,0 +1,7 @@
+import { CategoricalScheme, getCategoricalSchemeRegistry } from '../src';
+
+describe('CategoricalSchemeRegistry', () => {
+  it('has default value out-of-the-box', () => {
+    expect(getCategoricalSchemeRegistry().get()).toBeInstanceOf(CategoricalScheme);
+  });
+});

--- a/packages/superset-ui-color/test/SequentialSchemeRegistrySingleton.test.ts
+++ b/packages/superset-ui-color/test/SequentialSchemeRegistrySingleton.test.ts
@@ -1,0 +1,7 @@
+import { SequentialScheme, getSequentialSchemeRegistry } from '../src';
+
+describe('SequentialSchemeRegistry', () => {
+  it('has default value out-of-the-box', () => {
+    expect(getSequentialSchemeRegistry().get()).toBeInstanceOf(SequentialScheme);
+  });
+});


### PR DESCRIPTION
🏆 Enhancements

- At the moment, using `@superset-ui/color` has some friction because developers always need to add color schemes to it before using. Otherwise, it will crash. This PR registers one color scheme to each of the color (`Sequential`, `Categorical`) registries so the registries will always have at least one scheme to use and work out-of-the-box. 