### PR TITLE
chore: enforce check on PR title to be conventional commit

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
🏠 Internal

By default, the semantic pull request bot passes if either (1) PR title is conventional commit or (2) at least one commit message is conventional commit.

This PR will enforces that PR title must always be a valid message because this will be used when squash merge.

https://github.com/probot/semantic-pull-requests