### PR TITLE
feat: add support for conditional requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,12 @@
       "typescript"
     ],
     "jest": {
+      "globals": {
+        "caches": true
+      },
+      "setupFiles": [
+        "<rootDir>/test/setupTests.ts"
+      ],
       "testPathIgnorePatterns": [
         "<rootDir>/packages/generator-superset"
       ],

--- a/packages/superset-ui-connection/README.md
+++ b/packages/superset-ui-connection/README.md
@@ -23,6 +23,7 @@ a high-level it supports:
 - supports `GET` and `POST` requests (no `PUT` or `DELETE`)
 - timeouts
 - query aborts through the `AbortController` API
+- conditional `GET` requests using `If-None-Match` and `ETag` headers
 
 #### Example usage
 

--- a/packages/superset-ui-connection/src/callApi/callApi.ts
+++ b/packages/superset-ui-connection/src/callApi/callApi.ts
@@ -2,6 +2,7 @@
 import 'whatwg-fetch';
 import { CallApi } from '../types';
 import { CACHE_KEY, NOT_MODIFIED, OK } from '../constants';
+import invariant from 'invariant';
 
 const CACHE_AVAILABLE = 'caches' in self;
 
@@ -39,9 +40,8 @@ export default function callApi({
             // if we have a cached response, send its ETag in the
             // `If-None-Match` header in a conditional request
             const etag = cachedResponse.headers.get('Etag');
-            if (etag) {
-              request.headers = { ...request.headers, 'If-None-Match': etag };
-            }
+            invariant(etag, 'Cannot be null');
+            request.headers = { ...request.headers, 'If-None-Match': etag };
           }
 
           return fetch(url, request);

--- a/packages/superset-ui-connection/src/callApi/callApi.ts
+++ b/packages/superset-ui-connection/src/callApi/callApi.ts
@@ -2,7 +2,6 @@
 import 'whatwg-fetch';
 import { CallApi } from '../types';
 import { CACHE_KEY, NOT_MODIFIED, OK } from '../constants';
-import invariant from 'invariant';
 
 const CACHE_AVAILABLE = 'caches' in self;
 
@@ -39,8 +38,7 @@ export default function callApi({
           if (cachedResponse) {
             // if we have a cached response, send its ETag in the
             // `If-None-Match` header in a conditional request
-            const etag = cachedResponse.headers.get('Etag');
-            invariant(etag, 'Cannot be null');
+            const etag = <string>cachedResponse.headers.get('Etag');
             request.headers = { ...request.headers, 'If-None-Match': etag };
           }
 

--- a/packages/superset-ui-connection/src/callApi/callApi.ts
+++ b/packages/superset-ui-connection/src/callApi/callApi.ts
@@ -1,9 +1,7 @@
 /* eslint compat/compat: 'off' */
 import 'whatwg-fetch';
 import { CallApi } from '../types';
-import { CACHE_KEY, NOT_MODIFIED, OK } from '../constants';
-
-const CACHE_AVAILABLE = 'caches' in self;
+import { CACHE_AVAILABLE, CACHE_KEY, HTTP_STATUS_NOT_MODIFIED, HTTP_STATUS_OK } from '../constants';
 
 // This function fetches an API response and returns the corresponding json
 export default function callApi({
@@ -45,14 +43,14 @@ export default function callApi({
           return fetch(url, request);
         })
         .then(response => {
-          if (response.status === NOT_MODIFIED) {
+          if (response.status === HTTP_STATUS_NOT_MODIFIED) {
             return supersetCache.match(url).then(cachedResponse => {
               if (cachedResponse) {
                 return cachedResponse.clone();
               }
               throw new Error('Received 304 but no content is cached!');
             });
-          } else if (response.status === OK && response.headers.get('Etag')) {
+          } else if (response.status === HTTP_STATUS_OK && response.headers.get('Etag')) {
             supersetCache.delete(url);
             supersetCache.put(url, response.clone());
           }

--- a/packages/superset-ui-connection/src/callApi/callApi.ts
+++ b/packages/superset-ui-connection/src/callApi/callApi.ts
@@ -1,9 +1,9 @@
+/* eslint compat/compat: 'off' */
 import 'whatwg-fetch';
 import { CallApi } from '../types';
+import { CACHE_KEY, NOT_MODIFIED, OK } from '../constants';
 
-const cacheAvailable = 'caches' in self;
-const NOT_MODIFIED = 304;
-const OK = 200;
+const CACHE_AVAILABLE = 'caches' in self;
 
 // This function fetches an API response and returns the corresponding json
 export default function callApi({
@@ -30,8 +30,8 @@ export default function callApi({
     signal,
   };
 
-  if (method === 'GET' && cacheAvailable) {
-    return caches.open('superset').then(supersetCache =>
+  if (method === 'GET' && CACHE_AVAILABLE) {
+    return caches.open(CACHE_KEY).then(supersetCache =>
       supersetCache
         .match(url)
         .then(cachedResponse => {
@@ -40,12 +40,11 @@ export default function callApi({
             // `If-None-Match` header in a conditional request
             const etag = cachedResponse.headers.get('Etag');
             if (etag) {
-              request.headers = request.headers || {};
-              request.headers['If-None-Match'] = etag;
+              request.headers = { ...request.headers, 'If-None-Match': etag };
             }
           }
 
-          return fetch(url, request); // eslint-disable-line compat/compat
+          return fetch(url, request);
         })
         .then(response => {
           if (response.status === NOT_MODIFIED) {
@@ -83,5 +82,5 @@ export default function callApi({
     request.body = formData;
   }
 
-  return fetch(url, request); // eslint-disable-line compat/compat
+  return fetch(url, request);
 }

--- a/packages/superset-ui-connection/src/callApi/callApi.ts
+++ b/packages/superset-ui-connection/src/callApi/callApi.ts
@@ -38,7 +38,7 @@ export default function callApi({
           if (cachedResponse) {
             // if we have a cached response, send its ETag in the
             // `If-None-Match` header in a conditional request
-            const etag = <string>cachedResponse.headers.get('Etag');
+            const etag = cachedResponse.headers.get('Etag') as string;
             request.headers = { ...request.headers, 'If-None-Match': etag };
           }
 

--- a/packages/superset-ui-connection/src/constants.ts
+++ b/packages/superset-ui-connection/src/constants.ts
@@ -1,0 +1,6 @@
+// HTTP status codes
+export const OK = 200;
+export const NOT_MODIFIED = 304;
+
+// Namespace for Cache API
+export const CACHE_KEY = '@SUPERSET-UI/CONNECTION';

--- a/packages/superset-ui-connection/src/constants.ts
+++ b/packages/superset-ui-connection/src/constants.ts
@@ -1,6 +1,7 @@
 // HTTP status codes
-export const OK = 200;
-export const NOT_MODIFIED = 304;
+export const HTTP_STATUS_OK = 200;
+export const HTTP_STATUS_NOT_MODIFIED = 304;
 
 // Namespace for Cache API
+export const CACHE_AVAILABLE = 'caches' in self;
 export const CACHE_KEY = '@SUPERSET-UI/CONNECTION';

--- a/packages/superset-ui-connection/test/callApi/callApi.test.ts
+++ b/packages/superset-ui-connection/test/callApi/callApi.test.ts
@@ -1,7 +1,7 @@
 /* eslint promise/no-callback-in-promise: 'off' */
 import fetchMock from 'fetch-mock';
 import callApi from '../../src/callApi/callApi';
-import { CACHE_KEY } from '../../src/constants';
+import * as constants from '../../src/constants';
 
 import { LOGIN_GLOB } from '../fixtures/constants';
 import throwIfCalled from '../utils/throwIfCalled';
@@ -305,7 +305,7 @@ describe('callApi()', () => {
       const calls = fetchMock.calls(mockCacheUrl);
       expect(calls).toHaveLength(1);
 
-      return caches.open(CACHE_KEY).then(supersetCache =>
+      return caches.open(constants.CACHE_KEY).then(supersetCache =>
         supersetCache.match(mockCacheUrl).then(cachedResponse => {
           expect(cachedResponse).toBeDefined();
 
@@ -313,6 +313,29 @@ describe('callApi()', () => {
         }),
       );
     }));
+
+  it('works when the Cache API is disabled', () => {
+    Object.defineProperty(constants, 'CACHE_AVAILABLE', { value: false });
+
+    return callApi({ url: mockCacheUrl, method: 'GET' }).then(firstResponse => {
+      const calls = fetchMock.calls(mockCacheUrl);
+      expect(calls).toHaveLength(1);
+      expect(firstResponse.body).toEqual('BODY');
+
+      return callApi({ url: mockCacheUrl, method: 'GET' }).then(secondResponse => {
+        const fetchParams = calls[1][1];
+        expect(calls).toHaveLength(2);
+
+        // second call should not have If-None-Match header
+        expect(fetchParams.headers).toBeUndefined();
+        expect(secondResponse.body).toEqual('BODY');
+
+        Object.defineProperty(constants, 'CACHE_AVAILABLE', { value: true });
+
+        return Promise.resolve();
+      });
+    });
+  });
 
   it('sends known ETags in the If-None-Match header', () =>
     // first call sets the cache

--- a/packages/superset-ui-connection/test/callApi/callApi.test.ts
+++ b/packages/superset-ui-connection/test/callApi/callApi.test.ts
@@ -1,6 +1,7 @@
 /* eslint promise/no-callback-in-promise: 'off' */
 import fetchMock from 'fetch-mock';
 import callApi from '../../src/callApi/callApi';
+import { CACHE_KEY } from '../../src/constants';
 
 import { LOGIN_GLOB } from '../fixtures/constants';
 import throwIfCalled from '../utils/throwIfCalled';
@@ -17,16 +18,23 @@ describe('callApi()', () => {
   const mockPostUrl = '/mock/post/url';
   const mockPutUrl = '/mock/put/url';
   const mockPatchUrl = '/mock/patch/url';
+  const mockCacheUrl = '/mock/cache/url';
 
   const mockGetPayload = { get: 'payload' };
   const mockPostPayload = { post: 'payload' };
   const mockPutPayload = { post: 'payload' };
   const mockPatchPayload = { post: 'payload' };
+  const mockCachePayload = {
+    status: 200,
+    body: 'BODY',
+    headers: { Etag: 'etag' },
+  };
 
   fetchMock.get(mockGetUrl, mockGetPayload);
   fetchMock.post(mockPostUrl, mockPostPayload);
   fetchMock.put(mockPutUrl, mockPutPayload);
   fetchMock.patch(mockPatchUrl, mockPatchPayload);
+  fetchMock.get(mockCacheUrl, mockCachePayload);
 
   afterEach(fetchMock.reset);
 
@@ -289,6 +297,69 @@ describe('callApi()', () => {
 
         return Promise.resolve();
       });
+    });
+  });
+
+  it('caches requests with ETags', () =>
+    callApi({ url: mockCacheUrl, method: 'GET' }).then(() => {
+      const calls = fetchMock.calls(mockCacheUrl);
+      expect(calls).toHaveLength(1);
+
+      return caches.open(CACHE_KEY).then(supersetCache =>
+        supersetCache.match(mockCacheUrl).then(cachedResponse => {
+          expect(cachedResponse).toBeDefined();
+
+          return Promise.resolve();
+        }),
+      );
+    }));
+
+  it('sends known ETags in the If-None-Match header', () =>
+    // first call sets the cache
+    callApi({ url: mockCacheUrl, method: 'GET' }).then(() => {
+      const calls = fetchMock.calls(mockCacheUrl);
+      expect(calls).toHaveLength(1);
+
+      // second call sends the Etag in the If-None-Match header
+      return callApi({ url: mockCacheUrl, method: 'GET' }).then(() => {
+        const fetchParams = calls[1][1];
+        const headers = { 'If-None-Match': 'etag' };
+        expect(calls).toHaveLength(2);
+        expect(fetchParams.headers).toEqual(expect.objectContaining(headers));
+
+        return Promise.resolve();
+      });
+    }));
+
+  it('reuses cached responses on 304 status', () =>
+    // first call sets the cache
+    callApi({ url: mockCacheUrl, method: 'GET' }).then(() => {
+      const calls = fetchMock.calls(mockCacheUrl);
+      expect(calls).toHaveLength(1);
+
+      // second call reuses the cached payload on a 304
+      const mockCachedPayload = { status: 304 };
+      fetchMock.get(mockCacheUrl, mockCachedPayload, { overwriteRoutes: true });
+
+      return callApi({ url: mockCacheUrl, method: 'GET' }).then(response => {
+        expect(calls).toHaveLength(2);
+        expect(response.body).toEqual('BODY');
+
+        return Promise.resolve();
+      });
+    }));
+
+  it('throws error when cache fails on 304', () => {
+    // this should never happen, since a 304 is only returned if we have
+    // the cached response and sent the If-None-Match header
+    const mockUncachedUrl = '/mock/uncached/url';
+    const mockCachedPayload = { status: 304 };
+    fetchMock.get(mockUncachedUrl, mockCachedPayload);
+
+    return callApi({ url: mockUncachedUrl, method: 'GET' }).catch(error => {
+      const calls = fetchMock.calls(mockUncachedUrl);
+      expect(calls).toHaveLength(1);
+      expect(error.message).toEqual('Received 304 but no content is cached!');
     });
   });
 

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,0 +1,28 @@
+const caches = {};
+
+class Cache {
+  cache: object;
+  constructor(key: string) {
+    caches[key] = caches[key] || {};
+    this.cache = caches[key];
+  }
+  match(url: string): Promise<Response | null> {
+    return new Promise((resolve, reject) => resolve(this.cache[url]));
+  }
+  delete(url: string) {
+    delete this.cache[url];
+  }
+  put(url: string, response: Response) {
+    this.cache[url] = response;
+  }
+};
+
+class Caches {
+  open(key: string): Promise<Cache> {
+    return new Promise((resolve, reject) => {
+      resolve(new Cache(key));
+    });
+  }
+};
+
+global.caches = new Caches();

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -6,18 +6,20 @@ class Cache {
     caches[key] = caches[key] || {};
     this.cache = caches[key];
   }
-  match(url: string): Promise<Response | null> {
+  match(url: string): Promise<Response | undefined> {
     return new Promise((resolve, reject) => resolve(this.cache[url]));
   }
-  delete(url: string) {
+  delete(url: string): Promise<boolean> {
     delete this.cache[url];
+    return new Promise((resolve, reject) => resolve(true));
   }
-  put(url: string, response: Response) {
+  put(url: string, response: Response): Promise<void> {
     this.cache[url] = response;
+    return Promise.resolve();
   }
 };
 
-class Caches {
+class CacheStorage {
   open(key: string): Promise<Cache> {
     return new Promise((resolve, reject) => {
       resolve(new Cache(key));
@@ -25,4 +27,4 @@ class Caches {
   }
 };
 
-global.caches = new Caches();
+global.caches = new CacheStorage();


### PR DESCRIPTION
🏆 Enhancements

This PR adds support for conditional `GET` requests, since they're not supported by the Fetch API. This is how it works:

1. If a `GET` request is successful (status `200 OK`) and it has an `ETag` header, a copy of the response is stored using the [Cache API](https://developers.google.com/web/fundamentals/instant-and-offline/web-storage/cache-api).
2. The next time a request for the same URL is made, the cache is checked.
3. If the cache has a cached request, its `ETag` is retrieved.
4. The client does a request with the header `If-None-Matches` with the stored `ETag`.
5. If the server returns a status `304 Not Modified`, the cached response is used instead.
6. Otherwise, if the response is a `200 OK` the previous cache is deleted and the new response is stored.

This will be used with https://github.com/apache/incubator-superset/pull/7032 to allow for conditional requests in Superset.

I started writing unit tests, but the Cache API is not supported neither in Jest (https://github.com/facebook/jest/issues/7365) nor in jsdom (https://github.com/jsdom/jsdom/issues/2422). I did full end-to-end tests with Superset, verifying that resources are properly cached and retrieved.