### PR TITLE
chore(chart): remove faux @superset-ui/core TS declaration

### DIFF
--- a/packages/superset-ui-chart/src/clients/ChartClient.ts
+++ b/packages/superset-ui-chart/src/clients/ChartClient.ts
@@ -74,12 +74,14 @@ export default class ChartClient {
       : Promise.reject(new Error('At least one of sliceId or formData must be specified'));
   }
 
-  loadQueryData(formData: ChartFormData, options?: Partial<RequestConfig>): Promise<object> {
+  async loadQueryData(formData: ChartFormData, options?: Partial<RequestConfig>): Promise<object> {
     const { viz_type: visType } = formData;
+    const metaDataRegistry = getChartMetadataRegistry();
+    const buildQueryRegistry = getChartBuildQueryRegistry();
 
-    if (getChartMetadataRegistry().has(visType)) {
-      const { useLegacyApi } = getChartMetadataRegistry().get(visType);
-      const buildQuery = useLegacyApi ? () => formData : getChartBuildQueryRegistry().get(visType);
+    if (metaDataRegistry.has(visType)) {
+      const { useLegacyApi } = metaDataRegistry.get(visType)!;
+      const buildQuery = (await buildQueryRegistry.get(visType)) || (() => formData);
 
       return this.client
         .post({

--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -4,6 +4,8 @@ import getChartComponentRegistry from '../registries/ChartComponentRegistrySingl
 import getChartTransformPropsRegistry from '../registries/ChartTransformPropsRegistrySingleton';
 import ChartProps from '../models/ChartProps';
 import createLoadableRenderer, { LoadableRenderer } from './createLoadableRenderer';
+import { ChartType } from '../models/ChartPlugin';
+import { PreTransformProps, TransformProps, PostTransformProps } from '../types/Query';
 
 const IDENTITY = (x: any) => x;
 
@@ -21,26 +23,21 @@ const defaultProps = {
 };
 /* eslint-enable sort-keys */
 
-type TransformFunction<Input = PlainProps, Output = PlainProps> = (x: Input) => Output;
 type HandlerFunction = (...args: any[]) => void;
 
 interface LoadingProps {
   error: any;
 }
 
-interface PlainProps {
-  [key: string]: any;
-}
-
 interface LoadedModules {
-  Chart: React.Component | { default: React.Component };
-  transformProps: TransformFunction | { default: TransformFunction };
+  Chart: ChartType;
+  transformProps: TransformProps;
 }
 
 interface RenderProps {
   chartProps: ChartProps;
-  preTransformProps?: TransformFunction<ChartProps>;
-  postTransformProps?: TransformFunction;
+  preTransformProps?: PreTransformProps;
+  postTransformProps?: PostTransformProps;
 }
 
 const BLANK_CHART_PROPS = new ChartProps();
@@ -50,15 +47,11 @@ export interface SuperChartProps {
   className?: string;
   chartProps?: ChartProps | null;
   chartType: string;
-  preTransformProps?: TransformFunction<ChartProps>;
-  overrideTransformProps?: TransformFunction;
-  postTransformProps?: TransformFunction;
+  preTransformProps?: PreTransformProps;
+  overrideTransformProps?: TransformProps;
+  postTransformProps?: PostTransformProps;
   onRenderSuccess?: HandlerFunction;
   onRenderFailure?: HandlerFunction;
-}
-
-function getModule<T>(value: any): T {
-  return (value.default ? value.default : value) as T;
 }
 
 export default class SuperChart extends React.PureComponent<SuperChartProps, {}> {
@@ -125,19 +118,18 @@ export default class SuperChart extends React.PureComponent<SuperChartProps, {}>
 
   processChartProps: (input: {
     chartProps: ChartProps;
-    preTransformProps?: TransformFunction<ChartProps>;
-    transformProps?: TransformFunction;
-    postTransformProps?: TransformFunction;
+    preTransformProps?: PreTransformProps;
+    transformProps?: TransformProps;
+    postTransformProps?: PostTransformProps;
   }) => any;
 
   createLoadableRenderer: (input: {
     chartType: string;
-    overrideTransformProps?: TransformFunction;
+    overrideTransformProps?: TransformProps;
   }) => LoadableRenderer<RenderProps, LoadedModules> | (() => null);
 
   renderChart(loaded: LoadedModules, props: RenderProps) {
-    const Chart = getModule<typeof React.Component>(loaded.Chart);
-    const transformProps = getModule<TransformFunction>(loaded.transformProps);
+    const { Chart, transformProps } = loaded;
     const { chartProps, preTransformProps, postTransformProps } = props;
 
     return (

--- a/packages/superset-ui-chart/src/models/ChartMetadata.ts
+++ b/packages/superset-ui-chart/src/models/ChartMetadata.ts
@@ -2,6 +2,17 @@ interface LookupTable {
   [key: string]: boolean;
 }
 
+export interface ChartMetaDataConfig {
+  name: string;
+  canBeAnnotationTypes?: string[];
+  credits?: string[];
+  description?: string;
+  show?: boolean;
+  supportedAnnotationTypes?: string[];
+  thumbnail: string;
+  useLegacyApi?: boolean;
+}
+
 export default class ChartMetadata {
   name: string;
   canBeAnnotationTypes?: string[];
@@ -13,16 +24,7 @@ export default class ChartMetadata {
   thumbnail: string;
   useLegacyApi: boolean;
 
-  constructor(config: {
-    name: string;
-    canBeAnnotationTypes?: string[];
-    credits?: string[];
-    description?: string;
-    show?: boolean;
-    supportedAnnotationTypes?: string[];
-    thumbnail: string;
-    useLegacyApi?: boolean;
-  }) {
+  constructor(config: ChartMetaDataConfig) {
     const {
       name,
       canBeAnnotationTypes = [],

--- a/packages/superset-ui-chart/src/models/ChartMetadata.ts
+++ b/packages/superset-ui-chart/src/models/ChartMetadata.ts
@@ -2,7 +2,7 @@ interface LookupTable {
   [key: string]: boolean;
 }
 
-export interface ChartMetaDataConfig {
+export interface ChartMetadataConfig {
   name: string;
   canBeAnnotationTypes?: string[];
   credits?: string[];
@@ -24,7 +24,7 @@ export default class ChartMetadata {
   thumbnail: string;
   useLegacyApi: boolean;
 
-  constructor(config: ChartMetaDataConfig) {
+  constructor(config: ChartMetadataConfig) {
     const {
       name,
       canBeAnnotationTypes = [],

--- a/packages/superset-ui-chart/src/models/ChartPlugin.ts
+++ b/packages/superset-ui-chart/src/models/ChartPlugin.ts
@@ -33,22 +33,18 @@ interface ChartPluginConfig<T extends ChartFormData> {
 
 /**
  * Loaders of the form `() => import('foo')` may return esmodules
- * which require the value to be extracted as module.default
+ * which require the value to be extracted as `module.default`
  * */
 function sanitizeLoader<T>(
   loader: PromiseOrValueLoader<ValueOrModuleWithValue<T>>,
 ): PromiseOrValueLoader<T> {
-  if (loader) {
-    return () => {
-      const loaded = loader();
+  return () => {
+    const loaded = loader();
 
-      return loaded instanceof Promise
-        ? (loaded.then(module => ('default' in module && module.default) || module) as Promise<T>)
-        : (loaded as T);
-    };
-  }
-
-  return loader;
+    return loaded instanceof Promise
+      ? (loaded.then(module => ('default' in module && module.default) || module) as Promise<T>)
+      : (loaded as T);
+  };
 }
 
 export default class ChartPlugin<T extends ChartFormData = ChartFormData> extends Plugin {

--- a/packages/superset-ui-chart/src/registries/ChartBuildQueryRegistrySingleton.ts
+++ b/packages/superset-ui-chart/src/registries/ChartBuildQueryRegistrySingleton.ts
@@ -1,6 +1,10 @@
 import { Registry, makeSingleton, OverwritePolicy } from '@superset-ui/core';
+import { QueryContext } from '../types/Query';
 
-class ChartBuildQueryRegistry extends Registry {
+// Ideally this would be <T extends ChartFormData>
+type BuildQuery = (formData: any) => QueryContext;
+
+class ChartBuildQueryRegistry extends Registry<BuildQuery> {
   constructor() {
     super({ name: 'ChartBuildQuery', overwritePolicy: OverwritePolicy.WARN });
   }

--- a/packages/superset-ui-chart/src/registries/ChartComponentRegistrySingleton.ts
+++ b/packages/superset-ui-chart/src/registries/ChartComponentRegistrySingleton.ts
@@ -1,6 +1,7 @@
 import { Registry, makeSingleton, OverwritePolicy } from '@superset-ui/core';
+import { ChartType } from '../models/ChartPlugin';
 
-class ChartComponentRegistry extends Registry {
+class ChartComponentRegistry extends Registry<ChartType> {
   constructor() {
     super({ name: 'ChartComponent', overwritePolicy: OverwritePolicy.WARN });
   }

--- a/packages/superset-ui-chart/src/registries/ChartMetadataRegistrySingleton.ts
+++ b/packages/superset-ui-chart/src/registries/ChartMetadataRegistrySingleton.ts
@@ -1,6 +1,7 @@
 import { Registry, makeSingleton, OverwritePolicy } from '@superset-ui/core';
+import { ChartMetaDataConfig } from '../models/ChartMetadata';
 
-class ChartMetadataRegistry extends Registry {
+class ChartMetadataRegistry extends Registry<ChartMetaDataConfig, ChartMetaDataConfig> {
   constructor() {
     super({ name: 'ChartMetadata', overwritePolicy: OverwritePolicy.WARN });
   }

--- a/packages/superset-ui-chart/src/registries/ChartMetadataRegistrySingleton.ts
+++ b/packages/superset-ui-chart/src/registries/ChartMetadataRegistrySingleton.ts
@@ -1,7 +1,7 @@
 import { Registry, makeSingleton, OverwritePolicy } from '@superset-ui/core';
-import { ChartMetadataConfig } from '../models/ChartMetadata';
+import ChartMetadata from '../models/ChartMetadata';
 
-class ChartMetadataRegistry extends Registry<ChartMetadataConfig, ChartMetadataConfig> {
+class ChartMetadataRegistry extends Registry<ChartMetadata, ChartMetadata> {
   constructor() {
     super({ name: 'ChartMetadata', overwritePolicy: OverwritePolicy.WARN });
   }

--- a/packages/superset-ui-chart/src/registries/ChartMetadataRegistrySingleton.ts
+++ b/packages/superset-ui-chart/src/registries/ChartMetadataRegistrySingleton.ts
@@ -1,7 +1,7 @@
 import { Registry, makeSingleton, OverwritePolicy } from '@superset-ui/core';
-import { ChartMetaDataConfig } from '../models/ChartMetadata';
+import { ChartMetadataConfig } from '../models/ChartMetadata';
 
-class ChartMetadataRegistry extends Registry<ChartMetaDataConfig, ChartMetaDataConfig> {
+class ChartMetadataRegistry extends Registry<ChartMetadataConfig, ChartMetadataConfig> {
   constructor() {
     super({ name: 'ChartMetadata', overwritePolicy: OverwritePolicy.WARN });
   }

--- a/packages/superset-ui-chart/src/registries/ChartTransformPropsRegistrySingleton.ts
+++ b/packages/superset-ui-chart/src/registries/ChartTransformPropsRegistrySingleton.ts
@@ -1,6 +1,7 @@
 import { Registry, makeSingleton, OverwritePolicy } from '@superset-ui/core';
+import { TransformProps } from '../types/Query';
 
-class ChartTransformPropsRegistry extends Registry {
+class ChartTransformPropsRegistry extends Registry<TransformProps> {
   constructor() {
     super({ name: 'ChartTransformProps', overwritePolicy: OverwritePolicy.WARN });
   }

--- a/packages/superset-ui-chart/src/types/Query.ts
+++ b/packages/superset-ui-chart/src/types/Query.ts
@@ -1,8 +1,8 @@
 /* eslint camelcase: 0 */
-import ChartProps from '../models/ChartProps';
 import { DatasourceType } from './Datasource';
 import { ChartFormData } from './ChartFormData';
 import { Metric } from './Metric';
+import ChartProps from '../models/ChartProps';
 
 export interface QueryObject {
   granularity: string;
@@ -32,10 +32,14 @@ export interface QueryContext {
   queries: QueryObject[];
 }
 
-export type BuildQueryFunction<T extends ChartFormData> = (formData: T) => QueryContext;
-
-export type TransformPropsFunction = (
-  chartProps: ChartProps,
-) => {
+export interface PlainProps {
   [key: string]: any;
-};
+}
+
+type TransformFunction<Input = PlainProps, Output = PlainProps> = (x: Input) => Output;
+
+export type PreTransformProps = TransformFunction<ChartProps>;
+export type TransformProps = TransformFunction;
+export type PostTransformProps = TransformFunction;
+
+export type BuildQueryFunction<T extends ChartFormData> = (formData: T) => QueryContext;

--- a/packages/superset-ui-chart/test/clients/ChartClient.test.ts
+++ b/packages/superset-ui-chart/test/clients/ChartClient.test.ts
@@ -97,7 +97,7 @@ describe('ChartClient', () => {
 
   describe('.loadQueryData(formData, options)', () => {
     it('returns a promise of query data for known chart type', () => {
-      getChartMetadataRegistry().registerValue('word_cloud', { name: 'Word Cloud' });
+      getChartMetadataRegistry().registerValue('word_cloud', { name: 'Word Cloud', thumbnail: '' });
 
       getChartBuildQueryRegistry().registerValue('word_cloud', (formData: ChartFormData) =>
         buildQueryContext(formData),
@@ -131,6 +131,7 @@ describe('ChartClient', () => {
       // note legacy charts do not register a buildQuery function in the registry
       getChartMetadataRegistry().registerValue('word_cloud_legacy', {
         name: 'Legacy Word Cloud',
+        thumbnail: '.png',
         useLegacyApi: true,
       });
 
@@ -233,7 +234,7 @@ describe('ChartClient', () => {
         amet: true,
       });
 
-      getChartMetadataRegistry().registerValue('line', { name: 'Line' });
+      getChartMetadataRegistry().registerValue('line', { name: 'Line', thumbnail: '.gif' });
 
       getChartBuildQueryRegistry().registerValue('line', (formData: ChartFormData) =>
         buildQueryContext(formData),

--- a/packages/superset-ui-chart/test/clients/ChartClient.test.ts
+++ b/packages/superset-ui-chart/test/clients/ChartClient.test.ts
@@ -7,6 +7,7 @@ import {
   buildQueryContext,
   ChartFormData,
   getChartMetadataRegistry,
+  ChartMetadata,
 } from '../../src';
 
 import { SliceIdAndOrFormData } from '../../src/clients/ChartClient';
@@ -97,7 +98,10 @@ describe('ChartClient', () => {
 
   describe('.loadQueryData(formData, options)', () => {
     it('returns a promise of query data for known chart type', () => {
-      getChartMetadataRegistry().registerValue('word_cloud', { name: 'Word Cloud', thumbnail: '' });
+      getChartMetadataRegistry().registerValue(
+        'word_cloud',
+        new ChartMetadata({ name: 'Word Cloud', thumbnail: '' }),
+      );
 
       getChartBuildQueryRegistry().registerValue('word_cloud', (formData: ChartFormData) =>
         buildQueryContext(formData),
@@ -129,11 +133,14 @@ describe('ChartClient', () => {
 
     it('fetches data from the legacy API if ChartMetadata has useLegacyApi=true,', () => {
       // note legacy charts do not register a buildQuery function in the registry
-      getChartMetadataRegistry().registerValue('word_cloud_legacy', {
-        name: 'Legacy Word Cloud',
-        thumbnail: '.png',
-        useLegacyApi: true,
-      });
+      getChartMetadataRegistry().registerValue(
+        'word_cloud_legacy',
+        new ChartMetadata({
+          name: 'Legacy Word Cloud',
+          thumbnail: '.png',
+          useLegacyApi: true,
+        }),
+      );
 
       fetchMock.post('glob:*/api/v1/query/', () =>
         Promise.reject(Error('Unexpected all to v1 API')),
@@ -234,7 +241,10 @@ describe('ChartClient', () => {
         amet: true,
       });
 
-      getChartMetadataRegistry().registerValue('line', { name: 'Line', thumbnail: '.gif' });
+      getChartMetadataRegistry().registerValue(
+        'line',
+        new ChartMetadata({ name: 'Line', thumbnail: '.gif' }),
+      );
 
       getChartBuildQueryRegistry().registerValue('line', (formData: ChartFormData) =>
         buildQueryContext(formData),

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -30,7 +30,8 @@ describe('SuperChart', () => {
         }),
         // this mirrors `() => import(module)` syntax
         loadChart: () => Promise.resolve({ default: TestComponent }),
-        transformProps: x => x,
+        // promise without .default
+        loadTransformProps: () => Promise.resolve((x: any) => x),
       });
     }
   }

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -28,7 +28,8 @@ describe('SuperChart', () => {
           name: 'second-chart',
           thumbnail: '',
         }),
-        loadChart: () => Promise.resolve(TestComponent),
+        // this mirrors `() => import(module)` syntax
+        loadChart: () => Promise.resolve({ default: TestComponent }),
         transformProps: x => x,
       });
     }

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -28,7 +28,7 @@ describe('SuperChart', () => {
           name: 'second-chart',
           thumbnail: '',
         }),
-        loadChart: () => Promise.resolve({ default: TestComponent }),
+        loadChart: () => Promise.resolve(TestComponent),
         transformProps: x => x,
       });
     }
@@ -42,7 +42,7 @@ describe('SuperChart', () => {
           thumbnail: '',
         }),
         loadChart: () =>
-          new Promise<Function>(resolve => {
+          new Promise(resolve => {
             setTimeout(() => {
               resolve(TestComponent);
             }, 1000);

--- a/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
+++ b/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   ChartPlugin,
   ChartMetadata,
@@ -5,10 +7,12 @@ import {
   DatasourceType,
   ChartProps,
   BuildQueryFunction,
-  TransformPropsFunction,
+  TransformProps,
 } from '../../src';
 
 describe('ChartPlugin', () => {
+  const FakeChart = () => <span>test</span>;
+
   const metadata = new ChartMetadata({
     name: 'test-chart',
     thumbnail: '',
@@ -19,7 +23,6 @@ describe('ChartPlugin', () => {
   });
 
   describe('new ChartPlugin()', () => {
-    const FakeChart = () => 'test';
     const buildQuery = (_: ChartFormData) => ({
       datasource: { id: 1, type: DatasourceType.Table },
       queries: [{ granularity: 'day' }],
@@ -33,7 +36,7 @@ describe('ChartPlugin', () => {
     it('creates a new plugin', () => {
       const plugin = new ChartPlugin({
         metadata,
-        Chart() {},
+        Chart: FakeChart,
       });
       expect(plugin).toBeInstanceOf(ChartPlugin);
     });
@@ -102,7 +105,7 @@ describe('ChartPlugin', () => {
           metadata,
           Chart: FakeChart,
         });
-        const fn = plugin.loadTransformProps() as TransformPropsFunction;
+        const fn = plugin.loadTransformProps() as TransformProps;
         expect(fn(PROPS)).toBe(PROPS);
       });
       it('uses loadTransformProps field if specified', () => {
@@ -111,7 +114,7 @@ describe('ChartPlugin', () => {
           Chart: FakeChart,
           loadTransformProps: () => () => ({ field2: 2 }),
         });
-        const fn = plugin.loadTransformProps() as TransformPropsFunction;
+        const fn = plugin.loadTransformProps() as TransformProps;
         expect(fn(PROPS)).toEqual({ field2: 2 });
       });
       it('uses transformProps field if specified', () => {
@@ -120,7 +123,7 @@ describe('ChartPlugin', () => {
           Chart: FakeChart,
           transformProps: () => ({ field2: 2 }),
         });
-        const fn = plugin.loadTransformProps() as TransformPropsFunction;
+        const fn = plugin.loadTransformProps() as TransformProps;
         expect(fn(PROPS)).toEqual({ field2: 2 });
       });
     });
@@ -129,7 +132,7 @@ describe('ChartPlugin', () => {
   describe('.register()', () => {
     const plugin = new ChartPlugin({
       metadata,
-      Chart() {},
+      Chart: FakeChart,
     });
     it('throws an error if key is not provided', () => {
       expect(() => plugin.register()).toThrowError(Error);

--- a/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
+++ b/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
@@ -81,7 +81,8 @@ describe('ChartPlugin', () => {
           metadata,
           loadChart,
         });
-        expect(plugin.loadChart).toBe(loadChart);
+        // the loader is sanitized, so assert on the value
+        expect(plugin.loadChart()).toBe(loadChart());
       });
       it('uses Chart field if specified', () => {
         const plugin = new ChartPlugin({

--- a/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
+++ b/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
@@ -18,15 +18,16 @@ describe('ChartPlugin', () => {
     thumbnail: '',
   });
 
+  const buildQuery = (_: ChartFormData) => ({
+    datasource: { id: 1, type: DatasourceType.Table },
+    queries: [{ granularity: 'day' }],
+  });
+
   it('exists', () => {
     expect(ChartPlugin).toBeDefined();
   });
 
   describe('new ChartPlugin()', () => {
-    const buildQuery = (_: ChartFormData) => ({
-      datasource: { id: 1, type: DatasourceType.Table },
-      queries: [{ granularity: 'day' }],
-    });
     const FORM_DATA = {
       datasource: '1__table',
       granularity: 'day',
@@ -133,6 +134,7 @@ describe('ChartPlugin', () => {
     const plugin = new ChartPlugin({
       metadata,
       Chart: FakeChart,
+      buildQuery,
     });
     it('throws an error if key is not provided', () => {
       expect(() => plugin.register()).toThrowError(Error);

--- a/packages/superset-ui-chart/types/external.d.ts
+++ b/packages/superset-ui-chart/types/external.d.ts
@@ -1,1 +1,0 @@
-declare module '@superset-ui/core';

--- a/packages/superset-ui-core/src/models/Registry.ts
+++ b/packages/superset-ui-core/src/models/Registry.ts
@@ -99,7 +99,7 @@ export default class Registry<V, W extends V | Promise<V> = V | Promise<V>> {
     const item = this.items[key];
     if (item !== undefined) {
       if ('loader' in item) {
-        return item.loader();
+        return item.loader && item.loader();
       }
 
       return item.value;

--- a/packages/superset-ui-demo/storybook/stories/superset-ui-chart/ChartDataProviderStories.tsx
+++ b/packages/superset-ui-demo/storybook/stories/superset-ui-chart/ChartDataProviderStories.tsx
@@ -9,7 +9,6 @@ import LegacySunburstPlugin from '@superset-ui/legacy-plugin-chart-sunburst';
 import LegacyWordCloudPlugin from '@superset-ui/legacy-plugin-chart-word-cloud';
 import WordCloudPlugin from '@superset-ui/plugin-chart-word-cloud';
 
-import { DataProviderProvidedProps } from '@superset-ui/chart/src';
 import {
   bigNumberFormData,
   sankeyFormData,
@@ -59,7 +58,7 @@ export default [
           <VerifyCORS host={host}>
             {() => (
               <ChartDataProvider client={SupersetClient} formData={JSON.parse(formData)}>
-                {({ loading, payload, error }: DataProviderProvidedProps) => {
+                {({ loading, payload, error }) => {
                   if (loading) return <div>Loading!</div>;
 
                   if (error) return renderError(error);


### PR DESCRIPTION
🏠 Internal

This PR removes the faux `@superset-ui/core` TS declaration in `@superset-ui/chart` (introduced before `core` was re-written in TS). All of the changes are to clean up resulting TS errors from that removal. Some notes on specifics that were done:

- Refined and consolidated some `type`s that were duplicated across files like `ChartType`, `(Pre/Post)TransformProps`, etc.. Turns out the duplication wasn't always entirely consistent though at surface level it might not be obvious.
- Added the needed generics to all of the chart plugin `registry`s
- Updated the logic for supporting `Value | { default: Value }` generally across loaders. This is now confined to `ChartPlugin` in order to simplify types elsewhere, while still supporting dynamic loading of ES modules: `() => import('foo').default`

(EDIT: The following was refactored so as not to be a breaking change)

~💔 Breaking Changes~
-  ~Removed support for `{ default: Type }` in `Registry` `loader`s, which was previously allowed due to a Chart type using `module.exports` instead of `export default`ing. This simplifies typing when using these components which I think is a win 🏆. I think worst case if this is problematic in incubator `Superset` we could update `() => import('./module.xxx')` calls to `() => import('./module.xxx').default`~

**TODO**
- [x] 💯 % coverage
- [x] fix `.default` issue .. may not be a breaking change

@kristw @conglei @xtinec 