### PR TITLE
 fix(chart): import types from package, not monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "yarn run build:cjs && yarn run build:esm && yarn run type:dts && yarn run build:assets",
-    "build:cjs": "NODE_ENV=production beemo babel --extensions=\".js,.jsx,.ts,.tsx\" ./src --out-dir lib/ --minify --workspaces=\"@superset-ui/!(demo|generator-superset)\"",
-    "build:esm": "NODE_ENV=production beemo babel --extensions=\".js,.jsx,.ts,.tsx\" ./src --out-dir esm/ --esm --minify --workspaces=\"@superset-ui/!(demo|generator-superset)\"",
+    "build:cjs": "NODE_ENV=production beemo babel --extensions=\".js,.jsx,.ts,.tsx\" ./src --out-dir lib/ --delete-dir-on-start --minify --workspaces=\"@superset-ui/!(demo|generator-superset)\"",
+    "build:esm": "NODE_ENV=production beemo babel --extensions=\".js,.jsx,.ts,.tsx\" ./src --out-dir esm/ --delete-dir-on-start --esm --minify --workspaces=\"@superset-ui/!(demo|generator-superset)\"",
     "build:assets": "node ./scripts/buildAssets.js",
     "commit": "git-cz",
     "type": "NODE_ENV=production beemo typescript --workspaces=\"@superset-ui/!(generator-superset)\" --noEmit",

--- a/packages/superset-ui-chart/src/components/ChartDataProvider.tsx
+++ b/packages/superset-ui-chart/src/components/ChartDataProvider.tsx
@@ -1,6 +1,6 @@
 /* eslint react/sort-comp: 'off' */
 import React, { ReactNode } from 'react';
-import { SupersetClientInterface, RequestConfig } from '@superset-ui/connection/lib/types';
+import { SupersetClientInterface, RequestConfig } from '@superset-ui/connection';
 
 import ChartClient, { SliceIdAndOrFormData } from '../clients/ChartClient';
 import { ChartFormData } from '../types/ChartFormData';

--- a/packages/superset-ui-chart/src/components/ChartDataProvider.tsx
+++ b/packages/superset-ui-chart/src/components/ChartDataProvider.tsx
@@ -1,6 +1,6 @@
 /* eslint react/sort-comp: 'off' */
 import React, { ReactNode } from 'react';
-import { SupersetClientInterface, RequestConfig } from '../../../superset-ui-connection/src/types';
+import { SupersetClientInterface, RequestConfig } from '@superset-ui/connection/lib/types';
 
 import ChartClient, { SliceIdAndOrFormData } from '../clients/ChartClient';
 import { ChartFormData } from '../types/ChartFormData';


### PR DESCRIPTION
🐛 Bug Fix 🏠 Internal

This PR
- fixes an import in `@superset-ui/chart` that should be from a package, not the monorepo. this caused the build to include additional directories in `0.10.5` and `0.10.6`. I confirmed that these directories are no longer generated after the fix.

- adds a flag to the `build` `npm` scripts to delete the out directory, to ensure that deleted files and directories are not included in new releases.
