### PR TITLE
fix: 🐛 Fixed type definition for chart plugin

### DIFF
--- a/packages/superset-ui-chart/src/index.ts
+++ b/packages/superset-ui-chart/src/index.ts
@@ -25,3 +25,4 @@ export * from './types/Annotation';
 export * from './types/Datasource';
 export * from './types/ChartFormData';
 export * from './types/Query';
+export * from './types/Metric';

--- a/packages/superset-ui-chart/src/models/ChartPlugin.ts
+++ b/packages/superset-ui-chart/src/models/ChartPlugin.ts
@@ -12,7 +12,7 @@ const IDENTITY = (x: any) => x;
 
 export type PromiseOrValue<T> = Promise<T> | T;
 export type PromiseOrValueLoader<T> = () => PromiseOrValue<T>;
-export type ChartType = ComponentType | FunctionComponent;
+export type ChartType = ComponentType<any> | FunctionComponent<any>;
 type ValueOrModuleWithValue<T> = T | { default: T };
 
 interface ChartPluginConfig<T extends ChartFormData> {

--- a/packages/superset-ui-chart/src/types/Query.ts
+++ b/packages/superset-ui-chart/src/types/Query.ts
@@ -38,8 +38,8 @@ export interface PlainProps {
 
 type TransformFunction<Input = PlainProps, Output = PlainProps> = (x: Input) => Output;
 
-export type PreTransformProps = TransformFunction<ChartProps>;
-export type TransformProps = TransformFunction;
+export type PreTransformProps = TransformFunction<ChartProps, ChartProps | PlainProps>;
+export type TransformProps = TransformFunction<ChartProps | PlainProps>;
 export type PostTransformProps = TransformFunction;
 
 export type BuildQueryFunction<T extends ChartFormData> = (formData: T) => QueryContext;

--- a/packages/superset-ui-chart/src/types/Query.ts
+++ b/packages/superset-ui-chart/src/types/Query.ts
@@ -38,8 +38,8 @@ export interface PlainProps {
 
 type TransformFunction<Input = PlainProps, Output = PlainProps> = (x: Input) => Output;
 
-export type PreTransformProps = TransformFunction<ChartProps, ChartProps | PlainProps>;
-export type TransformProps = TransformFunction<ChartProps | PlainProps>;
+export type PreTransformProps = TransformFunction<ChartProps, ChartProps>;
+export type TransformProps = TransformFunction<ChartProps>;
 export type PostTransformProps = TransformFunction;
 
 export type BuildQueryFunction<T extends ChartFormData> = (formData: T) => QueryContext;

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -110,8 +110,15 @@ describe('SuperChart', () => {
       }, 0);
     });
     it('uses preTransformProps when specified', done => {
+      const chartPropsWithPayload = new ChartProps({
+        payload: { character: 'hulk' },
+      });
       const wrapper = shallow(
-        <SuperChart chartType="my-chart" preTransformProps={() => ({ character: 'hulk' })} />,
+        <SuperChart
+          chartType="my-chart"
+          preTransformProps={() => chartPropsWithPayload}
+          overrideTransformProps={props => props.payload}
+        />,
       );
       setTimeout(() => {
         expect(


### PR DESCRIPTION
This PR is to fix the type definiton for `transformProps` and `LoadData`.

For `TransformProps`, the input type should be `ChartProps` instead of `PlainObject`. 

For `LoadData`, before, the `ChartType` was `ComponentType | FunctionComponent`, which means the no props allowed for the component, which is not correct. 

💔 Breaking Changes

🏆 Enhancements

Exported Metric definition. 

📜 Documentation

🐛 Bug Fix

In most of the cases, There will be no `PreTransformProps` defined. Thus, the input for `TransformProp


🏠 Internal
