### PR TITLE
feat: getter function to return color mapping

### DIFF
--- a/packages/superset-ui-color/src/CategoricalColorScale.ts
+++ b/packages/superset-ui-color/src/CategoricalColorScale.ts
@@ -57,4 +57,22 @@ export default class CategoricalColorScale extends ExtensibleFunction {
 
     return this;
   }
+
+  /**
+   * Get a mapping of data values to colors
+   * @returns an object where the key is the data value and the value is the hex color code
+   */
+  getColorMap() {
+    const colorMap: { [key: string]: string } = {};
+    const { length } = this.colors;
+    Object.keys(this.seen).forEach(value => {
+      colorMap[value] = this.colors[this.seen[value] % length];
+    });
+
+    return {
+      ...colorMap,
+      ...this.forcedColors,
+      ...this.parentForcedColors,
+    };
+  }
 }

--- a/packages/superset-ui-color/test/CategoricalColorScale.test.ts
+++ b/packages/superset-ui-color/test/CategoricalColorScale.test.ts
@@ -83,6 +83,22 @@ describe('CategoricalColorScale', () => {
       expect(scale).toBe(output);
     });
   });
+  describe('.getColorMap()', () => {
+    it('returns correct mapping and parentForcedColors and forcedColors are specified', () => {
+      const scale1 = new CategoricalColorScale(['blue', 'red', 'green']);
+      scale1.setColor('cow', 'black');
+      const scale2 = new CategoricalColorScale(['blue', 'red', 'green'], scale1.forcedColors);
+      scale2.setColor('pig', 'pink');
+      scale2.getColor('cow');
+      scale2.getColor('pig');
+      scale2.getColor('horse');
+      expect(scale2.getColorMap()).toEqual({
+        cow: 'black',
+        pig: 'pink',
+        horse: 'blue',
+      });
+    });
+  });
   describe('a CategoricalColorScale instance is also a color function itself', () => {
     it('scale(value) returns color similar to calling scale.getColor(value)', () => {
       const scale = new CategoricalColorScale(['blue', 'red', 'green']);


### PR DESCRIPTION
🏆 Enhancements

Exposed a getter function to return the color mapping between a data value and a color hex code. This is needed so we can save it as dashboard metadata for color consistency in dashboards (https://github.com/apache/incubator-superset/pull/7086).