### PR TITLE
chore: add config for request-info bot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,15 @@
+# Configuration for request-info - https://github.com/behaviorbot/request-info
+
+# *Required* Comment to reply with
+requestInfoReplyComment: >
+  We would appreciate it if you could provide us with more info about this issue/pr!
+
+# *OPTIONAL* default titles to check against for lack of descriptiveness
+# MUST BE ALL LOWERCASE
+requestInfoDefaultTitles:
+  - update readme.md
+  - updates
+
+# *OPTIONAL* Label to be added to Issues and Pull Requests with insufficient information given
+requestInfoLabelToAdd: needs-more-info
+


### PR DESCRIPTION
🏠 Internal

Enable bots that comments when PR has no title or description.