### PR TITLE
feat: callback hooks for Reactified components

### DIFF
--- a/packages/superset-ui-chart/src/components/reactify.tsx
+++ b/packages/superset-ui-chart/src/components/reactify.tsx
@@ -17,6 +17,11 @@ export type ReactifyProps = {
   className?: string;
 };
 
+// TODO: add more React lifecycle callbacks as needed
+export type LifeCycleCallbacks = {
+  willUnmount?: () => void;
+};
+
 export interface RenderFuncType<Props> {
   (container: HTMLDivElement, props: Readonly<Props & ReactifyProps>): void;
   displayName?: string;
@@ -26,6 +31,7 @@ export interface RenderFuncType<Props> {
 
 export default function reactify<Props extends object>(
   renderFn: RenderFuncType<Props>,
+  callbacks?: LifeCycleCallbacks,
 ): React.ComponentClass<Props & ReactifyProps> {
   class ReactifiedComponent extends React.Component<Props & ReactifyProps> {
     // eslint-disable-next-line react/sort-comp
@@ -46,6 +52,9 @@ export default function reactify<Props extends object>(
 
     componentWillUnmount() {
       this.container = undefined;
+      if (callbacks && callbacks.willUnmount) {
+        callbacks.willUnmount();
+      }
     }
 
     setContainerRef(ref: HTMLDivElement) {

--- a/packages/superset-ui-chart/src/components/reactify.tsx
+++ b/packages/superset-ui-chart/src/components/reactify.tsx
@@ -19,7 +19,7 @@ export type ReactifyProps = {
 
 // TODO: add more React lifecycle callbacks as needed
 export type LifeCycleCallbacks = {
-  willUnmount?: () => void;
+  componentWillUnmount?: () => void;
 };
 
 export interface RenderFuncType<Props> {
@@ -52,8 +52,8 @@ export default function reactify<Props extends object>(
 
     componentWillUnmount() {
       this.container = undefined;
-      if (callbacks && callbacks.willUnmount) {
-        callbacks.willUnmount();
+      if (callbacks && callbacks.componentWillUnmount) {
+        callbacks.componentWillUnmount();
       }
     }
 

--- a/packages/superset-ui-chart/test/components/reactify.test.tsx
+++ b/packages/superset-ui-chart/test/components/reactify.test.tsx
@@ -25,7 +25,7 @@ describe('reactify(renderFn)', () => {
   const willUnmountCb = jest.fn();
 
   const TheChart = reactify(renderFn);
-  const TheChartWithWillUnmountHook = reactify(renderFn, { willUnmount: willUnmountCb });
+  const TheChartWithWillUnmountHook = reactify(renderFn, { componentWillUnmount: willUnmountCb });
 
   class TestComponent extends React.PureComponent<{}, { content: string }, any> {
     constructor(props = {}) {

--- a/packages/superset-ui-chart/test/components/reactify.test.tsx
+++ b/packages/superset-ui-chart/test/components/reactify.test.tsx
@@ -22,7 +22,9 @@ describe('reactify(renderFn)', () => {
     content: 'ghi',
   };
 
-  const TheChart = reactify(renderFn);
+  const willUnmountCb = jest.fn();
+
+  const TheChart = reactify(renderFn, { willUnmount: willUnmountCb });
 
   class TestComponent extends React.PureComponent<{}, { content: string }, any> {
     constructor(props = {}) {
@@ -52,6 +54,7 @@ describe('reactify(renderFn)', () => {
       expect(renderFn).toHaveBeenCalledTimes(2);
       expect(wrapper.html()).toEqual('<div id="test"><b>def</b></div>');
       wrapper.unmount();
+      expect(willUnmountCb).toHaveBeenCalledTimes(1);
       done();
     }, 20);
   });

--- a/packages/superset-ui-chart/test/components/reactify.test.tsx
+++ b/packages/superset-ui-chart/test/components/reactify.test.tsx
@@ -24,7 +24,8 @@ describe('reactify(renderFn)', () => {
 
   const willUnmountCb = jest.fn();
 
-  const TheChart = reactify(renderFn, { willUnmount: willUnmountCb });
+  const TheChart = reactify(renderFn);
+  const TheChartWithWillUnmountHook = reactify(renderFn, { willUnmount: willUnmountCb });
 
   class TestComponent extends React.PureComponent<{}, { content: string }, any> {
     constructor(props = {}) {
@@ -44,6 +45,12 @@ describe('reactify(renderFn)', () => {
       return <TheChart id="test" content={content} />;
     }
   }
+  /* eslint-disable-next-line react/no-multi-comp */
+  class AnotherTestComponent extends React.PureComponent<{}, {}, any> {
+    render() {
+      return <TheChartWithWillUnmountHook id="another_test" />;
+    }
+  }
 
   it('returns a React component class', done => {
     const wrapper = mount(<TestComponent />);
@@ -54,7 +61,6 @@ describe('reactify(renderFn)', () => {
       expect(renderFn).toHaveBeenCalledTimes(2);
       expect(wrapper.html()).toEqual('<div id="test"><b>def</b></div>');
       wrapper.unmount();
-      expect(willUnmountCb).toHaveBeenCalledTimes(1);
       done();
     }, 20);
   });
@@ -94,5 +100,13 @@ describe('reactify(renderFn)', () => {
     const AnotherChart = reactify(anotherRenderFn) as any; // enables valid new AnotherChart() call
     new AnotherChart({ id: 'test' }).execute();
     expect(anotherRenderFn).not.toHaveBeenCalled();
+  });
+  it('calls willUnmount hook when it is provided', done => {
+    const wrapper = mount(<AnotherTestComponent />);
+    setTimeout(() => {
+      wrapper.unmount();
+      expect(willUnmountCb).toHaveBeenCalledTimes(1);
+      done();
+    }, 20);
   });
 });


### PR DESCRIPTION
🏆 Enhancements

Add a second argument to the exported `reactify` method to allow wrapped component to pass in callback hooks for React lifecycle methods. This PR only exposes the willUnmount hook. Other hooks can be added in the future.