### PR TITLE
fix: bump peer dependencies

### DIFF
--- a/packages/superset-ui-chart/package.json
+++ b/packages/superset-ui-chart/package.json
@@ -38,8 +38,8 @@
     "node-fetch": "^2.2.0"
   },
   "peerDependencies": {
-    "@superset-ui/connection": "^0.10.0",
-    "@superset-ui/core": "^0.10.0",
+    "@superset-ui/connection": "^0.11.0",
+    "@superset-ui/core": "^0.11.0",
     "react": "^15 || ^16"
   }
 }

--- a/packages/superset-ui-color/package.json
+++ b/packages/superset-ui-color/package.json
@@ -30,6 +30,6 @@
     "d3-scale": "^2.1.2"
   },
   "peerDependencies": {
-    "@superset-ui/core": "^0.10.0"
+    "@superset-ui/core": "^0.11.0"
   }
 }

--- a/packages/superset-ui-number-format/package.json
+++ b/packages/superset-ui-number-format/package.json
@@ -30,6 +30,6 @@
     "d3-format": "^1.3.2"
   },
   "peerDependencies": {
-    "@superset-ui/core": "^0.10.0"
+    "@superset-ui/core": "^0.11.0"
   }
 }

--- a/packages/superset-ui-time-format/package.json
+++ b/packages/superset-ui-time-format/package.json
@@ -32,6 +32,6 @@
     "d3-time-format": "^2.1.3"
   },
   "peerDependencies": {
-    "@superset-ui/core": "^0.10.0"
+    "@superset-ui/core": "^0.11.0"
   }
 }


### PR DESCRIPTION
🐛 Bug Fix

* bump `peerDependencies` version, which are not bumped automatically by `lerna`.
