### PR TITLE
Feat: improve caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,5 +109,8 @@
       "yarn run prettier --write",
       "git add"
     ]
+  },
+  "dependencies": {
+    "@types/sinon": "^7.0.11"
   }
 }

--- a/packages/superset-ui-connection/src/index.ts
+++ b/packages/superset-ui-connection/src/index.ts
@@ -1,4 +1,5 @@
 export { default as callApi } from './callApi';
 export { default as SupersetClient } from './SupersetClient';
 export { default as SupersetClientClass } from './SupersetClientClass';
+export { CACHE_KEY } from './constants';
 export * from './types';


### PR DESCRIPTION
🏆 Enhancements

This PR changes `SupersetClient` so that it can reuse cached responses using the [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache), in addition to delegating it to the browser. This allows us to pass `cache: 'no-cache'`, bypassing the browser caching and handling it ourselves.

The reason for this is that using the native browser cache we're unable to invalidate the cache from Javascript, eg, when a user saves a new chart of force refreshes a dashboard. Using the Cache API we can easily do that, clearing all cached responses that reference a chart (see https://github.com/apache/incubator-superset/pull/7319).