### PR TITLE
fix: broken build due to failing unit tests

### DIFF
--- a/packages/superset-ui-connection/test/callApi/callApi.test.ts
+++ b/packages/superset-ui-connection/test/callApi/callApi.test.ts
@@ -320,19 +320,22 @@ describe('callApi()', () => {
     return callApi({ url: mockCacheUrl, method: 'GET' }).then(firstResponse => {
       const calls = fetchMock.calls(mockCacheUrl);
       expect(calls).toHaveLength(1);
-      expect(firstResponse.body).toEqual('BODY');
 
-      return callApi({ url: mockCacheUrl, method: 'GET' }).then(secondResponse => {
-        const fetchParams = calls[1][1];
-        expect(calls).toHaveLength(2);
+      return firstResponse.text().then(text => {
+        expect(text).toEqual('BODY');
 
-        // second call should not have If-None-Match header
-        expect(fetchParams.headers).toBeUndefined();
-        expect(secondResponse.body).toEqual('BODY');
+        return callApi({ url: mockCacheUrl, method: 'GET' }).then(secondResponse => {
+          const fetchParams = calls[1][1];
+          expect(calls).toHaveLength(2);
 
-        Object.defineProperty(constants, 'CACHE_AVAILABLE', { value: true });
+          // second call should not have If-None-Match header
+          expect(fetchParams.headers).toBeUndefined();
+          expect(secondResponse.body).toEqual('BODY');
 
-        return Promise.resolve();
+          Object.defineProperty(constants, 'CACHE_AVAILABLE', { value: true });
+
+          return Promise.resolve();
+        });
       });
     });
   });

--- a/packages/superset-ui-connection/test/callApi/callApi.test.ts
+++ b/packages/superset-ui-connection/test/callApi/callApi.test.ts
@@ -353,7 +353,7 @@ describe('callApi()', () => {
 
   it('reuses cached responses on 304 status', async () => {
     // first call sets the cache
-    const firstResponse = await callApi({ url: mockCacheUrl, method: 'GET' });
+    await callApi({ url: mockCacheUrl, method: 'GET' });
     const calls = fetchMock.calls(mockCacheUrl);
     expect(calls).toHaveLength(1);
     // second call reuses the cached payload on a 304


### PR DESCRIPTION
🐛 Bug Fix

* Replace `response.body` direct access which returns stream data input with `response.text()` which converts the data stream into single string (but returns `Promise<string>`).
The main changes are 
  * `firstResponse.body` => `firstResponse.text()`
  * `secondResponse.body`=> `secondResponse.text()` 
  * `response.body` => `secondResponse.text()`.
* Also change the code to `async`/`await` for readability as there are many `Promise` nesting.