### PR TITLE
refactor: separate transform function types into a new file

### DIFF
--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -5,7 +5,8 @@ import getChartTransformPropsRegistry from '../registries/ChartTransformPropsReg
 import ChartProps from '../models/ChartProps';
 import createLoadableRenderer, { LoadableRenderer } from './createLoadableRenderer';
 import { ChartType } from '../models/ChartPlugin';
-import { PreTransformProps, TransformProps, PostTransformProps } from '../types/Query';
+import { PreTransformProps, TransformProps, PostTransformProps } from '../types/TransformFunction';
+import { HandlerFunction } from '../types/Base';
 
 const IDENTITY = (x: any) => x;
 
@@ -22,8 +23,6 @@ const defaultProps = {
   onRenderFailure() {},
 };
 /* eslint-enable sort-keys */
-
-type HandlerFunction = (...args: any[]) => void;
 
 interface LoadingProps {
   error: any;

--- a/packages/superset-ui-chart/src/index.ts
+++ b/packages/superset-ui-chart/src/index.ts
@@ -26,3 +26,4 @@ export * from './types/ChartFormData';
 export * from './types/Datasource';
 export * from './types/Metric';
 export * from './types/Query';
+export * from './types/TransformFunction';

--- a/packages/superset-ui-chart/src/models/ChartPlugin.ts
+++ b/packages/superset-ui-chart/src/models/ChartPlugin.ts
@@ -6,7 +6,7 @@ import getChartBuildQueryRegistry from '../registries/ChartBuildQueryRegistrySin
 import getChartComponentRegistry from '../registries/ChartComponentRegistrySingleton';
 import getChartTransformPropsRegistry from '../registries/ChartTransformPropsRegistrySingleton';
 import { ChartFormData } from '../types/ChartFormData';
-import { BuildQueryFunction, TransformProps } from '../types/Query';
+import { BuildQueryFunction, TransformProps } from '../types/TransformFunction';
 
 const IDENTITY = (x: any) => x;
 

--- a/packages/superset-ui-chart/src/models/ChartProps.ts
+++ b/packages/superset-ui-chart/src/models/ChartProps.ts
@@ -1,9 +1,6 @@
 import { createSelector } from 'reselect';
 import { convertKeysToCamelCase } from '@superset-ui/core';
-
-interface PlainObject {
-  [key: string]: any;
-}
+import { HandlerFunction, PlainObject } from '../types/Base';
 
 // TODO: more specific typing for these fields of ChartProps
 type AnnotationData = PlainObject;
@@ -13,7 +10,6 @@ type CamelCaseFormData = PlainObject;
 type SnakeCaseFormData = PlainObject;
 export type QueryData = PlainObject;
 type Filters = any[];
-type HandlerFunction = (...args: any[]) => void;
 type ChartPropsSelector = (c: ChartPropsConfig) => ChartProps;
 
 interface ChartPropsConfig {

--- a/packages/superset-ui-chart/src/registries/ChartTransformPropsRegistrySingleton.ts
+++ b/packages/superset-ui-chart/src/registries/ChartTransformPropsRegistrySingleton.ts
@@ -1,5 +1,5 @@
 import { Registry, makeSingleton, OverwritePolicy } from '@superset-ui/core';
-import { TransformProps } from '../types/Query';
+import { TransformProps } from '../types/TransformFunction';
 
 class ChartTransformPropsRegistry extends Registry<TransformProps> {
   constructor() {

--- a/packages/superset-ui-chart/src/types/Base.ts
+++ b/packages/superset-ui-chart/src/types/Base.ts
@@ -1,0 +1,5 @@
+export type HandlerFunction = (...args: any[]) => void;
+
+export interface PlainObject {
+  [key: string]: any;
+}

--- a/packages/superset-ui-chart/src/types/Query.ts
+++ b/packages/superset-ui-chart/src/types/Query.ts
@@ -1,8 +1,6 @@
 /* eslint camelcase: 0 */
 import { DatasourceType } from './Datasource';
-import { ChartFormData } from './ChartFormData';
 import { AdhocMetric } from './Metric';
-import ChartProps from '../models/ChartProps';
 import { BinaryOperator, SetOperator, UnaryOperator } from './Operator';
 import { TimeRange } from './Time';
 
@@ -83,15 +81,3 @@ export interface QueryContext {
   };
   queries: QueryObject[];
 }
-
-export interface PlainProps {
-  [key: string]: any;
-}
-
-type TransformFunction<Input = PlainProps, Output = PlainProps> = (x: Input) => Output;
-
-export type PreTransformProps = TransformFunction<ChartProps, ChartProps>;
-export type TransformProps = TransformFunction<ChartProps>;
-export type PostTransformProps = TransformFunction;
-
-export type BuildQueryFunction<T extends ChartFormData> = (formData: T) => QueryContext;

--- a/packages/superset-ui-chart/src/types/TransformFunction.ts
+++ b/packages/superset-ui-chart/src/types/TransformFunction.ts
@@ -1,0 +1,15 @@
+import { ChartFormData } from './ChartFormData';
+import ChartProps from '../models/ChartProps';
+import { QueryContext } from './Query';
+
+export interface PlainProps {
+  [key: string]: any;
+}
+
+type TransformFunction<Input = PlainProps, Output = PlainProps> = (x: Input) => Output;
+
+export type PreTransformProps = TransformFunction<ChartProps, ChartProps>;
+export type TransformProps = TransformFunction<ChartProps>;
+export type PostTransformProps = TransformFunction;
+
+export type BuildQueryFunction<T extends ChartFormData> = (formData: T) => QueryContext;


### PR DESCRIPTION
🏠 Internal

* Move the types of transform functions from `types/Query.ts` to `types/TransformFunction.ts`
* Extract basic types `HandlerFunction` and `PlainObject` to `types/Base.ts`