### PR TITLE
feat: add parseLength function to @superset-ui/dimension

### DIFF
--- a/packages/superset-ui-dimension/src/index.ts
+++ b/packages/superset-ui-dimension/src/index.ts
@@ -1,5 +1,6 @@
 export { default as getTextDimension } from './getTextDimension';
 export { default as computeMaxFontSize } from './computeMaxFontSize';
 export { default as mergeMargin } from './mergeMargin';
+export { default as parseLength } from './parseLength';
 
 export * from './types';

--- a/packages/superset-ui-dimension/src/parseLength.ts
+++ b/packages/superset-ui-dimension/src/parseLength.ts
@@ -1,7 +1,5 @@
 const HUNDRED_PERCENT = { isDynamic: true, multiplier: 1 } as const;
 
-const pxPattern = /px$/;
-
 export default function parseLength(
   input: string | number,
 ): { isDynamic: true; multiplier: number } | { isDynamic: false; value: number } {
@@ -9,9 +7,9 @@ export default function parseLength(
     return HUNDRED_PERCENT;
   } else if (typeof input === 'string' && input.length > 0 && input[input.length - 1] === '%') {
     // eslint-disable-next-line no-magic-numbers
-    return { isDynamic: true, multiplier: parseFloat(input.substring(0, input.length - 1)) / 100 };
+    return { isDynamic: true, multiplier: parseFloat(input) / 100 };
   }
-  const value = typeof input === 'number' ? input : parseFloat(input.replace(pxPattern, ''));
+  const value = typeof input === 'number' ? input : parseFloat(input);
 
   return { isDynamic: false, value };
 }

--- a/packages/superset-ui-dimension/src/parseLength.ts
+++ b/packages/superset-ui-dimension/src/parseLength.ts
@@ -1,0 +1,17 @@
+const HUNDRED_PERCENT = { isDynamic: true, multiplier: 1 } as const;
+
+const pxPattern = /px$/;
+
+export default function parseLength(
+  input: string | number,
+): { isDynamic: true; multiplier: number } | { isDynamic: false; value: number } {
+  if (input === 'auto' || input === '100%') {
+    return HUNDRED_PERCENT;
+  } else if (typeof input === 'string' && input.length > 0 && input[input.length - 1] === '%') {
+    // eslint-disable-next-line no-magic-numbers
+    return { isDynamic: true, multiplier: parseFloat(input.substring(0, input.length - 1)) / 100 };
+  }
+  const value = typeof input === 'number' ? input : parseFloat(input.replace(pxPattern, ''));
+
+  return { isDynamic: false, value };
+}

--- a/packages/superset-ui-dimension/test/parseLength.test.ts
+++ b/packages/superset-ui-dimension/test/parseLength.test.ts
@@ -1,0 +1,29 @@
+import parseLength from '../src/parseLength';
+
+describe('parseLength(input)', () => {
+  it('handles string "auto"', () => {
+    expect(parseLength('auto')).toEqual({ isDynamic: true, multiplier: 1 });
+  });
+
+  it('handles strings with % at the end', () => {
+    expect(parseLength('100%')).toEqual({ isDynamic: true, multiplier: 1 });
+    expect(parseLength('50%')).toEqual({ isDynamic: true, multiplier: 0.5 });
+    expect(parseLength('0%')).toEqual({ isDynamic: true, multiplier: 0 });
+  });
+
+  it('handles strings that are numbers with px at the end', () => {
+    expect(parseLength('100px')).toEqual({ isDynamic: false, value: 100 });
+    expect(parseLength('20.5px')).toEqual({ isDynamic: false, value: 20.5 });
+  });
+
+  it('handles strings that are numbers', () => {
+    expect(parseLength('100')).toEqual({ isDynamic: false, value: 100 });
+    expect(parseLength('40.5')).toEqual({ isDynamic: false, value: 40.5 });
+    expect(parseLength('20.0')).toEqual({ isDynamic: false, value: 20 });
+  });
+
+  it('handles numbers', () => {
+    expect(parseLength(100)).toEqual({ isDynamic: false, value: 100 });
+    expect(parseLength(0)).toEqual({ isDynamic: false, value: 0 });
+  });
+});


### PR DESCRIPTION
🏆 Enhancements

Add function `parseLength` to parse width or height 
* `'100%'` => `{ isDynamic: true, multiplier: 1 }`
* `'50%'` => `{ isDynamic: true, multiplier: 0.5 }`
* `100` => `{ isDynamic: false, value: 100 }`
* `'100'` => `{ isDynamic: false, value: 100 }`
* `100px` => `{ isDynamic: false, value: 100 }` 