### PR TITLE
feat: reuse svg element in getTextDimension

### DIFF
--- a/packages/superset-ui-chart-composition/src/tooltip/TooltipTable.tsx
+++ b/packages/superset-ui-chart-composition/src/tooltip/TooltipTable.tsx
@@ -29,7 +29,7 @@ export default class TooltipTable extends PureComponent<Props, {}> {
     return (
       <table className={className}>
         <tbody>
-          {data.map(({ key, keyColumn, keyStyle, valueColumn, valueStyle }, i) => (
+          {data.map(({ key, keyColumn, keyStyle, valueColumn, valueStyle }) => (
             <tr key={key}>
               <td style={keyStyle}>{keyColumn || key}</td>
               <td style={valueStyle ? { ...VALUE_CELL_STYLE, ...valueStyle } : VALUE_CELL_STYLE}>

--- a/packages/superset-ui-dimension/src/createSVGNode.ts
+++ b/packages/superset-ui-dimension/src/createSVGNode.ts
@@ -1,5 +1,34 @@
-export default function createSVGNode(container: HTMLElement): SVGSVGElement {
+import { TextStyle } from './types';
+
+export interface CreateSVGNodeInput {
+  className?: string;
+  container?: HTMLElement;
+  style?: TextStyle;
+}
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const STYLE_FIELDS: (keyof TextStyle)[] = [
+  'font',
+  'fontWeight',
+  'fontStyle',
+  'fontSize',
+  'fontFamily',
+  'letterSpacing',
+];
+
+export default function createSVGNode(input: CreateSVGNodeInput): SVGSVGElement {
+  const { className, style = {}, container = document.body } = input;
+
   const textNode = document.createElementNS(SVG_NS, 'text');
+  if (className !== undefined && className !== null) {
+    textNode.setAttribute('class', className);
+  }
+  STYLE_FIELDS.filter(
+    (field: keyof TextStyle) => style[field] !== undefined && style[field] !== null,
+  ).forEach((field: keyof TextStyle) => {
+    textNode.style[field] = `${style[field]}`;
+  });
+
   const svg = document.createElementNS(SVG_NS, 'svg');
   svg.style.position = 'absolute'; // so it won't disrupt page layout
   svg.style.opacity = '0'; // and not visible

--- a/packages/superset-ui-dimension/src/createSVGNode.ts
+++ b/packages/superset-ui-dimension/src/createSVGNode.ts
@@ -1,0 +1,11 @@
+export default function createSVGNode(container: HTMLElement): SVGSVGElement {
+  const textNode = document.createElementNS(SVG_NS, 'text');
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.style.position = 'absolute'; // so it won't disrupt page layout
+  svg.style.opacity = '0'; // and not visible
+  svg.style.pointerEvents = 'none'; // and not capturing mouse events
+  svg.appendChild(textNode);
+  container.appendChild(svg);
+
+  return svg;
+}

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -19,13 +19,27 @@ export interface GetTextDimensionInput {
 
 const DEFAULT_DIMENSION = { height: 20, width: 100 };
 
+export function createSVGNode(container: HTMLElement): SVGSVGElement {
+  const textNode = document.createElementNS(SVG_NS, 'text');
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.style.position = 'absolute'; // so it won't disrupt page layout
+  svg.style.opacity = '0'; // and not visible
+  svg.style.pointerEvents = 'none'; // and not capturing mouse events
+  svg.appendChild(textNode);
+  container.appendChild(svg);
+
+  return svg;
+}
+
 export default function getTextDimension(
   input: GetTextDimensionInput,
   defaultDimension: Dimension = DEFAULT_DIMENSION,
+  existingSVGNode?: SVGSVGElement,
 ): Dimension {
   const { text, className, style = {}, container = document.body } = input;
 
-  const textNode = document.createElementNS(SVG_NS, 'text');
+  const svg = existingSVGNode || createSVGNode(container);
+  const textNode = svg.lastElementChild as SVGSVGElement;
   textNode.textContent = text;
 
   if (className !== undefined && className !== null) {
@@ -38,15 +52,11 @@ export default function getTextDimension(
     textNode.style[field] = `${style[field]}`;
   });
 
-  const svg = document.createElementNS(SVG_NS, 'svg');
-  svg.style.position = 'absolute'; // so it won't disrupt page layout
-  svg.style.opacity = '0'; // and not visible
-  svg.style.pointerEvents = 'none'; // and not capturing mouse events
-  svg.appendChild(textNode);
-  container.appendChild(svg);
-
   const bbox = textNode.getBBox ? textNode.getBBox() : defaultDimension;
-  container.removeChild(svg);
+
+  if (!existingSVGNode) {
+    container.removeChild(svg);
+  }
 
   return {
     height: Math.ceil(bbox.height),

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -17,7 +17,7 @@ export default function getTextDimension(
 ): Dimension {
   const { text, className, style = {}, container = document.body, existingSVGNode } = input;
 
-  const svg = existingSVGNode || createSVGNode({ className, style, container });
+  const svg = existingSVGNode || createSVGNode({ className, container, style });
   const textNode = svg.lastElementChild as SVGSVGElement;
   textNode.textContent = text;
   const bbox = textNode.getBBox ? textNode.getBBox() : defaultDimension;

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -15,6 +15,23 @@ export default function getTextDimension(
   input: GetTextDimensionInput,
   defaultDimension: Dimension = DEFAULT_DIMENSION,
 ): Dimension {
+  /*
+   * Compute dimensions (height, width) of a text string.
+   *
+   * When calling this function you can specify a container and formatting
+   * attributes that will be applied to the text (class name and CSS style).
+   * An SVG element will be appended to the container, and child text element
+   * will store the text string in order to compute its dimensions based on its
+   * bounding box.
+   *
+   * Alternatively, for improved performance, it is also possible instead to
+   * pass a pre-existing SVG node, created with `createSVGNode`. This is the
+   * recommended approach if you need to compute the dimensions of a high
+   * number of text strings, since it minimizes changes to the DOM.
+   *
+   * Note that if you pass a pre-existing SVG node you need to remove it
+   * yourself when it is no longer needed.
+   */
   const { text, className, style = {}, container = document.body, existingSVGNode } = input;
 
   const svg = existingSVGNode || createSVGNode({ className, container, style });

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -1,16 +1,6 @@
 import { TextStyle, Dimension } from './types';
 import createSVGNode from './createSVGNode';
 
-const SVG_NS = 'http://www.w3.org/2000/svg';
-const STYLE_FIELDS: (keyof TextStyle)[] = [
-  'font',
-  'fontWeight',
-  'fontStyle',
-  'fontSize',
-  'fontFamily',
-  'letterSpacing',
-];
-
 export interface GetTextDimensionInput {
   className?: string;
   container?: HTMLElement;
@@ -27,20 +17,9 @@ export default function getTextDimension(
 ): Dimension {
   const { text, className, style = {}, container = document.body } = input;
 
-  const svg = existingSVGNode || createSVGNode(container);
+  const svg = existingSVGNode || createSVGNode({ className, style, container });
   const textNode = svg.lastElementChild as SVGSVGElement;
   textNode.textContent = text;
-
-  if (className !== undefined && className !== null) {
-    textNode.setAttribute('class', className);
-  }
-
-  STYLE_FIELDS.filter(
-    (field: keyof TextStyle) => style[field] !== undefined && style[field] !== null,
-  ).forEach((field: keyof TextStyle) => {
-    textNode.style[field] = `${style[field]}`;
-  });
-
   const bbox = textNode.getBBox ? textNode.getBBox() : defaultDimension;
 
   if (!existingSVGNode) {

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -6,6 +6,7 @@ export interface GetTextDimensionInput {
   container?: HTMLElement;
   style?: TextStyle;
   text: string;
+  existingSVGNode?: SVGSVGElement;
 }
 
 const DEFAULT_DIMENSION = { height: 20, width: 100 };
@@ -13,9 +14,8 @@ const DEFAULT_DIMENSION = { height: 20, width: 100 };
 export default function getTextDimension(
   input: GetTextDimensionInput,
   defaultDimension: Dimension = DEFAULT_DIMENSION,
-  existingSVGNode?: SVGSVGElement,
 ): Dimension {
-  const { text, className, style = {}, container = document.body } = input;
+  const { text, className, style = {}, container = document.body, existingSVGNode } = input;
 
   const svg = existingSVGNode || createSVGNode({ className, style, container });
   const textNode = svg.lastElementChild as SVGSVGElement;

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -1,4 +1,5 @@
 import { TextStyle, Dimension } from './types';
+import createSVGNode from './createSVGNode';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const STYLE_FIELDS: (keyof TextStyle)[] = [
@@ -18,18 +19,6 @@ export interface GetTextDimensionInput {
 }
 
 const DEFAULT_DIMENSION = { height: 20, width: 100 };
-
-export function createSVGNode(container: HTMLElement): SVGSVGElement {
-  const textNode = document.createElementNS(SVG_NS, 'text');
-  const svg = document.createElementNS(SVG_NS, 'svg');
-  svg.style.position = 'absolute'; // so it won't disrupt page layout
-  svg.style.opacity = '0'; // and not visible
-  svg.style.pointerEvents = 'none'; // and not capturing mouse events
-  svg.appendChild(textNode);
-  container.appendChild(svg);
-
-  return svg;
-}
 
 export default function getTextDimension(
   input: GetTextDimensionInput,

--- a/packages/superset-ui-dimension/src/index.ts
+++ b/packages/superset-ui-dimension/src/index.ts
@@ -1,4 +1,4 @@
-export { default as getTextDimension } from './getTextDimension';
+export { default as getTextDimension, createSVGNode } from './getTextDimension';
 export { default as computeMaxFontSize } from './computeMaxFontSize';
 export { default as mergeMargin } from './mergeMargin';
 export { default as parseLength } from './parseLength';

--- a/packages/superset-ui-dimension/src/index.ts
+++ b/packages/superset-ui-dimension/src/index.ts
@@ -1,4 +1,5 @@
-export { default as getTextDimension, createSVGNode } from './getTextDimension';
+export { default as getTextDimension } from './getTextDimension';
+export { default as createSVGNode } from './createSVGNode';
 export { default as computeMaxFontSize } from './computeMaxFontSize';
 export { default as mergeMargin } from './mergeMargin';
 export { default as parseLength } from './parseLength';

--- a/packages/superset-ui-dimension/test/getTextDimension.test.ts
+++ b/packages/superset-ui-dimension/test/getTextDimension.test.ts
@@ -1,4 +1,4 @@
-import { getTextDimension } from '../src/index';
+import { createSVGNode, getTextDimension } from '../src/index';
 import addDummyFill, { SAMPLE_TEXT } from './addDummyFill';
 
 describe('getTextDimension(input)', () => {
@@ -142,6 +142,23 @@ describe('getTextDimension(input)', () => {
         height: 20,
         width: 221, // Ceiling(200 [baseWidth] * 1.1 [letterSpacing=1.1])
       });
+    });
+    it('reuses an existing svg element if provided', () => {
+      const container = document.createElement('div');
+      const svg = createSVGNode(container);
+      const textNode = svg.lastElementChild as SVGSVGElement;
+      expect(textNode.textContent).toEqual('');
+      getTextDimension(
+        {
+          text: SAMPLE_TEXT,
+        },
+        {
+          height: 30,
+          width: 400,
+        },
+        svg,
+      );
+      expect(textNode.textContent).toEqual(SAMPLE_TEXT);
     });
   });
 });

--- a/packages/superset-ui-dimension/test/getTextDimension.test.ts
+++ b/packages/superset-ui-dimension/test/getTextDimension.test.ts
@@ -145,19 +145,13 @@ describe('getTextDimension(input)', () => {
     });
     it('reuses an existing svg element if provided', () => {
       const container = document.createElement('div');
-      const svg = createSVGNode(container);
+      const svg = createSVGNode({ input: container });
       const textNode = svg.lastElementChild as SVGSVGElement;
       expect(textNode.textContent).toEqual('');
-      getTextDimension(
-        {
-          text: SAMPLE_TEXT,
-        },
-        {
-          height: 30,
-          width: 400,
-        },
-        svg,
-      );
+      getTextDimension({
+        text: SAMPLE_TEXT,
+        existingSVGNode: svg,
+      });
       expect(textNode.textContent).toEqual(SAMPLE_TEXT);
     });
   });


### PR DESCRIPTION
🏆 Enhancements

This PR optimizes the rendering of a `FilterableTable` component in Superset (see https://github.com/apache/incubator-superset/pull/7690) by allowing an SVG element to be reused when calling `getTextDimension`.