### PR TITLE
feat: add error boundary and responsiveness to SuperChart

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pretest": "yarn run lint",
     "prettier": "beemo prettier \"./packages/*/{src,test,storybook}/**/*.{js,jsx,ts,tsx,json,md}\"",
     "release": "yarn run prepare-release && lerna publish && yarn run postrelease",
-    "test": "yarn run type && yarn run jest",
+    "test": "yarn run jest",
     "test:watch": "yarn run lint:fix && beemo create-config jest --react && jest --watch"
   },
   "repository": "https://github.com/apache-superset/superset-ui.git",

--- a/packages/superset-ui-chart/__mocks__/resize-observer-polyfill.js
+++ b/packages/superset-ui-chart/__mocks__/resize-observer-polyfill.js
@@ -1,0 +1,22 @@
+const allCallbacks = [];
+
+export default function ResizeObserver(callback) {
+  if (callback) {
+    allCallbacks.push(callback);
+  }
+
+  return {
+    disconnect: () => {
+      allCallbacks.splice(allCallbacks.findIndex(callback), 1);
+    },
+    observe: () => {},
+  };
+}
+
+const DEFAULT_OUTPUT = [{ contentRect: { height: 300, width: 300 } }];
+
+export function triggerResizeObserver(output = DEFAULT_OUTPUT) {
+  allCallbacks.forEach(fn => {
+    fn(output);
+  });
+}

--- a/packages/superset-ui-chart/package.json
+++ b/packages/superset-ui-chart/package.json
@@ -42,6 +42,7 @@
   "peerDependencies": {
     "@superset-ui/connection": "^0.11.0",
     "@superset-ui/core": "^0.11.0",
+    "@superset-ui/dimension": "^0.11.7",
     "react": "^15 || ^16"
   }
 }

--- a/packages/superset-ui-chart/package.json
+++ b/packages/superset-ui-chart/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@superset-ui/connection": "^0.11.0",
     "@superset-ui/core": "^0.11.0",
-    "@superset-ui/dimension": "^0.11.7",
+    "@superset-ui/dimension": "^0.11.10",
     "react": "^15 || ^16"
   }
 }

--- a/packages/superset-ui-chart/package.json
+++ b/packages/superset-ui-chart/package.json
@@ -28,7 +28,9 @@
   "dependencies": {
     "@types/react": "^16.7.17",
     "@types/react-loadable": "^5.4.2",
+    "@vx/responsive": "^0.0.189",
     "prop-types": "^15.6.2",
+    "react-error-boundary": "^1.2.5",
     "react-loadable": "^5.5.0",
     "reselect": "^4.0.0"
   },

--- a/packages/superset-ui-chart/src/components/FallbackComponent.tsx
+++ b/packages/superset-ui-chart/src/components/FallbackComponent.tsx
@@ -3,20 +3,32 @@ import { FallbackProps } from 'react-error-boundary';
 
 export type Props = FallbackProps;
 
+const CONTAINER_STYLE = {
+  backgroundColor: '#000',
+  color: '#fff',
+  padding: 32,
+};
+
 export default function FallbackComponent({ componentStack, error }: Props) {
   return (
-    <div>
+    <div style={CONTAINER_STYLE}>
       <p>
-        <strong>Oops! An error occured!</strong>
-      </p>
-      <p>Here’s what we know…</p>
-      <p>
-        <strong>Error:</strong> <span>{error ? error.toString() : 'Unknown Error'}</span>
+        <div>
+          <b>Oops! An error occured!</b>
+        </div>
+        <span>
+          <code>{error ? error.toString() : 'Unknown Error'}</code>
+        </span>
       </p>
       {componentStack && (
-        <p>
-          <strong>Stacktrace:</strong> <span>{componentStack}</span>
-        </p>
+        <div>
+          <b>Stack Trace:</b>
+          <code>
+            {componentStack.split('\n').map(row => (
+              <div key={row}>{row}</div>
+            ))}
+          </code>
+        </div>
       )}
     </div>
   );

--- a/packages/superset-ui-chart/src/components/FallbackComponent.tsx
+++ b/packages/superset-ui-chart/src/components/FallbackComponent.tsx
@@ -6,6 +6,7 @@ export type Props = FallbackProps;
 const CONTAINER_STYLE = {
   backgroundColor: '#000',
   color: '#fff',
+  overflow: 'auto',
   padding: 32,
 };
 
@@ -16,9 +17,7 @@ export default function FallbackComponent({ componentStack, error }: Props) {
         <div>
           <b>Oops! An error occured!</b>
         </div>
-        <span>
-          <code>{error ? error.toString() : 'Unknown Error'}</code>
-        </span>
+        <code>{error ? error.toString() : 'Unknown Error'}</code>
       </p>
       {componentStack && (
         <div>

--- a/packages/superset-ui-chart/src/components/FallbackComponent.tsx
+++ b/packages/superset-ui-chart/src/components/FallbackComponent.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { FallbackProps } from 'react-error-boundary';
+
+export type Props = FallbackProps;
+
+export default function FallbackComponent({ componentStack, error }: Props) {
+  return (
+    <div>
+      <p>
+        <strong>Oops! An error occured!</strong>
+      </p>
+      <p>Here’s what we know…</p>
+      <p>
+        <strong>Error:</strong> <span>{error ? error.toString() : 'Unknown Error'}</span>
+      </p>
+      {componentStack && (
+        <p>
+          <strong>Stacktrace:</strong> <span>{componentStack}</span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/superset-ui-chart/src/components/FallbackComponent.tsx
+++ b/packages/superset-ui-chart/src/components/FallbackComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { FallbackProps } from 'react-error-boundary';
+import { FallbackPropsWithDimension } from './SuperChartShell';
 
-export type Props = FallbackProps;
+export type Props = FallbackPropsWithDimension;
 
 const CONTAINER_STYLE = {
   backgroundColor: '#000',
@@ -10,9 +10,9 @@ const CONTAINER_STYLE = {
   padding: 32,
 };
 
-export default function FallbackComponent({ componentStack, error }: Props) {
+export default function FallbackComponent({ componentStack, error, height, width }: Props) {
   return (
-    <div style={CONTAINER_STYLE}>
+    <div style={{ ...CONTAINER_STYLE, height, width }}>
       <p>
         <div>
           <b>Oops! An error occured!</b>

--- a/packages/superset-ui-chart/src/components/FallbackComponent.tsx
+++ b/packages/superset-ui-chart/src/components/FallbackComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FallbackPropsWithDimension } from './SuperChartShell';
+import { FallbackPropsWithDimension } from './SuperChart';
 
 export type Props = FallbackPropsWithDimension;
 
@@ -13,17 +13,17 @@ const CONTAINER_STYLE = {
 export default function FallbackComponent({ componentStack, error, height, width }: Props) {
   return (
     <div style={{ ...CONTAINER_STYLE, height, width }}>
-      <p>
+      <div>
         <div>
           <b>Oops! An error occured!</b>
         </div>
         <code>{error ? error.toString() : 'Unknown Error'}</code>
-      </p>
+      </div>
       {componentStack && (
         <div>
           <b>Stack Trace:</b>
           <code>
-            {componentStack.split('\n').map(row => (
+            {componentStack.split('\n').map((row: string) => (
               <div key={row}>{row}</div>
             ))}
           </code>

--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import ErrorBoundary, { ErrorBoundaryProps, FallbackProps } from 'react-error-boundary';
+import { parseLength } from '@superset-ui/dimension';
+import { ParentSize } from '@vx/responsive';
+import SuperChartCore, { Props as SuperChartCoreProps } from './SuperChartCore';
+import DefaultFallbackComponent from './FallbackComponent';
+import ChartProps, { ChartPropsConfig } from '../models/ChartProps';
+
+const defaultProps = {
+  FallbackComponent: DefaultFallbackComponent,
+  // eslint-disable-next-line no-magic-numbers
+  height: 400 as string | number,
+  width: '100%' as string | number,
+};
+
+export type FallbackPropsWithDimension = FallbackProps & { width?: number; height?: number };
+
+export type Props = Omit<SuperChartCoreProps, 'chartProps'> &
+  Omit<ChartPropsConfig, 'width' | 'height'> & {
+    disableErrorBoundary?: boolean;
+    debounceTime?: number;
+    FallbackComponent?: React.ComponentType<FallbackPropsWithDimension>;
+    onErrorBoundary?: ErrorBoundaryProps['onError'];
+    height?: number | string;
+    width?: number | string;
+  };
+
+type PropsWithDefault = Props & Readonly<typeof defaultProps>;
+
+export default class SuperChart extends React.PureComponent<Props, {}> {
+  static defaultProps = defaultProps;
+
+  private createChartProps = ChartProps.createSelector();
+
+  renderChart(width: number, height: number) {
+    const {
+      id,
+      className,
+      chartType,
+      preTransformProps,
+      overrideTransformProps,
+      postTransformProps,
+      onRenderSuccess,
+      onRenderFailure,
+      disableErrorBoundary,
+      FallbackComponent,
+      onErrorBoundary,
+      ...rest
+    } = this.props as PropsWithDefault;
+
+    const chart = (
+      <SuperChartCore
+        id={id}
+        className={className}
+        chartType={chartType}
+        chartProps={this.createChartProps({
+          ...rest,
+          height,
+          width,
+        })}
+        preTransformProps={preTransformProps}
+        overrideTransformProps={overrideTransformProps}
+        postTransformProps={postTransformProps}
+        onRenderSuccess={onRenderSuccess}
+        onRenderFailure={onRenderFailure}
+      />
+    );
+
+    // Include the error boundary by default unless it is specifically disabled.
+    return disableErrorBoundary === true ? (
+      chart
+    ) : (
+      <ErrorBoundary
+        FallbackComponent={(props: FallbackProps) => (
+          <FallbackComponent width={width} height={height} {...props} />
+        )}
+        onError={onErrorBoundary}
+      >
+        {chart}
+      </ErrorBoundary>
+    );
+  }
+
+  render() {
+    const { width: inputWidth, height: inputHeight } = this.props as PropsWithDefault;
+
+    // Parse them in case they are % or 'auto'
+    const widthInfo = parseLength(inputWidth);
+    const heightInfo = parseLength(inputHeight);
+
+    // If any of the dimension is dynamic, get parent's dimension
+    if (widthInfo.isDynamic || heightInfo.isDynamic) {
+      const { debounceTime } = this.props;
+
+      return (
+        <ParentSize debounceTime={debounceTime}>
+          {({ width, height }) =>
+            width > 0 &&
+            height > 0 &&
+            this.renderChart(
+              widthInfo.isDynamic ? Math.floor(width * widthInfo.multiplier) : widthInfo.value,
+              heightInfo.isDynamic ? Math.floor(height * heightInfo.multiplier) : heightInfo.value,
+            )
+          }
+        </ParentSize>
+      );
+    }
+
+    return this.renderChart(widthInfo.value, heightInfo.value);
+  }
+}

--- a/packages/superset-ui-chart/src/components/SuperChartCore.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChartCore.tsx
@@ -53,7 +53,7 @@ export type Props = {
   onRenderFailure?: HandlerFunction;
 };
 
-export default class SuperChart extends React.PureComponent<Props, {}> {
+export default class SuperChartCore extends React.PureComponent<Props, {}> {
   static defaultProps = defaultProps;
 
   processChartProps: (input: {

--- a/packages/superset-ui-chart/src/components/SuperChartKernel.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChartKernel.tsx
@@ -41,7 +41,7 @@ interface RenderProps {
 
 const BLANK_CHART_PROPS = new ChartProps();
 
-export interface SuperChartProps {
+export type Props = {
   id?: string;
   className?: string;
   chartProps?: ChartProps | null;
@@ -51,9 +51,9 @@ export interface SuperChartProps {
   postTransformProps?: PostTransformProps;
   onRenderSuccess?: HandlerFunction;
   onRenderFailure?: HandlerFunction;
-}
+};
 
-export default class SuperChart extends React.PureComponent<SuperChartProps, {}> {
+export default class SuperChart extends React.PureComponent<Props, {}> {
   static defaultProps = defaultProps;
 
   processChartProps: (input: {
@@ -68,7 +68,7 @@ export default class SuperChart extends React.PureComponent<SuperChartProps, {}>
     overrideTransformProps?: TransformProps;
   }) => LoadableRenderer<RenderProps, LoadedModules> | (() => null);
 
-  constructor(props: SuperChartProps) {
+  constructor(props: Props) {
     super(props);
 
     this.renderChart = this.renderChart.bind(this);

--- a/packages/superset-ui-chart/src/components/SuperChartShell.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChartShell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ErrorBoundary, { ErrorBoundaryProps, FallbackProps } from 'react-error-boundary';
 import { parseLength } from '@superset-ui/dimension';
 import { ParentSize } from '@vx/responsive';
-import SuperChartKernel, { Props as SuperChartKernelProps } from './SuperChartKernel';
+import SuperChartCore, { Props as SuperChartCoreProps } from './SuperChartCore';
 import DefaultFallbackComponent from './FallbackComponent';
 import ChartProps, { ChartPropsConfig } from '../models/ChartProps';
 
@@ -28,13 +28,13 @@ type WrapperProps = {
 };
 
 /** SuperChart Props for version 0.11 and below has chartProps */
-type ClassicProps = Omit<SuperChartKernelProps, 'chartProps'> & {
+type ClassicProps = Omit<SuperChartCoreProps, 'chartProps'> & {
   chartProps?: ChartProps | ChartPropsConfig;
 } & WrapperProps &
   Readonly<typeof defaultProps>;
 
 /** A newer alternative now lists the fields that were inside chartProps as top-level fields */
-type ModernProps = Omit<SuperChartKernelProps, 'chartProps'> &
+type ModernProps = Omit<SuperChartCoreProps, 'chartProps'> &
   Omit<ChartPropsConfig, 'width' | 'height'> &
   WrapperProps &
   Readonly<typeof defaultProps>;
@@ -94,7 +94,7 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
 
     const chartPropsConfig = this.getChartPropsConfig();
     const chart = (
-      <SuperChartKernel
+      <SuperChartCore
         id={id}
         className={className}
         chartType={chartType}

--- a/packages/superset-ui-chart/src/components/SuperChartShell.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChartShell.tsx
@@ -123,8 +123,8 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
     let inputHeight: string | number = DEFAULT_HEIGHT;
 
     // Check if the chartProps contain any width or height
-    if ('chartProps' in this.props) {
-      const { width: w = undefined, height: h = undefined } = this.props.chartProps || {};
+    if ('chartProps' in this.props && typeof this.props.chartProps !== 'undefined') {
+      const { width: w, height: h } = this.props.chartProps;
       if (typeof w !== 'undefined') {
         inputWidth = w;
       }
@@ -134,13 +134,12 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
     }
 
     // Now check if there are props width or height,
-    // which takes higher precedent
-    const { width: w2, height: h2 } = this.props;
-    if (typeof w2 !== 'undefined') {
-      inputWidth = w2;
+    // which takes higher precedent than the ones inside chartProps
+    if (typeof this.props.width !== 'undefined') {
+      inputWidth = this.props.width;
     }
-    if (typeof h2 !== 'undefined') {
-      inputHeight = h2;
+    if (typeof this.props.height !== 'undefined') {
+      inputHeight = this.props.height;
     }
 
     // Parse them in case they are % or 'auto'

--- a/packages/superset-ui-chart/src/components/SuperChartShell.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChartShell.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import ErrorBoundary, { ErrorBoundaryProps } from 'react-error-boundary';
+import { parseLength } from '@superset-ui/dimension';
+import { ParentSize } from '@vx/responsive';
+import SuperChartKernel, { Props as SuperChartKernelProps } from './SuperChartKernel';
+import DefaultFallbackComponent from './FallbackComponent';
+import ChartProps, { ChartPropsConfig } from '../models/ChartProps';
+
+// Only use these two when both top-level props
+// and inside chartProps are not specified
+// so they are not included in defaultProps
+const DEFAULT_HEIGHT = 400;
+const DEFAULT_WIDTH = '100%';
+
+const defaultProps = {
+  FallbackComponent: DefaultFallbackComponent,
+};
+
+type WrapperProps = {
+  disableErrorBoundary?: boolean;
+  FallbackComponent?: ErrorBoundaryProps['FallbackComponent'];
+  onErrorBoundary?: ErrorBoundaryProps['onError'];
+  height?: number | string;
+  width?: number | string;
+};
+
+/** SuperChart Props for version 0.11 and below has chartProps */
+type ClassicProps = Omit<SuperChartKernelProps, 'chartProps'> & {
+  chartProps?: ChartProps | ChartPropsConfig;
+} & WrapperProps &
+  Readonly<typeof defaultProps>;
+
+/** A newer alternative now lists the fields that were inside chartProps as top-level fields */
+type ModernProps = Omit<SuperChartKernelProps, 'chartProps'> &
+  Omit<ChartPropsConfig, 'width' | 'height'> &
+  WrapperProps &
+  Readonly<typeof defaultProps>;
+
+export type Props = ClassicProps | ModernProps;
+
+function isClassicProps(props: Props): props is ClassicProps {
+  return 'chartProps' in props;
+}
+
+function isModernProps(props: Props): props is ModernProps {
+  return 'formData' in props || 'payload' in props;
+}
+
+export default class SuperChart extends React.PureComponent<Props, {}> {
+  static defaultProps = defaultProps;
+
+  private createChartProps = ChartProps.createSelector();
+
+  private getChartPropsConfig() {
+    if (isClassicProps(this.props)) {
+      return this.props.chartProps;
+    }
+    if (isModernProps(this.props)) {
+      const { annotationData, datasource, filters, formData, hooks, payload } = this.props;
+
+      return {
+        annotationData,
+        datasource,
+        filters,
+        formData,
+        hooks,
+        payload,
+      };
+    }
+
+    return {};
+  }
+
+  renderChart(width: number, height: number) {
+    const {
+      id,
+      className,
+      chartType,
+      preTransformProps,
+      overrideTransformProps,
+      postTransformProps,
+      onRenderSuccess,
+      onRenderFailure,
+    } = this.props;
+
+    const chartPropsConfig = this.getChartPropsConfig();
+
+    return (
+      <SuperChartKernel
+        id={id}
+        className={className}
+        chartType={chartType}
+        chartProps={this.createChartProps({ ...chartPropsConfig, height, width })}
+        preTransformProps={preTransformProps}
+        overrideTransformProps={overrideTransformProps}
+        postTransformProps={postTransformProps}
+        onRenderSuccess={onRenderSuccess}
+        onRenderFailure={onRenderFailure}
+      />
+    );
+  }
+
+  renderResponsiveChart() {
+    let inputWidth: string | number = DEFAULT_WIDTH;
+    let inputHeight: string | number = DEFAULT_HEIGHT;
+
+    // Check if the chartProps contain any width or height
+    if ('chartProps' in this.props) {
+      const { width: w = undefined, height: h = undefined } = this.props.chartProps || {};
+      if (typeof w !== 'undefined') {
+        inputWidth = w;
+      }
+      if (typeof h !== 'undefined') {
+        inputHeight = h;
+      }
+    }
+
+    // Now check if there are props width or height,
+    // which takes higher precedent
+    const { width: w2, height: h2 } = this.props;
+    if (typeof w2 !== 'undefined') {
+      inputWidth = w2;
+    }
+    if (typeof h2 !== 'undefined') {
+      inputHeight = h2;
+    }
+
+    // Parse them in case they are % or 'auto'
+    const widthInfo = parseLength(inputWidth);
+    const heightInfo = parseLength(inputHeight);
+
+    // If any of the dimension is dynamic, get parent's dimension
+    if (widthInfo.isDynamic || heightInfo.isDynamic) {
+      return (
+        <ParentSize>
+          {({ width, height }) =>
+            width > 0 &&
+            height > 0 &&
+            this.renderChart(
+              widthInfo.isDynamic ? Math.floor(width * widthInfo.multiplier) : widthInfo.value,
+              heightInfo.isDynamic ? Math.floor(height * heightInfo.multiplier) : heightInfo.value,
+            )
+          }
+        </ParentSize>
+      );
+    }
+
+    return this.renderChart(widthInfo.value, heightInfo.value);
+  }
+
+  render() {
+    const { disableErrorBoundary, FallbackComponent, onErrorBoundary } = this.props;
+
+    const component = this.renderResponsiveChart();
+
+    // Include the error boundary by default unless it is specifically disabled.
+    return disableErrorBoundary === true ? (
+      component
+    ) : (
+      <ErrorBoundary FallbackComponent={FallbackComponent} onError={onErrorBoundary}>
+        {component}
+      </ErrorBoundary>
+    );
+  }
+}

--- a/packages/superset-ui-chart/src/components/SuperChartShell.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChartShell.tsx
@@ -18,6 +18,7 @@ const defaultProps = {
 
 type WrapperProps = {
   disableErrorBoundary?: boolean;
+  debounceTime?: number;
   FallbackComponent?: ErrorBoundaryProps['FallbackComponent'];
   onErrorBoundary?: ErrorBoundaryProps['onError'];
   height?: number | string;
@@ -131,8 +132,10 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
 
     // If any of the dimension is dynamic, get parent's dimension
     if (widthInfo.isDynamic || heightInfo.isDynamic) {
+      const { debounceTime } = this.props;
+
       return (
-        <ParentSize>
+        <ParentSize debounceTime={debounceTime}>
           {({ width, height }) =>
             width > 0 &&
             height > 0 &&

--- a/packages/superset-ui-chart/src/components/SuperChartShell.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChartShell.tsx
@@ -46,7 +46,13 @@ function isClassicProps(props: Props): props is ClassicProps {
 }
 
 function isModernProps(props: Props): props is ModernProps {
-  return 'formData' in props || 'payload' in props;
+  return (
+    'formData' in props ||
+    'payload' in props ||
+    'annotationData' in props ||
+    'datasource' in props ||
+    'filters' in props
+  );
 }
 
 export default class SuperChart extends React.PureComponent<Props, {}> {

--- a/packages/superset-ui-chart/src/components/SuperChartShell.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChartShell.tsx
@@ -154,14 +154,12 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
   render() {
     const { disableErrorBoundary, FallbackComponent, onErrorBoundary } = this.props;
 
-    const component = this.renderResponsiveChart();
-
     // Include the error boundary by default unless it is specifically disabled.
     return disableErrorBoundary === true ? (
-      component
+      this.renderResponsiveChart()
     ) : (
       <ErrorBoundary FallbackComponent={FallbackComponent} onError={onErrorBoundary}>
-        {component}
+        {this.renderResponsiveChart()}
       </ErrorBoundary>
     );
   }

--- a/packages/superset-ui-chart/src/components/SuperChartShell.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChartShell.tsx
@@ -1,175 +1,62 @@
 import React from 'react';
-import ErrorBoundary, { ErrorBoundaryProps, FallbackProps } from 'react-error-boundary';
-import { parseLength } from '@superset-ui/dimension';
-import { ParentSize } from '@vx/responsive';
-import SuperChartCore, { Props as SuperChartCoreProps } from './SuperChartCore';
-import DefaultFallbackComponent from './FallbackComponent';
+import SuperChart, { Props as SuperChartProps } from './SuperChart';
 import ChartProps, { ChartPropsConfig } from '../models/ChartProps';
 
-// Only use these two when both top-level props
-// and inside chartProps are not specified
-// so they are not included in defaultProps
-const DEFAULT_HEIGHT = 400;
-const DEFAULT_WIDTH = '100%';
-
-const defaultProps = {
-  FallbackComponent: DefaultFallbackComponent,
-};
-
-export type FallbackPropsWithDimension = FallbackProps & { width?: number; height?: number };
-
-type WrapperProps = {
-  disableErrorBoundary?: boolean;
-  debounceTime?: number;
-  FallbackComponent?: React.ComponentType<FallbackPropsWithDimension>;
-  onErrorBoundary?: ErrorBoundaryProps['onError'];
-  height?: number | string;
-  width?: number | string;
-};
-
 /** SuperChart Props for version 0.11 and below has chartProps */
-type ClassicProps = Omit<SuperChartCoreProps, 'chartProps'> & {
-  chartProps?: ChartProps | ChartPropsConfig;
-} & WrapperProps &
-  Readonly<typeof defaultProps>;
+type ClassicProps = Omit<
+  SuperChartProps,
+  | 'annotationData'
+  | 'datasource'
+  | 'filters'
+  | 'formData'
+  | 'payload'
+  | 'onAddFilter'
+  | 'onError'
+  | 'setControlValue'
+  | 'setTooltip'
+  | 'width'
+  | 'height'
+> & {
+  chartProps: ChartProps | ChartPropsConfig;
+};
 
-/** A newer alternative now lists the fields that were inside chartProps as top-level fields */
-type ModernProps = Omit<SuperChartCoreProps, 'chartProps'> &
-  Omit<ChartPropsConfig, 'width' | 'height'> &
-  WrapperProps &
-  Readonly<typeof defaultProps>;
+export type Props = ClassicProps | SuperChartProps;
 
-export type Props = ClassicProps | ModernProps;
+export default function SuperChartShell(props: Props) {
+  if ('chartProps' in props) {
+    const { chartProps, ...rest } = props;
 
-function isClassicProps(props: Props): props is ClassicProps {
-  return 'chartProps' in props;
-}
-
-function isModernProps(props: Props): props is ModernProps {
-  return (
-    'formData' in props ||
-    'payload' in props ||
-    'annotationData' in props ||
-    'datasource' in props ||
-    'filters' in props
-  );
-}
-
-export default class SuperChart extends React.PureComponent<Props, {}> {
-  static defaultProps = defaultProps;
-
-  private createChartProps = ChartProps.createSelector();
-
-  private getChartPropsConfig() {
-    if (isClassicProps(this.props)) {
-      return this.props.chartProps;
-    }
-    if (isModernProps(this.props)) {
-      const { annotationData, datasource, filters, formData, hooks, payload } = this.props;
-
-      return {
-        annotationData,
-        datasource,
-        filters,
-        formData,
-        hooks,
-        payload,
-      };
-    }
-
-    return {};
-  }
-
-  renderChart(width: number, height: number) {
     const {
-      id,
-      className,
-      chartType,
-      preTransformProps,
-      overrideTransformProps,
-      postTransformProps,
-      onRenderSuccess,
-      onRenderFailure,
-    } = this.props;
+      annotationData,
+      datasource,
+      filters,
+      formData,
+      payload,
+      onAddFilter,
+      onError,
+      setControlValue,
+      setTooltip,
+      width,
+      height,
+    } = chartProps;
 
-    const chartPropsConfig = this.getChartPropsConfig();
-    const chart = (
-      <SuperChartCore
-        id={id}
-        className={className}
-        chartType={chartType}
-        chartProps={this.createChartProps({ ...chartPropsConfig, height, width })}
-        preTransformProps={preTransformProps}
-        overrideTransformProps={overrideTransformProps}
-        postTransformProps={postTransformProps}
-        onRenderSuccess={onRenderSuccess}
-        onRenderFailure={onRenderFailure}
+    return (
+      <SuperChart
+        {...rest}
+        annotationData={annotationData}
+        datasource={datasource}
+        filters={filters}
+        formData={formData}
+        payload={payload}
+        onAddFilter={onAddFilter}
+        onError={onError}
+        setControlValue={setControlValue}
+        setTooltip={setTooltip}
+        width={width}
+        height={height}
       />
     );
-
-    const { disableErrorBoundary, FallbackComponent, onErrorBoundary } = this.props;
-
-    // Include the error boundary by default unless it is specifically disabled.
-    return disableErrorBoundary === true ? (
-      chart
-    ) : (
-      <ErrorBoundary
-        FallbackComponent={(props: FallbackProps) => (
-          <FallbackComponent width={width} height={height} {...props} />
-        )}
-        onError={onErrorBoundary}
-      >
-        {chart}
-      </ErrorBoundary>
-    );
   }
 
-  render() {
-    let inputWidth: string | number = DEFAULT_WIDTH;
-    let inputHeight: string | number = DEFAULT_HEIGHT;
-
-    // Check if the chartProps contain any width or height
-    if ('chartProps' in this.props && typeof this.props.chartProps !== 'undefined') {
-      const { width: w, height: h } = this.props.chartProps;
-      if (typeof w !== 'undefined') {
-        inputWidth = w;
-      }
-      if (typeof h !== 'undefined') {
-        inputHeight = h;
-      }
-    }
-
-    // Now check if there are props width or height,
-    // which takes higher precedent than the ones inside chartProps
-    if (typeof this.props.width !== 'undefined') {
-      inputWidth = this.props.width;
-    }
-    if (typeof this.props.height !== 'undefined') {
-      inputHeight = this.props.height;
-    }
-
-    // Parse them in case they are % or 'auto'
-    const widthInfo = parseLength(inputWidth);
-    const heightInfo = parseLength(inputHeight);
-
-    // If any of the dimension is dynamic, get parent's dimension
-    if (widthInfo.isDynamic || heightInfo.isDynamic) {
-      const { debounceTime } = this.props;
-
-      return (
-        <ParentSize debounceTime={debounceTime}>
-          {({ width, height }) =>
-            width > 0 &&
-            height > 0 &&
-            this.renderChart(
-              widthInfo.isDynamic ? Math.floor(width * widthInfo.multiplier) : widthInfo.value,
-              heightInfo.isDynamic ? Math.floor(height * heightInfo.multiplier) : heightInfo.value,
-            )
-          }
-        </ParentSize>
-      );
-    }
-
-    return this.renderChart(widthInfo.value, heightInfo.value);
-  }
+  return <SuperChart {...props} />;
 }

--- a/packages/superset-ui-chart/src/index.ts
+++ b/packages/superset-ui-chart/src/index.ts
@@ -5,7 +5,7 @@ export { default as ChartProps } from './models/ChartProps';
 
 export { default as createLoadableRenderer } from './components/createLoadableRenderer';
 export { default as reactify } from './components/reactify';
-export { default as SuperChart } from './components/SuperChart';
+export { default as SuperChart } from './components/SuperChartShell';
 
 export {
   default as getChartBuildQueryRegistry,

--- a/packages/superset-ui-chart/src/models/ChartProps.ts
+++ b/packages/superset-ui-chart/src/models/ChartProps.ts
@@ -12,7 +12,7 @@ export type QueryData = PlainObject;
 type Filters = any[];
 type ChartPropsSelector = (c: ChartPropsConfig) => ChartProps;
 
-interface ChartPropsConfig {
+export interface ChartPropsConfig {
   annotationData?: AnnotationData;
   datasource?: SnakeCaseDatasource;
   filters?: Filters;

--- a/packages/superset-ui-chart/test/components/FallbackComponent.test.tsx
+++ b/packages/superset-ui-chart/test/components/FallbackComponent.test.tsx
@@ -8,31 +8,31 @@ describe('FallbackComponent', () => {
 
   it('renders error and stack trace', () => {
     const wrapper = shallow(<FallbackComponent componentStack={STACK_TRACE} error={ERROR} />);
-    const span = wrapper.find('span');
-    expect(span).toHaveLength(2);
-    expect(span.at(0).text()).toEqual('Error: CaffeineOverLoadException');
-    expect(span.at(1).text()).toEqual('Error at line 1: x.drink(coffee)');
+    const messages = wrapper.find('code');
+    expect(messages).toHaveLength(2);
+    expect(messages.at(0).text()).toEqual('Error: CaffeineOverLoadException');
+    expect(messages.at(1).text()).toEqual('Error at line 1: x.drink(coffee)');
   });
 
   it('renders error only', () => {
     const wrapper = shallow(<FallbackComponent error={ERROR} />);
-    const span = wrapper.find('span');
-    expect(span).toHaveLength(1);
-    expect(span.at(0).text()).toEqual('Error: CaffeineOverLoadException');
+    const messages = wrapper.find('code');
+    expect(messages).toHaveLength(1);
+    expect(messages.at(0).text()).toEqual('Error: CaffeineOverLoadException');
   });
 
   it('renders stacktrace only', () => {
     const wrapper = shallow(<FallbackComponent componentStack={STACK_TRACE} />);
-    const span = wrapper.find('span');
-    expect(span).toHaveLength(2);
-    expect(span.at(0).text()).toEqual('Unknown Error');
-    expect(span.at(1).text()).toEqual('Error at line 1: x.drink(coffee)');
+    const messages = wrapper.find('code');
+    expect(messages).toHaveLength(2);
+    expect(messages.at(0).text()).toEqual('Unknown Error');
+    expect(messages.at(1).text()).toEqual('Error at line 1: x.drink(coffee)');
   });
 
   it('renders when nothing is given', () => {
     const wrapper = shallow(<FallbackComponent />);
-    const span = wrapper.find('span');
-    expect(span).toHaveLength(1);
-    expect(span.at(0).text()).toEqual('Unknown Error');
+    const messages = wrapper.find('code');
+    expect(messages).toHaveLength(1);
+    expect(messages.at(0).text()).toEqual('Unknown Error');
   });
 });

--- a/packages/superset-ui-chart/test/components/FallbackComponent.test.tsx
+++ b/packages/superset-ui-chart/test/components/FallbackComponent.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import FallbackComponent from '../../src/components/FallbackComponent';
+
+describe('FallbackComponent', () => {
+  const ERROR = new Error('CaffeineOverLoadException');
+  const STACK_TRACE = 'Error at line 1: x.drink(coffee)';
+
+  it('renders error and stack trace', () => {
+    const wrapper = shallow(<FallbackComponent componentStack={STACK_TRACE} error={ERROR} />);
+    const span = wrapper.find('span');
+    expect(span).toHaveLength(2);
+    expect(span.at(0).text()).toEqual('Error: CaffeineOverLoadException');
+    expect(span.at(1).text()).toEqual('Error at line 1: x.drink(coffee)');
+  });
+
+  it('renders error only', () => {
+    const wrapper = shallow(<FallbackComponent error={ERROR} />);
+    const span = wrapper.find('span');
+    expect(span).toHaveLength(1);
+    expect(span.at(0).text()).toEqual('Error: CaffeineOverLoadException');
+  });
+
+  it('renders stacktrace only', () => {
+    const wrapper = shallow(<FallbackComponent componentStack={STACK_TRACE} />);
+    const span = wrapper.find('span');
+    expect(span).toHaveLength(2);
+    expect(span.at(0).text()).toEqual('Unknown Error');
+    expect(span.at(1).text()).toEqual('Error at line 1: x.drink(coffee)');
+  });
+
+  it('renders when nothing is given', () => {
+    const wrapper = shallow(<FallbackComponent />);
+    const span = wrapper.find('span');
+    expect(span).toHaveLength(1);
+    expect(span.at(0).text()).toEqual('Unknown Error');
+  });
+});

--- a/packages/superset-ui-chart/test/components/MockChartPlugins.tsx
+++ b/packages/superset-ui-chart/test/components/MockChartPlugins.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import { ChartMetadata, ChartPlugin, ChartFormData } from '../../src';
 
+const DIMENSION_STYLE = {
+  fontSize: 36,
+  fontWeight: 700,
+  flex: '1 1 auto',
+  display: 'flex',
+  alignItems: 'center',
+};
+
 export const TestComponent = ({
   formData,
   message,
@@ -12,10 +20,28 @@ export const TestComponent = ({
   width?: number;
   height?: number;
 }) => (
-  <div className="test-component">
-    <span className="message">{message || 'test-message'}</span>
-    <span className="dimension">{[width, height].join('x')}</span>
-    <span className="formData">{JSON.stringify(formData)}</span>
+  <div
+    className="test-component"
+    style={{
+      width,
+      height,
+      backgroundColor: '#00d1c1',
+      color: '#fff',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      borderRadius: 8,
+    }}
+  >
+    <div className="message" style={{ padding: 10 }}>
+      {message || 'custom component'}
+    </div>
+    <div className="dimension" style={DIMENSION_STYLE}>
+      {[width, height].join('x')}
+    </div>
+    <div className="formData" style={{ padding: 10 }}>
+      <code style={{ color: '#D3F9F7' }}>{JSON.stringify(formData)}</code>
+    </div>
   </div>
 );
 

--- a/packages/superset-ui-chart/test/components/MockChartPlugins.tsx
+++ b/packages/superset-ui-chart/test/components/MockChartPlugins.tsx
@@ -2,17 +2,20 @@ import React from 'react';
 import { ChartMetadata, ChartPlugin, ChartFormData } from '../../src';
 
 export const TestComponent = ({
+  formData,
   message,
   width,
   height,
 }: {
-  message: string;
-  width: number;
-  height: number;
+  formData?: any;
+  message?: string;
+  width?: number;
+  height?: number;
 }) => (
   <div className="test-component">
     <span className="message">{message || 'test-message'}</span>
     <span className="dimension">{[width, height].join('x')}</span>
+    <span className="formData">{JSON.stringify(formData)}</span>
   </div>
 );
 
@@ -20,6 +23,7 @@ export const ChartKeys = {
   DILIGENT: 'diligent-chart',
   LAZY: 'lazy-chart',
   SLOW: 'slow-chart',
+  BUGGY: 'buggy-chart',
 };
 
 export class DiligentChartPlugin extends ChartPlugin<ChartFormData> {
@@ -63,6 +67,21 @@ export class SlowChartPlugin extends ChartPlugin<ChartFormData> {
             resolve(TestComponent);
           }, 1000);
         }),
+      transformProps: x => x,
+    });
+  }
+}
+
+export class BuggyChartPlugin extends ChartPlugin<ChartFormData> {
+  constructor() {
+    super({
+      metadata: new ChartMetadata({
+        name: ChartKeys.BUGGY,
+        thumbnail: '',
+      }),
+      Chart: () => {
+        throw new Error('The component is too buggy to render.');
+      },
       transformProps: x => x,
     });
   }

--- a/packages/superset-ui-chart/test/components/SuperChartCore.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChartCore.test.tsx
@@ -7,10 +7,10 @@ import {
   LazyChartPlugin,
   SlowChartPlugin,
 } from './MockChartPlugins';
-import SuperChartKernel from '../../src/components/SuperChartKernel';
+import SuperChartCore from '../../src/components/SuperChartCore';
 import promiseTimeout from './promiseTimeout';
 
-describe('SuperChartKernel', () => {
+describe('SuperChartCore', () => {
   const chartProps = new ChartProps();
 
   const plugins = [
@@ -34,7 +34,7 @@ describe('SuperChartKernel', () => {
   describe('registered charts', () => {
     it('renders registered chart', () => {
       const wrapper = shallow(
-        <SuperChartKernel chartType={ChartKeys.DILIGENT} chartProps={chartProps} />,
+        <SuperChartCore chartType={ChartKeys.DILIGENT} chartProps={chartProps} />,
       );
 
       return promiseTimeout(() => {
@@ -42,7 +42,7 @@ describe('SuperChartKernel', () => {
       });
     });
     it('renders registered chart with lazy loading', () => {
-      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.LAZY} />);
+      const wrapper = shallow(<SuperChartCore chartType={ChartKeys.LAZY} />);
 
       return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
@@ -50,14 +50,14 @@ describe('SuperChartKernel', () => {
     });
     it('does not render if chartType is not set', () => {
       // @ts-ignore chartType is required
-      const wrapper = shallow(<SuperChartKernel />);
+      const wrapper = shallow(<SuperChartCore />);
 
       return promiseTimeout(() => {
         expect(wrapper.render().children()).toHaveLength(0);
       }, 5);
     });
     it('adds id to container if specified', () => {
-      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.DILIGENT} id="the-chart" />);
+      const wrapper = shallow(<SuperChartCore chartType={ChartKeys.DILIGENT} id="the-chart" />);
 
       return promiseTimeout(() => {
         expect(wrapper.render().attr('id')).toEqual('the-chart');
@@ -65,7 +65,7 @@ describe('SuperChartKernel', () => {
     });
     it('adds class to container if specified', () => {
       const wrapper = shallow(
-        <SuperChartKernel chartType={ChartKeys.DILIGENT} className="the-chart" />,
+        <SuperChartCore chartType={ChartKeys.DILIGENT} className="the-chart" />,
       );
 
       return promiseTimeout(() => {
@@ -74,7 +74,7 @@ describe('SuperChartKernel', () => {
     });
     it('uses overrideTransformProps when specified', () => {
       const wrapper = shallow(
-        <SuperChartKernel
+        <SuperChartCore
           chartType={ChartKeys.DILIGENT}
           overrideTransformProps={() => ({ message: 'hulk' })}
         />,
@@ -94,7 +94,7 @@ describe('SuperChartKernel', () => {
         payload: { message: 'hulk' },
       });
       const wrapper = shallow(
-        <SuperChartKernel
+        <SuperChartCore
           chartType={ChartKeys.DILIGENT}
           preTransformProps={() => chartPropsWithPayload}
           overrideTransformProps={props => props.payload}
@@ -112,7 +112,7 @@ describe('SuperChartKernel', () => {
     });
     it('uses postTransformProps when specified', () => {
       const wrapper = shallow(
-        <SuperChartKernel
+        <SuperChartCore
           chartType={ChartKeys.DILIGENT}
           postTransformProps={() => ({ message: 'hulk' })}
         />,
@@ -128,30 +128,28 @@ describe('SuperChartKernel', () => {
       });
     });
     it('renders if chartProps is not specified', () => {
-      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.DILIGENT} />);
+      const wrapper = shallow(<SuperChartCore chartType={ChartKeys.DILIGENT} />);
 
       return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
       });
     });
     it('does not render anything while waiting for Chart code to load', () => {
-      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.SLOW} />);
+      const wrapper = shallow(<SuperChartCore chartType={ChartKeys.SLOW} />);
 
       return promiseTimeout(() => {
         expect(wrapper.render().children()).toHaveLength(0);
       });
     });
     it('eventually renders after Chart is loaded', () => {
-      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.SLOW} />);
+      const wrapper = shallow(<SuperChartCore chartType={ChartKeys.SLOW} />);
 
       return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
       }, 1500);
     });
     it('does not render if chartProps is null', () => {
-      const wrapper = shallow(
-        <SuperChartKernel chartType={ChartKeys.DILIGENT} chartProps={null} />,
-      );
+      const wrapper = shallow(<SuperChartCore chartType={ChartKeys.DILIGENT} chartProps={null} />);
 
       return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(0);
@@ -161,7 +159,7 @@ describe('SuperChartKernel', () => {
 
   describe('unregistered charts', () => {
     it('renders error message', () => {
-      const wrapper = mount(<SuperChartKernel chartType="4d-pie-chart" chartProps={chartProps} />);
+      const wrapper = mount(<SuperChartCore chartType="4d-pie-chart" chartProps={chartProps} />);
 
       return promiseTimeout(() => {
         expect(wrapper.render().find('.alert')).toHaveLength(1);
@@ -171,7 +169,7 @@ describe('SuperChartKernel', () => {
 
   describe('.processChartProps()', () => {
     it('use identity functions for unspecified transforms', () => {
-      const chart = new SuperChartKernel({
+      const chart = new SuperChartCore({
         chartType: ChartKeys.DILIGENT,
       });
       const chartProps2 = new ChartProps();

--- a/packages/superset-ui-chart/test/components/SuperChartKernel.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChartKernel.test.tsx
@@ -84,7 +84,7 @@ describe('SuperChartKernel', () => {
         expect(
           wrapper
             .render()
-            .find('span.message')
+            .find('.message')
             .text(),
         ).toEqual('hulk');
       });
@@ -105,7 +105,7 @@ describe('SuperChartKernel', () => {
         expect(
           wrapper
             .render()
-            .find('span.message')
+            .find('.message')
             .text(),
         ).toEqual('hulk');
       });
@@ -122,7 +122,7 @@ describe('SuperChartKernel', () => {
         expect(
           wrapper
             .render()
-            .find('span.message')
+            .find('.message')
             .text(),
         ).toEqual('hulk');
       });

--- a/packages/superset-ui-chart/test/components/SuperChartKernel.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChartKernel.test.tsx
@@ -7,7 +7,7 @@ import {
   LazyChartPlugin,
   SlowChartPlugin,
 } from './MockChartPlugins';
-import SuperChart from '../../src/components/SuperChart';
+import SuperChartKernel from '../../src/components/SuperChartKernel';
 
 describe('SuperChart', () => {
   const chartProps = new ChartProps();
@@ -19,7 +19,7 @@ describe('SuperChart', () => {
   describe('registered charts', () => {
     it('renders registered chart', done => {
       const wrapper = shallow(
-        <SuperChart chartType={ChartKeys.DILIGENT} chartProps={chartProps} />,
+        <SuperChartKernel chartType={ChartKeys.DILIGENT} chartProps={chartProps} />,
       );
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
@@ -27,7 +27,7 @@ describe('SuperChart', () => {
       }, 0);
     });
     it('renders registered chart with default export', done => {
-      const wrapper = shallow(<SuperChart chartType={ChartKeys.LAZY} />);
+      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.LAZY} />);
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
         done();
@@ -35,21 +35,23 @@ describe('SuperChart', () => {
     });
     it('does not render if chartType is not set', done => {
       // @ts-ignore chartType is required
-      const wrapper = shallow(<SuperChart />);
+      const wrapper = shallow(<SuperChartKernel />);
       setTimeout(() => {
         expect(wrapper.render().children()).toHaveLength(0);
         done();
       }, 5);
     });
     it('adds id to container if specified', done => {
-      const wrapper = shallow(<SuperChart chartType={ChartKeys.DILIGENT} id="the-chart" />);
+      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.DILIGENT} id="the-chart" />);
       setTimeout(() => {
         expect(wrapper.render().attr('id')).toEqual('the-chart');
         done();
       }, 0);
     });
     it('adds class to container if specified', done => {
-      const wrapper = shallow(<SuperChart chartType={ChartKeys.DILIGENT} className="the-chart" />);
+      const wrapper = shallow(
+        <SuperChartKernel chartType={ChartKeys.DILIGENT} className="the-chart" />,
+      );
       setTimeout(() => {
         expect(wrapper.hasClass('the-chart')).toBeTruthy();
         done();
@@ -57,7 +59,7 @@ describe('SuperChart', () => {
     });
     it('uses overrideTransformProps when specified', done => {
       const wrapper = shallow(
-        <SuperChart
+        <SuperChartKernel
           chartType={ChartKeys.DILIGENT}
           overrideTransformProps={() => ({ message: 'hulk' })}
         />,
@@ -77,7 +79,7 @@ describe('SuperChart', () => {
         payload: { message: 'hulk' },
       });
       const wrapper = shallow(
-        <SuperChart
+        <SuperChartKernel
           chartType={ChartKeys.DILIGENT}
           preTransformProps={() => chartPropsWithPayload}
           overrideTransformProps={props => props.payload}
@@ -95,7 +97,7 @@ describe('SuperChart', () => {
     });
     it('uses postTransformProps when specified', done => {
       const wrapper = shallow(
-        <SuperChart
+        <SuperChartKernel
           chartType={ChartKeys.DILIGENT}
           postTransformProps={() => ({ message: 'hulk' })}
         />,
@@ -111,28 +113,30 @@ describe('SuperChart', () => {
       }, 0);
     });
     it('renders if chartProps is not specified', done => {
-      const wrapper = shallow(<SuperChart chartType={ChartKeys.DILIGENT} />);
+      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.DILIGENT} />);
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
         done();
       }, 0);
     });
     it('does not render anything while waiting for Chart code to load', done => {
-      const wrapper = shallow(<SuperChart chartType={ChartKeys.SLOW} />);
+      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.SLOW} />);
       setTimeout(() => {
         expect(wrapper.render().children()).toHaveLength(0);
         done();
       }, 0);
     });
     it('eventually renders after Chart is loaded', done => {
-      const wrapper = shallow(<SuperChart chartType={ChartKeys.SLOW} />);
+      const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.SLOW} />);
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
         done();
       }, 1500);
     });
     it('does not render if chartProps is null', done => {
-      const wrapper = shallow(<SuperChart chartType={ChartKeys.DILIGENT} chartProps={null} />);
+      const wrapper = shallow(
+        <SuperChartKernel chartType={ChartKeys.DILIGENT} chartProps={null} />,
+      );
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(0);
         done();
@@ -142,7 +146,7 @@ describe('SuperChart', () => {
 
   describe('unregistered charts', () => {
     it('renders error message', done => {
-      const wrapper = mount(<SuperChart chartType="4d-pie-chart" chartProps={chartProps} />);
+      const wrapper = mount(<SuperChartKernel chartType="4d-pie-chart" chartProps={chartProps} />);
       setTimeout(() => {
         expect(wrapper.render().find('.alert')).toHaveLength(1);
         done();
@@ -152,7 +156,7 @@ describe('SuperChart', () => {
 
   describe('.processChartProps()', () => {
     it('use identity functions for unspecified transforms', () => {
-      const chart = new SuperChart({
+      const chart = new SuperChartKernel({
         chartType: ChartKeys.DILIGENT,
       });
       const chartProps2 = new ChartProps();

--- a/packages/superset-ui-chart/test/components/SuperChartKernel.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChartKernel.test.tsx
@@ -8,6 +8,7 @@ import {
   SlowChartPlugin,
 } from './MockChartPlugins';
 import SuperChartKernel from '../../src/components/SuperChartKernel';
+import promiseTimeout from './promiseTimeout';
 
 describe('SuperChartKernel', () => {
   const chartProps = new ChartProps();
@@ -31,64 +32,64 @@ describe('SuperChartKernel', () => {
   });
 
   describe('registered charts', () => {
-    it('renders registered chart', done => {
+    it('renders registered chart', () => {
       const wrapper = shallow(
         <SuperChartKernel chartType={ChartKeys.DILIGENT} chartProps={chartProps} />,
       );
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        done();
-      }, 0);
+      });
     });
-    it('renders registered chart with lazy loading', done => {
+    it('renders registered chart with lazy loading', () => {
       const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.LAZY} />);
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        done();
-      }, 0);
+      });
     });
-    it('does not render if chartType is not set', done => {
+    it('does not render if chartType is not set', () => {
       // @ts-ignore chartType is required
       const wrapper = shallow(<SuperChartKernel />);
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().children()).toHaveLength(0);
-        done();
       }, 5);
     });
-    it('adds id to container if specified', done => {
+    it('adds id to container if specified', () => {
       const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.DILIGENT} id="the-chart" />);
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().attr('id')).toEqual('the-chart');
-        done();
-      }, 0);
+      });
     });
-    it('adds class to container if specified', done => {
+    it('adds class to container if specified', () => {
       const wrapper = shallow(
         <SuperChartKernel chartType={ChartKeys.DILIGENT} className="the-chart" />,
       );
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.hasClass('the-chart')).toBeTruthy();
-        done();
       }, 0);
     });
-    it('uses overrideTransformProps when specified', done => {
+    it('uses overrideTransformProps when specified', () => {
       const wrapper = shallow(
         <SuperChartKernel
           chartType={ChartKeys.DILIGENT}
           overrideTransformProps={() => ({ message: 'hulk' })}
         />,
       );
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(
           wrapper
             .render()
             .find('span.message')
             .text(),
         ).toEqual('hulk');
-        done();
-      }, 0);
+      });
     });
-    it('uses preTransformProps when specified', done => {
+    it('uses preTransformProps when specified', () => {
       const chartPropsWithPayload = new ChartProps({
         payload: { message: 'hulk' },
       });
@@ -99,72 +100,72 @@ describe('SuperChartKernel', () => {
           overrideTransformProps={props => props.payload}
         />,
       );
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(
           wrapper
             .render()
             .find('span.message')
             .text(),
         ).toEqual('hulk');
-        done();
-      }, 0);
+      });
     });
-    it('uses postTransformProps when specified', done => {
+    it('uses postTransformProps when specified', () => {
       const wrapper = shallow(
         <SuperChartKernel
           chartType={ChartKeys.DILIGENT}
           postTransformProps={() => ({ message: 'hulk' })}
         />,
       );
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(
           wrapper
             .render()
             .find('span.message')
             .text(),
         ).toEqual('hulk');
-        done();
-      }, 0);
+      });
     });
-    it('renders if chartProps is not specified', done => {
+    it('renders if chartProps is not specified', () => {
       const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.DILIGENT} />);
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        done();
-      }, 0);
+      });
     });
-    it('does not render anything while waiting for Chart code to load', done => {
+    it('does not render anything while waiting for Chart code to load', () => {
       const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.SLOW} />);
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().children()).toHaveLength(0);
-        done();
-      }, 0);
+      });
     });
-    it('eventually renders after Chart is loaded', done => {
+    it('eventually renders after Chart is loaded', () => {
       const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.SLOW} />);
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        done();
       }, 1500);
     });
-    it('does not render if chartProps is null', done => {
+    it('does not render if chartProps is null', () => {
       const wrapper = shallow(
         <SuperChartKernel chartType={ChartKeys.DILIGENT} chartProps={null} />,
       );
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(0);
-        done();
-      }, 0);
+      });
     });
   });
 
   describe('unregistered charts', () => {
-    it('renders error message', done => {
+    it('renders error message', () => {
       const wrapper = mount(<SuperChartKernel chartType="4d-pie-chart" chartProps={chartProps} />);
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('.alert')).toHaveLength(1);
-        done();
-      }, 0);
+      });
     });
   });
 

--- a/packages/superset-ui-chart/test/components/SuperChartKernel.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChartKernel.test.tsx
@@ -9,12 +9,26 @@ import {
 } from './MockChartPlugins';
 import SuperChartKernel from '../../src/components/SuperChartKernel';
 
-describe('SuperChart', () => {
+describe('SuperChartKernel', () => {
   const chartProps = new ChartProps();
 
-  new DiligentChartPlugin().configure({ key: ChartKeys.DILIGENT }).register();
-  new LazyChartPlugin().configure({ key: ChartKeys.LAZY }).register();
-  new SlowChartPlugin().configure({ key: ChartKeys.SLOW }).register();
+  const plugins = [
+    new DiligentChartPlugin().configure({ key: ChartKeys.DILIGENT }),
+    new LazyChartPlugin().configure({ key: ChartKeys.LAZY }),
+    new SlowChartPlugin().configure({ key: ChartKeys.SLOW }),
+  ];
+
+  beforeAll(() => {
+    plugins.forEach(p => {
+      p.unregister().register();
+    });
+  });
+
+  afterAll(() => {
+    plugins.forEach(p => {
+      p.unregister();
+    });
+  });
 
   describe('registered charts', () => {
     it('renders registered chart', done => {
@@ -26,7 +40,7 @@ describe('SuperChart', () => {
         done();
       }, 0);
     });
-    it('renders registered chart with default export', done => {
+    it('renders registered chart with lazy loading', done => {
       const wrapper = shallow(<SuperChartKernel chartType={ChartKeys.LAZY} />);
       setTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);

--- a/packages/superset-ui-chart/test/components/SuperChartShell.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChartShell.test.tsx
@@ -1,0 +1,148 @@
+/* eslint-disable import/first */
+import React from 'react';
+import { mount } from 'enzyme';
+
+jest.mock('resize-observer-polyfill');
+// @ts-ignore
+import { triggerResizeObserver } from 'resize-observer-polyfill';
+import { ChartProps, SuperChart } from '../../src';
+import { ChartKeys, DiligentChartPlugin, BuggyChartPlugin } from './MockChartPlugins';
+
+describe('SuperChart', () => {
+  const plugins = [
+    new DiligentChartPlugin().configure({ key: ChartKeys.DILIGENT }),
+    new BuggyChartPlugin().configure({ key: ChartKeys.BUGGY }),
+  ];
+
+  beforeAll(() => {
+    plugins.forEach(p => {
+      p.unregister().register();
+    });
+  });
+
+  afterAll(() => {
+    plugins.forEach(p => {
+      p.unregister();
+    });
+  });
+
+  describe('includes ErrorBoundary', () => {
+    it('renders default FallbackComponent', () => {});
+    it('renders custom FallbackComponent', () => {});
+    it('call onError', () => {});
+    it('does not include ErrorBoundary if told so', () => {});
+  });
+
+  describe('supports multiple way of specifying chartProps', () => {
+    it('chartProps is instanceof ChartProps', done => {
+      const wrapper = mount(
+        <SuperChart
+          chartType={ChartKeys.DILIGENT}
+          chartProps={new ChartProps({ width: 20, height: 20 })}
+        />,
+      );
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        expect(
+          wrapper
+            .render()
+            .find('span.dimension')
+            .text(),
+        ).toEqual('20x20');
+        done();
+      }, 0);
+    });
+    it('chartProps is ChartPropsConfig', done => {
+      const wrapper = mount(
+        <SuperChart chartType={ChartKeys.DILIGENT} chartProps={{ width: 201, height: 202 }} />,
+      );
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        expect(
+          wrapper
+            .render()
+            .find('span.dimension')
+            .text(),
+        ).toEqual('201x202');
+        done();
+      }, 0);
+    });
+    it('fields of chartProps are listed as props of SuperChart', done => {
+      const wrapper = mount(<SuperChart chartType={ChartKeys.DILIGENT} width={101} height={118} />);
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        expect(
+          wrapper
+            .render()
+            .find('span.dimension')
+            .text(),
+        ).toEqual('101x118');
+        done();
+      }, 0);
+    });
+  });
+
+  describe('supports dynamic width and/or height', () => {
+    it('works with width and height that are numbers', done => {
+      const wrapper = mount(<SuperChart chartType={ChartKeys.DILIGENT} width={100} height={100} />);
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        expect(
+          wrapper
+            .render()
+            .find('span.dimension')
+            .text(),
+        ).toEqual('100x100');
+        done();
+      }, 0);
+    });
+    it('works when width and height are percent', done => {
+      const wrapper = mount(
+        <SuperChart chartType={ChartKeys.DILIGENT} debounceTime={1} width="100%" height="100%" />,
+      );
+      triggerResizeObserver();
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        expect(
+          wrapper
+            .render()
+            .find('span.dimension')
+            .text(),
+        ).toEqual('300x300');
+        done();
+      }, 100);
+    });
+    it('works when only width is percent', done => {
+      const wrapper = mount(
+        <SuperChart chartType={ChartKeys.DILIGENT} debounceTime={1} width="50%" height="125" />,
+      );
+      triggerResizeObserver();
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        expect(
+          wrapper
+            .render()
+            .find('span.dimension')
+            .text(),
+        ).toEqual('150x125');
+        done();
+      }, 100);
+    });
+    it('works when only height is percent', done => {
+      const wrapper = mount(
+        <SuperChart chartType={ChartKeys.DILIGENT} debounceTime={1} width="50" height="25%" />,
+      );
+      triggerResizeObserver();
+      setTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        expect(
+          wrapper
+            .render()
+            .find('span.dimension')
+            .text(),
+        ).toEqual('50x75');
+        done();
+      }, 100);
+    });
+  });
+});

--- a/packages/superset-ui-chart/test/components/SuperChartShell.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChartShell.test.tsx
@@ -1,12 +1,23 @@
 /* eslint-disable import/first */
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 
 jest.mock('resize-observer-polyfill');
 // @ts-ignore
 import { triggerResizeObserver } from 'resize-observer-polyfill';
+import ErrorBoundary from 'react-error-boundary';
 import { ChartProps, SuperChart } from '../../src';
 import { ChartKeys, DiligentChartPlugin, BuggyChartPlugin } from './MockChartPlugins';
+import promiseTimeout from './promiseTimeout';
+
+function expectDimension(wrapper: ReactWrapper, width: number, height: number) {
+  expect(
+    wrapper
+      .render()
+      .find('span.dimension')
+      .text(),
+  ).toEqual([width, height].join('x'));
+}
 
 describe('SuperChart', () => {
   const plugins = [
@@ -27,121 +38,156 @@ describe('SuperChart', () => {
   });
 
   describe('includes ErrorBoundary', () => {
-    it('renders default FallbackComponent', () => {});
-    it('renders custom FallbackComponent', () => {});
-    it('call onError', () => {});
-    it('does not include ErrorBoundary if told so', () => {});
+    it('renders default FallbackComponent', () => {
+      const wrapper = mount(
+        <ErrorBoundary onError={() => 'omg omg'}>
+          <SuperChart chartType={ChartKeys.BUGGY} width="200" height="200" />
+        </ErrorBoundary>,
+      );
+      const renderedWrapper = wrapper.render();
+
+      return promiseTimeout(() => {
+        expect(renderedWrapper.find('div.test-component')).toHaveLength(0);
+        console.log('wrapper.render()', renderedWrapper.find('p').html());
+        expect(renderedWrapper.find('p strong')).toHaveLength(1);
+      }, 100);
+    });
+    it('renders custom FallbackComponent', () => {
+      const CustomFallbackComponent = jest.fn(() => <div>Custom Fallback!</div>);
+      const wrapper = mount(
+        <SuperChart
+          chartType={ChartKeys.BUGGY}
+          width="200"
+          height="200"
+          FallbackComponent={CustomFallbackComponent}
+        />,
+      );
+
+      return promiseTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(0);
+        expect(CustomFallbackComponent).toBeCalledTimes(1);
+      });
+    });
+    it('call onErrorBoundary', () => {
+      const handleError = jest.fn();
+      mount(
+        <SuperChart
+          chartType={ChartKeys.BUGGY}
+          width="200"
+          height="200"
+          onErrorBoundary={handleError}
+        />,
+      );
+
+      return promiseTimeout(() => {
+        expect(handleError).toHaveBeenCalledTimes(1);
+      });
+    });
+    it('does not include ErrorBoundary if told so', () => {
+      const inactiveErrorHandler = jest.fn();
+      const activeErrorHandler = jest.fn();
+      mount(
+        <ErrorBoundary onError={activeErrorHandler}>
+          <SuperChart
+            chartType={ChartKeys.BUGGY}
+            width="200"
+            height="200"
+            disableErrorBoundary
+            onErrorBoundary={inactiveErrorHandler}
+          />
+        </ErrorBoundary>,
+      );
+
+      return promiseTimeout(() => {
+        expect(activeErrorHandler).toHaveBeenCalledTimes(1);
+        expect(inactiveErrorHandler).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 
   describe('supports multiple way of specifying chartProps', () => {
-    it('chartProps is instanceof ChartProps', done => {
+    it('chartProps is instanceof ChartProps', () => {
       const wrapper = mount(
         <SuperChart
           chartType={ChartKeys.DILIGENT}
           chartProps={new ChartProps({ width: 20, height: 20 })}
         />,
       );
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        expect(
-          wrapper
-            .render()
-            .find('span.dimension')
-            .text(),
-        ).toEqual('20x20');
-        done();
-      }, 0);
+        expectDimension(wrapper, 20, 20);
+      });
     });
-    it('chartProps is ChartPropsConfig', done => {
+    it('chartProps is ChartPropsConfig', () => {
       const wrapper = mount(
         <SuperChart chartType={ChartKeys.DILIGENT} chartProps={{ width: 201, height: 202 }} />,
       );
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        expect(
-          wrapper
-            .render()
-            .find('span.dimension')
-            .text(),
-        ).toEqual('201x202');
-        done();
-      }, 0);
+        expectDimension(wrapper, 201, 202);
+      });
     });
-    it('fields of chartProps are listed as props of SuperChart', done => {
+    it('fields of chartProps are listed as props of SuperChart', () => {
       const wrapper = mount(<SuperChart chartType={ChartKeys.DILIGENT} width={101} height={118} />);
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        expect(
-          wrapper
-            .render()
-            .find('span.dimension')
-            .text(),
-        ).toEqual('101x118');
-        done();
-      }, 0);
+        expectDimension(wrapper, 101, 118);
+      });
     });
   });
 
   describe('supports dynamic width and/or height', () => {
-    it('works with width and height that are numbers', done => {
+    it('works with width and height that are numbers', () => {
       const wrapper = mount(<SuperChart chartType={ChartKeys.DILIGENT} width={100} height={100} />);
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        expect(
-          wrapper
-            .render()
-            .find('span.dimension')
-            .text(),
-        ).toEqual('100x100');
-        done();
-      }, 0);
+        expectDimension(wrapper, 100, 100);
+      });
     });
-    it('works when width and height are percent', done => {
+    it('works when width and height are percent', () => {
       const wrapper = mount(
         <SuperChart chartType={ChartKeys.DILIGENT} debounceTime={1} width="100%" height="100%" />,
       );
       triggerResizeObserver();
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        expect(
-          wrapper
-            .render()
-            .find('span.dimension')
-            .text(),
-        ).toEqual('300x300');
-        done();
+        expectDimension(wrapper, 300, 300);
       }, 100);
     });
-    it('works when only width is percent', done => {
+    it('works when only width is percent', () => {
       const wrapper = mount(
         <SuperChart chartType={ChartKeys.DILIGENT} debounceTime={1} width="50%" height="125" />,
       );
       triggerResizeObserver();
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        expect(
-          wrapper
-            .render()
-            .find('span.dimension')
-            .text(),
-        ).toEqual('150x125');
-        done();
+        expectDimension(wrapper, 150, 125);
       }, 100);
     });
-    it('works when only height is percent', done => {
+    it('works when only height is percent', () => {
       const wrapper = mount(
         <SuperChart chartType={ChartKeys.DILIGENT} debounceTime={1} width="50" height="25%" />,
       );
       triggerResizeObserver();
-      setTimeout(() => {
+
+      return promiseTimeout(() => {
         expect(wrapper.render().find('div.test-component')).toHaveLength(1);
-        expect(
-          wrapper
-            .render()
-            .find('span.dimension')
-            .text(),
-        ).toEqual('50x75');
-        done();
+        expectDimension(wrapper, 50, 75);
+      }, 100);
+    });
+    it('works when width and height are not specified', () => {
+      const wrapper = mount(<SuperChart chartType={ChartKeys.DILIGENT} debounceTime={1} />);
+      triggerResizeObserver();
+
+      return promiseTimeout(() => {
+        expect(wrapper.render().find('div.test-component')).toHaveLength(1);
+        expectDimension(wrapper, 300, 400);
       }, 100);
     });
   });

--- a/packages/superset-ui-chart/test/components/SuperChartShell.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChartShell.test.tsx
@@ -7,6 +7,7 @@ jest.mock('resize-observer-polyfill');
 import { triggerResizeObserver } from 'resize-observer-polyfill';
 import ErrorBoundary from 'react-error-boundary';
 import { ChartProps, SuperChart } from '../../src';
+import RealSuperChart from '../../src/components/SuperChart';
 import { ChartKeys, DiligentChartPlugin, BuggyChartPlugin } from './MockChartPlugins';
 import promiseTimeout from './promiseTimeout';
 
@@ -34,13 +35,13 @@ describe('SuperChart', () => {
 
   describe('includes ErrorBoundary', () => {
     it('renders default FallbackComponent', () => {
-      jest.spyOn(SuperChart.defaultProps, 'FallbackComponent');
+      jest.spyOn(RealSuperChart.defaultProps, 'FallbackComponent');
       const wrapper = mount(<SuperChart chartType={ChartKeys.BUGGY} width="200" height="200" />);
       const renderedWrapper = wrapper.render();
 
       return promiseTimeout(() => {
         expect(renderedWrapper.find('div.test-component')).toHaveLength(0);
-        expect(SuperChart.defaultProps.FallbackComponent).toHaveBeenCalledTimes(1);
+        expect(RealSuperChart.defaultProps.FallbackComponent).toHaveBeenCalledTimes(1);
       }, 100);
     });
     it('renders custom FallbackComponent', () => {

--- a/packages/superset-ui-chart/test/components/SuperChartShell.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChartShell.test.tsx
@@ -14,7 +14,7 @@ function expectDimension(wrapper: ReactWrapper, width: number, height: number) {
   expect(
     wrapper
       .render()
-      .find('span.dimension')
+      .find('.dimension')
       .text(),
   ).toEqual([width, height].join('x'));
 }

--- a/packages/superset-ui-chart/test/components/promiseTimeout.tsx
+++ b/packages/superset-ui-chart/test/components/promiseTimeout.tsx
@@ -1,3 +1,4 @@
+/** setTimeout that returns a promise */
 export default function promiseTimeout(
   /** A function to be executed after the timer expires. */
   func: Function,

--- a/packages/superset-ui-chart/test/components/promiseTimeout.tsx
+++ b/packages/superset-ui-chart/test/components/promiseTimeout.tsx
@@ -1,0 +1,12 @@
+export default function promiseTimeout(
+  /** A function to be executed after the timer expires. */
+  func: Function,
+  /** The time, in milliseconds (thousandths of a second), the timer should wait before the specified function or code is executed. If this parameter is omitted, a value of 0 is used, meaning execute "immediately", or more accurately, as soon as possible.  */
+  delay?: number,
+) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(func());
+    }, delay);
+  });
+}

--- a/packages/superset-ui-chart/types/@vx/responsive/index.d.ts
+++ b/packages/superset-ui-chart/types/@vx/responsive/index.d.ts
@@ -1,0 +1,70 @@
+declare module '@vx/responsive' {
+  import React from 'react';
+
+  export const ScaleSVG: React.ComponentType<{
+    children: React.ReactNode;
+    width: number | string;
+    height: number | string;
+    xOrigin?: number | string;
+    yOrigin?: number | string;
+    preserveAspectRatio?: string;
+    innerRef?: () => void | string;
+  }>;
+
+  export interface ParentSizeState {
+    width: number;
+    height: number;
+    top: number;
+    left: number;
+  }
+
+  export const ParentSize: React.ComponentClass<
+    {
+      className?: string;
+      children: (renderProps: {
+        width: number;
+        height: number;
+        top: number;
+        left: number;
+        ref: HTMLElement;
+        resize: (state: ParentSizeState) => void;
+      }) => React.ReactNode;
+      debounceTime?: number;
+    },
+    ParentSizeState
+  >;
+
+  export interface WithParentSizeProps {
+    parentWidth: number;
+    parentHeight: number;
+  }
+
+  export function withParentSize<T extends {}>(
+    BaseComponent: React.ComponentType<T>,
+  ): React.ComponentClass<
+    {
+      debounceTime?: number;
+    } & T,
+    {
+      parentWidth: number | null;
+      parentHeight: number | null;
+    }
+  >;
+
+  export interface WithScreenSizeProps {
+    screeWidth: number;
+    screenHeight: number;
+  }
+
+  export function withScreenSize<T extends {}>(
+    BaseComponent: React.ComponentType<T>,
+  ): React.ComponentClass<
+    {
+      windowResizeDebounceTime?: number;
+    } & T,
+    {
+      screenWidth: number | null;
+      screenHeight: number | null;
+    }
+  >;
+}

--- a/packages/superset-ui-demo/.storybook/config.js
+++ b/packages/superset-ui-demo/.storybook/config.js
@@ -6,6 +6,7 @@ addParameters({
     addonPanelInRight: false,
     enableShortcuts: false,
     goFullScreen: false,
+    hierarchyRootSeparator: null,
     hierarchySeparator: /\|/,
     selectedAddonPanel: undefined, // The order of addons in the "Addon panel" is the same as you import them in 'addons.js'. The first panel will be opened by default as you run Storybook
     showAddonPanel: true,

--- a/packages/superset-ui-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-demo/.storybook/webpack.config.js
@@ -7,6 +7,11 @@ module.exports = async ({ config }) => {
         '@babel/preset-react',
         '@babel/preset-typescript',
       ],
+      plugins: [
+        '@babel/plugin-proposal-object-rest-spread',
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-syntax-dynamic-import',
+      ],
     },
     test: /\.tsx?$/,
     exclude: /node_modules/,

--- a/packages/superset-ui-demo/storybook/stories/superset-ui-chart/SuperChartStories.tsx
+++ b/packages/superset-ui-demo/storybook/stories/superset-ui-chart/SuperChartStories.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { text } from '@storybook/addon-knobs';
+import { SuperChart, ChartProps } from '../../../../superset-ui-chart/src';
+import {
+  DiligentChartPlugin,
+  BuggyChartPlugin,
+  ChartKeys,
+} from '../../../../superset-ui-chart/test/components/MockChartPlugins';
+
+new DiligentChartPlugin().configure({ key: ChartKeys.DILIGENT }).register();
+new BuggyChartPlugin().configure({ key: ChartKeys.BUGGY }).register();
+
+export default [
+  {
+    renderStory: () => {
+      const width = text('Vis width', '50%');
+      const height = text('Vis height', '75%');
+
+      return (
+        <SuperChart
+          chartType={ChartKeys.DILIGENT}
+          width={width}
+          height={height}
+          formData={{ hi: 1 }}
+        />
+      );
+    },
+    storyName: 'Basic',
+    storyPath: '@superset-ui/chart|SuperChart',
+  },
+  {
+    renderStory: () => {
+      const width = text('Vis width', '500');
+      const height = text('Vis height', '300');
+
+      return (
+        <SuperChart
+          chartType={ChartKeys.DILIGENT}
+          chartProps={{
+            height: Number(height),
+            width: Number(width),
+          }}
+        />
+      );
+    },
+    storyName: 'passing ChartPropsConfig',
+    storyPath: '@superset-ui/chart|SuperChart',
+  },
+  {
+    renderStory: () => {
+      const width = text('Vis width', '500');
+      const height = text('Vis height', '300');
+
+      return (
+        <SuperChart
+          chartType={ChartKeys.DILIGENT}
+          chartProps={
+            new ChartProps({
+              height: Number(height),
+              width: Number(width),
+            })
+          }
+        />
+      );
+    },
+    storyName: 'passing ChartProps',
+    storyPath: '@superset-ui/chart|SuperChart',
+  },
+  {
+    renderStory: () => {
+      const width = text('Vis width', '500');
+      const height = text('Vis height', '300');
+
+      return (
+        <SuperChart
+          chartType={ChartKeys.BUGGY}
+          chartProps={
+            new ChartProps({
+              height: Number(height),
+              width: Number(width),
+            })
+          }
+        />
+      );
+    },
+    storyName: 'With error boundary',
+    storyPath: '@superset-ui/chart|SuperChart',
+  },
+];

--- a/packages/superset-ui-demo/storybook/stories/superset-ui-chart/index.ts
+++ b/packages/superset-ui-demo/storybook/stories/superset-ui-chart/index.ts
@@ -1,5 +1,6 @@
 import ChartDataProviderStories from './ChartDataProviderStories';
+import SuperChartStories from './SuperChartStories';
 
 export default {
-  examples: [...ChartDataProviderStories],
+  examples: [...ChartDataProviderStories, ...SuperChartStories],
 };


### PR DESCRIPTION
## 🏠 Internal

* Rename former `SuperChart` class to `SuperChartCore`.
* Add `@vx/responsive` type declaration.

## 🏆 Enhancements

Create new class `SuperChart` that wraps `SuperChartCore`. 
Create another new class `SuperChartShell` to wrap `SuperChart` and provide backward-compatibility API. This can be removed in the upcoming breaking change.
`SuperChartShell` is exported as `SuperChart` and provide 100% backward-compatibility.

* Provide `ErrorBoundary`, which can be disabled if needed.
* Allow users to specify `width` `height` as `number` or dynamic value such as `100%`.
* Support spreading `chartProps` fields to top-level.

**Before**

This behavior is still supported, but less preferred.

```tsx
<SuperChart chartProps={new ChartProps({ width: 400, height: 400, formData: {a: 1} })} />
```

**Enhancement#1 Support plain object as `chartProps`**

This format was used in many Storybooks, although it will show error once the story is converted to typescript. With this PR, the pattern is now legit.

```tsx
<SuperChart chartProps={{ width: 400, height: 400, formData: {a: 1} }} />
```

**Enhancement#2 Can list the fields as props to `SuperChart`**

The new preferred way, which should be more natural. 

```tsx
<SuperChart width={400} height={400} formData={{a: 1}} />
```

See the storybook preview. Can use knobs to adjust `width` and `height`.

![image](https://user-images.githubusercontent.com/1659771/59467708-2f2cc080-8de5-11e9-8ee0-a1d2d3b04242.png)

This one shows error boundary.

![image](https://user-images.githubusercontent.com/1659771/59467760-49ff3500-8de5-11e9-94dc-b915044ea669.png)


