### PR TITLE
fix: wrong type for filters field

### DIFF
--- a/packages/superset-ui-chart/src/models/ChartProps.ts
+++ b/packages/superset-ui-chart/src/models/ChartProps.ts
@@ -9,7 +9,7 @@ type SnakeCaseDatasource = PlainObject;
 type CamelCaseFormData = PlainObject;
 type SnakeCaseFormData = PlainObject;
 export type QueryData = PlainObject;
-type Filters = any[];
+type Filters = PlainObject;
 type ChartPropsSelector = (c: ChartPropsConfig) => ChartProps;
 
 export interface ChartPropsConfig {
@@ -54,7 +54,7 @@ export default class ChartProps {
     const {
       annotationData = {},
       datasource = {},
-      filters = [],
+      filters = {},
       formData = {},
       hooks = {},
       onAddFilter = NOOP,


### PR DESCRIPTION
* type of `filters` field is an object, not array. The name `filters` is misleading because it is actually the initial values of `filter_box` and `table`