### PR TITLE
fix: move eslint disable comment in reactify test

### DIFF
--- a/packages/superset-ui-chart/test/components/reactify.test.tsx
+++ b/packages/superset-ui-chart/test/components/reactify.test.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-multi-comp */
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import { mount } from 'enzyme';
@@ -45,7 +47,7 @@ describe('reactify(renderFn)', () => {
       return <TheChart id="test" content={content} />;
     }
   }
-  /* eslint-disable-next-line react/no-multi-comp */
+
   class AnotherTestComponent extends React.PureComponent<{}, {}, any> {
     render() {
       return <TheChartWithWillUnmountHook id="another_test" />;


### PR DESCRIPTION
🐛 Bug Fix

For some reason `yarn lint` was still failing with this rule, breaking the build. I've disabled the rule for the whole file, which should be fine since it's a test
