### PR TITLE
fix(connection): disable caching when on an insecure connection

### DIFF
--- a/packages/superset-ui-connection/src/callApi/callApi.ts
+++ b/packages/superset-ui-connection/src/callApi/callApi.ts
@@ -28,7 +28,11 @@ export default function callApi({
     signal,
   };
 
-  if (method === 'GET' && CACHE_AVAILABLE) {
+  if (
+    method === 'GET' &&
+    CACHE_AVAILABLE &&
+    (self.location && self.location.protocol) === 'https:'
+  ) {
     return caches.open(CACHE_KEY).then(supersetCache =>
       supersetCache
         .match(url)

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -25,6 +25,14 @@ class CacheStorage {
       resolve(new Cache(key));
     });
   }
+  delete(key: string): Promise<boolean> {
+    const wasPresent = key in caches;
+    if (wasPresent) {
+      caches[key] = undefined;
+    }
+
+    return Promise.resolve(wasPresent);
+  }
 };
 
 global.caches = new CacheStorage();


### PR DESCRIPTION
When the page is served over an insecure connection, some browsers (Firefox) will disable the
CacheStorage API for security reasons and will throw an error when an attempt is made to use it.
Thus, do not even attempt to use CacheStorage on such connections in the first place.

🐛 Bug Fix

fix #193

🏠 Internal

Contrary to what I suggested in the bug, I had to put the test for the insecure connection into `callApi` itself to be able to test it.