### PR TITLE
fix: eslint issues

### DIFF
--- a/packages/superset-ui-chart-composition/src/tooltip/TooltipTable.tsx
+++ b/packages/superset-ui-chart-composition/src/tooltip/TooltipTable.tsx
@@ -29,7 +29,7 @@ export default class TooltipTable extends PureComponent<Props, {}> {
     return (
       <table className={className}>
         <tbody>
-          {data.map(({ key, keyColumn, keyStyle, valueColumn, valueStyle }, i) => (
+          {data.map(({ key, keyColumn, keyStyle, valueColumn, valueStyle }) => (
             <tr key={key}>
               <td style={keyStyle}>{keyColumn || key}</td>
               <td style={valueStyle ? { ...VALUE_CELL_STYLE, ...valueStyle } : VALUE_CELL_STYLE}>

--- a/packages/superset-ui-chart/src/types/Column.ts
+++ b/packages/superset-ui-chart/src/types/Column.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-vars */
+/* eslint-disable import/prefer-default-export */
 
 export enum ColumnType {
   DOUBLE = 'DOUBLE',

--- a/packages/superset-ui-chart/src/types/Datasource.ts
+++ b/packages/superset-ui-chart/src/types/Datasource.ts
@@ -1,3 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+
 import { Column } from './Column';
 import { QueryObjectMetric } from './Query';
 

--- a/packages/superset-ui-chart/src/types/Metric.ts
+++ b/packages/superset-ui-chart/src/types/Metric.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-vars */
+/* eslint-disable import/prefer-default-export */
 
 import { Column } from './Column';
 

--- a/packages/superset-ui-chart/test/clients/ChartClient.test.ts
+++ b/packages/superset-ui-chart/test/clients/ChartClient.test.ts
@@ -170,7 +170,8 @@ describe('ChartClient', () => {
         field1: 'abc',
         field2: 'def',
       });
-      expect(chartClient.loadDatasource('1__table')).resolves.toEqual({
+
+      return expect(chartClient.loadDatasource('1__table')).resolves.toEqual({
         field1: 'abc',
         field2: 'def',
       });


### PR DESCRIPTION
🐛 Bug Fix

Fix the following lint errors

```
/home/travis/build/apache-superset/superset-ui/packages/superset-ui-chart/src/types/Column.ts
  3:1  error  Prefer default export  import/prefer-default-export
/home/travis/build/apache-superset/superset-ui/packages/superset-ui-chart/src/types/Datasource.ts
  4:1  error  Prefer default export  import/prefer-default-export
/home/travis/build/apache-superset/superset-ui/packages/superset-ui-chart/src/types/Metric.ts
  7:1  error  Prefer default export  import/prefer-default-export
/home/travis/build/apache-superset/superset-ui/packages/superset-ui-chart/test/clients/ChartClient.test.ts
  173:7  error  Async assertions must be awaited or returned  jest/valid-expect
/home/travis/build/apache-superset/superset-ui/packages/superset-ui-chart-composition/src/tooltip/TooltipTable.tsx
  32:77  warning  'i' is defined but never used  no-unused-vars
  32:77  warning  'i' is defined but never used  @typescript-eslint/no-unused-vars
```
