### PR TITLE
feat: optimize functions for getting text dimension

### DIFF
--- a/packages/superset-ui-dimension/src/getMultipleTextDimensions.ts
+++ b/packages/superset-ui-dimension/src/getMultipleTextDimensions.ts
@@ -49,7 +49,7 @@ export default function getMultipleTextDimensions(
   // Remove svg node, if any
   if (svgNode && textNode) {
     // The nodes are added to the DOM briefly only to make getBBox works.
-    // (If not added to DOM getBBox will always return 0,0.)
+    // (If not added to DOM getBBox will always return 0x0.)
     // After that the svg nodes are not needed.
     // We delay its removal in case there are subsequent calls to this function
     // that can reuse the svg nodes.

--- a/packages/superset-ui-dimension/src/getMultipleTextDimensions.ts
+++ b/packages/superset-ui-dimension/src/getMultipleTextDimensions.ts
@@ -1,6 +1,6 @@
 import { TextStyle, Dimension } from './types';
 import createTextNode from './svg/createTextNode';
-import createHiddenSvgNode from './svg/createHiddenSvgNode';
+import { createHiddenSvgNode, removeHiddenSvgNode } from './svg/createHiddenSvgNode';
 import getBBoxCeil from './svg/getBBoxCeil';
 
 /**
@@ -17,7 +17,7 @@ export default function getMultipleTextDimensions(
   },
   defaultDimension?: Dimension,
 ): Dimension[] {
-  const { texts, className, style, container = document.body } = input;
+  const { texts, className, style, container } = input;
 
   const cache = new Map<string, Dimension>();
   let textNode: SVGTextElement | undefined;
@@ -36,9 +36,8 @@ export default function getMultipleTextDimensions(
     // Lazy creation of text and svg nodes
     if (!textNode) {
       textNode = createTextNode({ className, style });
-      svgNode = createHiddenSvgNode();
+      svgNode = createHiddenSvgNode(container);
       svgNode.appendChild(textNode);
-      container.appendChild(svgNode);
     }
 
     // Update text and get dimension
@@ -51,8 +50,12 @@ export default function getMultipleTextDimensions(
   });
 
   // Remove svg node, if any
-  if (svgNode) {
-    container.removeChild(svgNode);
+  if (svgNode && textNode) {
+    setTimeout(() => {
+      svgNode!.removeChild(textNode!);
+      removeHiddenSvgNode(container);
+      // eslint-disable-next-line no-magic-numbers
+    }, 500);
   }
 
   return dimensions;

--- a/packages/superset-ui-dimension/src/getMultipleTextDimensions.ts
+++ b/packages/superset-ui-dimension/src/getMultipleTextDimensions.ts
@@ -1,0 +1,59 @@
+import { TextStyle, Dimension } from './types';
+import createTextNode from './svg/createTextNode';
+import createHiddenSvgNode from './svg/createHiddenSvgNode';
+import getBBoxCeil from './svg/getBBoxCeil';
+
+/**
+ * get dimensions of multiple texts with same style
+ * @param input
+ * @param defaultDimension
+ */
+export default function getMultipleTextDimensions(
+  input: {
+    className?: string;
+    container?: HTMLElement;
+    style?: TextStyle;
+    texts: string[];
+  },
+  defaultDimension?: Dimension,
+): Dimension[] {
+  const { texts, className, style, container = document.body } = input;
+
+  const cache = new Map<string, Dimension>();
+  let textNode: SVGTextElement | undefined;
+  let svgNode: SVGSVGElement | undefined;
+
+  const dimensions = texts.map(text => {
+    // Empty string
+    if (text.length === 0) {
+      return { height: 0, width: 0 };
+    }
+    // Check if this string has been computed already
+    if (cache.has(text)) {
+      return cache.get(text) as Dimension;
+    }
+
+    // Lazy creation of text and svg nodes
+    if (!textNode) {
+      textNode = createTextNode({ className, style });
+      svgNode = createHiddenSvgNode();
+      svgNode.appendChild(textNode);
+      container.appendChild(svgNode);
+    }
+
+    // Update text and get dimension
+    textNode.textContent = text;
+    const dimension = getBBoxCeil(textNode, defaultDimension);
+    // Store result to cache
+    cache.set(text, dimension);
+
+    return dimension;
+  });
+
+  // Remove svg node, if any
+  if (svgNode) {
+    container.removeChild(svgNode);
+  }
+
+  return dimensions;
+}

--- a/packages/superset-ui-dimension/src/getMultipleTextDimensions.ts
+++ b/packages/superset-ui-dimension/src/getMultipleTextDimensions.ts
@@ -1,7 +1,7 @@
 import { TextStyle, Dimension } from './types';
-import createTextNode from './svg/createTextNode';
-import { createHiddenSvgNode, removeHiddenSvgNode } from './svg/createHiddenSvgNode';
 import getBBoxCeil from './svg/getBBoxCeil';
+import { hiddenSvgFactory, textFactory } from './svg/factories';
+import updateTextNode from './svg/updateTextNode';
 
 /**
  * get dimensions of multiple texts with same style
@@ -35,13 +35,12 @@ export default function getMultipleTextDimensions(
 
     // Lazy creation of text and svg nodes
     if (!textNode) {
-      textNode = createTextNode({ className, style });
-      svgNode = createHiddenSvgNode(container);
-      svgNode.appendChild(textNode);
+      svgNode = hiddenSvgFactory.createInContainer(container);
+      textNode = textFactory.createInContainer(svgNode);
     }
 
     // Update text and get dimension
-    textNode.textContent = text;
+    updateTextNode(textNode, { className, style, text });
     const dimension = getBBoxCeil(textNode, defaultDimension);
     // Store result to cache
     cache.set(text, dimension);
@@ -52,8 +51,8 @@ export default function getMultipleTextDimensions(
   // Remove svg node, if any
   if (svgNode && textNode) {
     setTimeout(() => {
-      svgNode!.removeChild(textNode!);
-      removeHiddenSvgNode(container);
+      textFactory.removeFromContainer(svgNode);
+      hiddenSvgFactory.removeFromContainer(container);
       // eslint-disable-next-line no-magic-numbers
     }, 500);
   }

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -1,14 +1,7 @@
 import { TextStyle, Dimension } from './types';
-
-const SVG_NS = 'http://www.w3.org/2000/svg';
-const STYLE_FIELDS: (keyof TextStyle)[] = [
-  'font',
-  'fontWeight',
-  'fontStyle',
-  'fontSize',
-  'fontFamily',
-  'letterSpacing',
-];
+import createTextNode from './svg/createTextNode';
+import createHiddenSvgNode from './svg/createHiddenSvgNode';
+import getBBoxCeil from './svg/getBBoxCeil';
 
 export interface GetTextDimensionInput {
   className?: string;
@@ -17,39 +10,23 @@ export interface GetTextDimensionInput {
   text: string;
 }
 
-const DEFAULT_DIMENSION = { height: 20, width: 100 };
-
 export default function getTextDimension(
   input: GetTextDimensionInput,
-  defaultDimension: Dimension = DEFAULT_DIMENSION,
+  defaultDimension?: Dimension,
 ): Dimension {
-  const { text, className, style = {}, container = document.body } = input;
+  const { text, className, style, container = document.body } = input;
 
-  const textNode = document.createElementNS(SVG_NS, 'text');
-  textNode.textContent = text;
-
-  if (className !== undefined && className !== null) {
-    textNode.setAttribute('class', className);
+  // Empty string
+  if (text.length === 0) {
+    return { height: 0, width: 0 };
   }
 
-  STYLE_FIELDS.filter(
-    (field: keyof TextStyle) => style[field] !== undefined && style[field] !== null,
-  ).forEach((field: keyof TextStyle) => {
-    textNode.style[field] = `${style[field]}`;
-  });
+  const textNode = createTextNode({ className, style, text });
+  const svgNode = createHiddenSvgNode();
+  svgNode.appendChild(textNode);
+  container.appendChild(svgNode);
+  const dimension = getBBoxCeil(textNode, defaultDimension);
+  container.removeChild(svgNode);
 
-  const svg = document.createElementNS(SVG_NS, 'svg');
-  svg.style.position = 'absolute'; // so it won't disrupt page layout
-  svg.style.opacity = '0'; // and not visible
-  svg.style.pointerEvents = 'none'; // and not capturing mouse events
-  svg.appendChild(textNode);
-  container.appendChild(svg);
-
-  const bbox = textNode.getBBox ? textNode.getBBox() : defaultDimension;
-  container.removeChild(svg);
-
-  return {
-    height: Math.ceil(bbox.height),
-    width: Math.ceil(bbox.width),
-  };
+  return dimension;
 }

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -1,6 +1,6 @@
 import { TextStyle, Dimension } from './types';
 import createTextNode from './svg/createTextNode';
-import createHiddenSvgNode from './svg/createHiddenSvgNode';
+import { createHiddenSvgNode, removeHiddenSvgNode } from './svg/createHiddenSvgNode';
 import getBBoxCeil from './svg/getBBoxCeil';
 
 export interface GetTextDimensionInput {
@@ -14,7 +14,7 @@ export default function getTextDimension(
   input: GetTextDimensionInput,
   defaultDimension?: Dimension,
 ): Dimension {
-  const { text, className, style, container = document.body } = input;
+  const { text, className, style, container } = input;
 
   // Empty string
   if (text.length === 0) {
@@ -22,11 +22,15 @@ export default function getTextDimension(
   }
 
   const textNode = createTextNode({ className, style, text });
-  const svgNode = createHiddenSvgNode();
+  const svgNode = createHiddenSvgNode(container);
   svgNode.appendChild(textNode);
-  container.appendChild(svgNode);
   const dimension = getBBoxCeil(textNode, defaultDimension);
-  container.removeChild(svgNode);
+
+  setTimeout(() => {
+    svgNode.removeChild(textNode);
+    removeHiddenSvgNode(container);
+    // eslint-disable-next-line no-magic-numbers
+  }, 500);
 
   return dimension;
 }

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -1,7 +1,7 @@
 import { TextStyle, Dimension } from './types';
-import createTextNode from './svg/createTextNode';
-import { createHiddenSvgNode, removeHiddenSvgNode } from './svg/createHiddenSvgNode';
+import updateTextNode from './svg/updateTextNode';
 import getBBoxCeil from './svg/getBBoxCeil';
+import { hiddenSvgFactory, textFactory } from './svg/factories';
 
 export interface GetTextDimensionInput {
   className?: string;
@@ -21,14 +21,14 @@ export default function getTextDimension(
     return { height: 0, width: 0 };
   }
 
-  const textNode = createTextNode({ className, style, text });
-  const svgNode = createHiddenSvgNode(container);
-  svgNode.appendChild(textNode);
+  const svgNode = hiddenSvgFactory.createInContainer(container);
+  const textNode = textFactory.createInContainer(svgNode);
+  updateTextNode(textNode, { className, style, text });
   const dimension = getBBoxCeil(textNode, defaultDimension);
 
   setTimeout(() => {
-    svgNode.removeChild(textNode);
-    removeHiddenSvgNode(container);
+    textFactory.removeFromContainer(svgNode);
+    hiddenSvgFactory.removeFromContainer(container);
     // eslint-disable-next-line no-magic-numbers
   }, 500);
 

--- a/packages/superset-ui-dimension/src/getTextDimension.ts
+++ b/packages/superset-ui-dimension/src/getTextDimension.ts
@@ -26,6 +26,13 @@ export default function getTextDimension(
   updateTextNode(textNode, { className, style, text });
   const dimension = getBBoxCeil(textNode, defaultDimension);
 
+  // The nodes are added to the DOM briefly only to make getBBox works.
+  // (If not added to DOM getBBox will always return 0x0.)
+  // After that the svg nodes are not needed.
+  // We delay its removal in case there are subsequent calls to this function
+  // that can reuse the svg nodes.
+  // Experiments have shown that reusing existing nodes
+  // instead of deleting and adding new ones can save lot of time.
   setTimeout(() => {
     textFactory.removeFromContainer(svgNode);
     hiddenSvgFactory.removeFromContainer(container);

--- a/packages/superset-ui-dimension/src/index.ts
+++ b/packages/superset-ui-dimension/src/index.ts
@@ -1,4 +1,5 @@
 export { default as getTextDimension } from './getTextDimension';
+export { default as getMultipleTextDimensions } from './getMultipleTextDimensions';
 export { default as computeMaxFontSize } from './computeMaxFontSize';
 export { default as mergeMargin } from './mergeMargin';
 export { default as parseLength } from './parseLength';

--- a/packages/superset-ui-dimension/src/svg/LazyFactory.ts
+++ b/packages/superset-ui-dimension/src/svg/LazyFactory.ts
@@ -1,5 +1,5 @@
 export default class LazyFactory<T extends HTMLElement | SVGElement> {
-  private cache = new Map<
+  private activeNodes = new Map<
     HTMLElement | SVGElement,
     {
       counter: number;
@@ -14,8 +14,8 @@ export default class LazyFactory<T extends HTMLElement | SVGElement> {
   }
 
   createInContainer(container: HTMLElement | SVGElement = document.body) {
-    if (this.cache.has(container)) {
-      const entry = this.cache.get(container)!;
+    if (this.activeNodes.has(container)) {
+      const entry = this.activeNodes.get(container)!;
       entry.counter += 1;
 
       return entry.node;
@@ -23,18 +23,18 @@ export default class LazyFactory<T extends HTMLElement | SVGElement> {
 
     const node = this.factoryFn();
     container.appendChild(node);
-    this.cache.set(container, { counter: 1, node });
+    this.activeNodes.set(container, { counter: 1, node });
 
     return node;
   }
 
   removeFromContainer(container: HTMLElement | SVGElement = document.body) {
-    if (this.cache.has(container)) {
-      const entry = this.cache.get(container)!;
+    if (this.activeNodes.has(container)) {
+      const entry = this.activeNodes.get(container)!;
       entry.counter -= 1;
       if (entry.counter === 0) {
         container.removeChild(entry.node);
-        this.cache.delete(container);
+        this.activeNodes.delete(container);
       }
     }
   }

--- a/packages/superset-ui-dimension/src/svg/LazyFactory.ts
+++ b/packages/superset-ui-dimension/src/svg/LazyFactory.ts
@@ -1,0 +1,41 @@
+export default class LazyFactory<T extends HTMLElement | SVGElement> {
+  private cache = new Map<
+    HTMLElement | SVGElement,
+    {
+      counter: number;
+      node: T;
+    }
+  >();
+
+  private factoryFn: () => T;
+
+  constructor(factoryFn: () => T) {
+    this.factoryFn = factoryFn;
+  }
+
+  createInContainer(container: HTMLElement | SVGElement = document.body) {
+    if (this.cache.has(container)) {
+      const entry = this.cache.get(container)!;
+      entry.counter += 1;
+
+      return entry.node;
+    }
+
+    const node = this.factoryFn();
+    container.appendChild(node);
+    this.cache.set(container, { counter: 1, node });
+
+    return node;
+  }
+
+  removeFromContainer(container: HTMLElement | SVGElement = document.body) {
+    if (this.cache.has(container)) {
+      const entry = this.cache.get(container)!;
+      entry.counter -= 1;
+      if (entry.counter === 0) {
+        container.removeChild(entry.node);
+        this.cache.delete(container);
+      }
+    }
+  }
+}

--- a/packages/superset-ui-dimension/src/svg/constants.ts
+++ b/packages/superset-ui-dimension/src/svg/constants.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const SVG_NS = 'http://www.w3.org/2000/svg';

--- a/packages/superset-ui-dimension/src/svg/createHiddenSvgNode.ts
+++ b/packages/superset-ui-dimension/src/svg/createHiddenSvgNode.ts
@@ -1,39 +1,10 @@
 import { SVG_NS } from './constants';
 
-const cache = new Map<
-  HTMLElement,
-  {
-    counter: number;
-    svgNode: SVGSVGElement;
-  }
->();
-
-export function createHiddenSvgNode(container: HTMLElement = document.body) {
-  if (cache.has(container)) {
-    const entry = cache.get(container)!;
-    entry.counter += 1;
-
-    return entry.svgNode;
-  }
-
+export default function createHiddenSvgNode() {
   const svgNode = document.createElementNS(SVG_NS, 'svg');
   svgNode.style.position = 'absolute'; // so it won't disrupt page layout
   svgNode.style.opacity = '0'; // and not visible
   svgNode.style.pointerEvents = 'none'; // and not capturing mouse events
-  container.appendChild(svgNode);
-
-  cache.set(container, { counter: 1, svgNode });
 
   return svgNode;
-}
-
-export function removeHiddenSvgNode(container: HTMLElement = document.body) {
-  if (cache.has(container)) {
-    const entry = cache.get(container)!;
-    entry.counter -= 1;
-    if (entry.counter === 0) {
-      container.removeChild(entry.svgNode);
-      cache.delete(container);
-    }
-  }
 }

--- a/packages/superset-ui-dimension/src/svg/createHiddenSvgNode.ts
+++ b/packages/superset-ui-dimension/src/svg/createHiddenSvgNode.ts
@@ -1,10 +1,39 @@
 import { SVG_NS } from './constants';
 
-export default function createHiddenSvgNode() {
-  const svg = document.createElementNS(SVG_NS, 'svg');
-  svg.style.position = 'absolute'; // so it won't disrupt page layout
-  svg.style.opacity = '0'; // and not visible
-  svg.style.pointerEvents = 'none'; // and not capturing mouse events
+const cache = new Map<
+  HTMLElement,
+  {
+    counter: number;
+    svgNode: SVGSVGElement;
+  }
+>();
 
-  return svg;
+export function createHiddenSvgNode(container: HTMLElement = document.body) {
+  if (cache.has(container)) {
+    const entry = cache.get(container)!;
+    entry.counter += 1;
+
+    return entry.svgNode;
+  }
+
+  const svgNode = document.createElementNS(SVG_NS, 'svg');
+  svgNode.style.position = 'absolute'; // so it won't disrupt page layout
+  svgNode.style.opacity = '0'; // and not visible
+  svgNode.style.pointerEvents = 'none'; // and not capturing mouse events
+  container.appendChild(svgNode);
+
+  cache.set(container, { counter: 1, svgNode });
+
+  return svgNode;
+}
+
+export function removeHiddenSvgNode(container: HTMLElement = document.body) {
+  if (cache.has(container)) {
+    const entry = cache.get(container)!;
+    entry.counter -= 1;
+    if (entry.counter === 0) {
+      container.removeChild(entry.svgNode);
+      cache.delete(container);
+    }
+  }
 }

--- a/packages/superset-ui-dimension/src/svg/createHiddenSvgNode.ts
+++ b/packages/superset-ui-dimension/src/svg/createHiddenSvgNode.ts
@@ -1,0 +1,10 @@
+import { SVG_NS } from './constants';
+
+export default function createHiddenSvgNode() {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.style.position = 'absolute'; // so it won't disrupt page layout
+  svg.style.opacity = '0'; // and not visible
+  svg.style.pointerEvents = 'none'; // and not capturing mouse events
+
+  return svg;
+}

--- a/packages/superset-ui-dimension/src/svg/createTextNode.ts
+++ b/packages/superset-ui-dimension/src/svg/createTextNode.ts
@@ -1,38 +1,5 @@
-import { TextStyle } from '../types';
 import { SVG_NS } from './constants';
 
-const STYLE_FIELDS: (keyof TextStyle)[] = [
-  'font',
-  'fontWeight',
-  'fontStyle',
-  'fontSize',
-  'fontFamily',
-  'letterSpacing',
-];
-
-export default function createTextNode({
-  className,
-  style = {},
-  text,
-}: {
-  className?: string;
-  style?: TextStyle;
-  text?: string;
-} = {}) {
-  const textNode = document.createElementNS(SVG_NS, 'text');
-  if (typeof text !== 'undefined') {
-    textNode.textContent = text;
-  }
-
-  if (typeof className !== 'undefined' && className !== null) {
-    textNode.setAttribute('class', className);
-  }
-
-  STYLE_FIELDS.filter(
-    (field: keyof TextStyle) => style[field] !== undefined && style[field] !== null,
-  ).forEach((field: keyof TextStyle) => {
-    textNode.style[field] = `${style[field]}`;
-  });
-
-  return textNode;
+export default function createTextNode() {
+  return document.createElementNS(SVG_NS, 'text');
 }

--- a/packages/superset-ui-dimension/src/svg/createTextNode.ts
+++ b/packages/superset-ui-dimension/src/svg/createTextNode.ts
@@ -1,0 +1,38 @@
+import { TextStyle } from '../types';
+import { SVG_NS } from './constants';
+
+const STYLE_FIELDS: (keyof TextStyle)[] = [
+  'font',
+  'fontWeight',
+  'fontStyle',
+  'fontSize',
+  'fontFamily',
+  'letterSpacing',
+];
+
+export default function createTextNode({
+  className,
+  style = {},
+  text,
+}: {
+  className?: string;
+  style?: TextStyle;
+  text?: string;
+} = {}) {
+  const textNode = document.createElementNS(SVG_NS, 'text');
+  if (typeof text !== 'undefined') {
+    textNode.textContent = text;
+  }
+
+  if (typeof className !== 'undefined' && className !== null) {
+    textNode.setAttribute('class', className);
+  }
+
+  STYLE_FIELDS.filter(
+    (field: keyof TextStyle) => style[field] !== undefined && style[field] !== null,
+  ).forEach((field: keyof TextStyle) => {
+    textNode.style[field] = `${style[field]}`;
+  });
+
+  return textNode;
+}

--- a/packages/superset-ui-dimension/src/svg/factories.ts
+++ b/packages/superset-ui-dimension/src/svg/factories.ts
@@ -1,0 +1,6 @@
+import LazyFactory from './LazyFactory';
+import createHiddenSvgNode from './createHiddenSvgNode';
+import createTextNode from './createTextNode';
+
+export const hiddenSvgFactory = new LazyFactory(createHiddenSvgNode);
+export const textFactory = new LazyFactory(createTextNode);

--- a/packages/superset-ui-dimension/src/svg/getBBoxCeil.ts
+++ b/packages/superset-ui-dimension/src/svg/getBBoxCeil.ts
@@ -1,0 +1,15 @@
+import { Dimension } from '../types';
+
+const DEFAULT_DIMENSION = { height: 20, width: 100 };
+
+export default function getBBoxCeil(
+  node: SVGGraphicsElement,
+  defaultDimension: Dimension = DEFAULT_DIMENSION,
+) {
+  const { width, height } = node.getBBox ? node.getBBox() : defaultDimension;
+
+  return {
+    height: Math.ceil(height),
+    width: Math.ceil(width),
+  };
+}

--- a/packages/superset-ui-dimension/src/svg/updateTextNode.ts
+++ b/packages/superset-ui-dimension/src/svg/updateTextNode.ts
@@ -1,0 +1,47 @@
+import { TextStyle } from '../types';
+
+const STYLE_FIELDS: (keyof TextStyle)[] = [
+  'font',
+  'fontWeight',
+  'fontStyle',
+  'fontSize',
+  'fontFamily',
+  'letterSpacing',
+];
+
+export default function updateTextNode(
+  node: SVGTextElement,
+  {
+    className,
+    style = {},
+    text,
+  }: {
+    className?: string;
+    style?: TextStyle;
+    text?: string;
+  } = {},
+) {
+  const textNode = node;
+
+  if (textNode.textContent !== text) {
+    textNode.textContent = typeof text === 'undefined' ? null : text;
+  }
+  if (textNode.getAttribute('class') !== className) {
+    textNode.setAttribute('class', className || '');
+  }
+
+  // clear style
+  STYLE_FIELDS.forEach((field: keyof TextStyle) => {
+    textNode.style[field] = null;
+  });
+
+  // apply new style
+  // Note that the font field will auto-populate other font fields when applicable.
+  STYLE_FIELDS.filter(
+    (field: keyof TextStyle) => typeof style[field] !== 'undefined' && style[field] !== null,
+  ).forEach((field: keyof TextStyle) => {
+    textNode.style[field] = `${style[field]}`;
+  });
+
+  return textNode;
+}

--- a/packages/superset-ui-dimension/test/computeMaxFontSize.test.ts
+++ b/packages/superset-ui-dimension/test/computeMaxFontSize.test.ts
@@ -1,20 +1,10 @@
 import { computeMaxFontSize } from '../src/index';
-import addDummyFill from './addDummyFill';
+import { addDummyFill, removeDummyFill } from './getBBoxDummyFill';
 
 describe('computeMaxFontSize(input)', () => {
   describe('returns dimension of the given text', () => {
-    let originalFn: () => DOMRect;
-
-    beforeEach(() => {
-      // @ts-ignore - fix jsdom
-      originalFn = SVGElement.prototype.getBBox;
-      addDummyFill();
-    });
-
-    afterEach(() => {
-      // @ts-ignore - fix jsdom
-      SVGElement.prototype.getBBox = originalFn;
-    });
+    beforeEach(addDummyFill);
+    afterEach(removeDummyFill);
 
     it('requires either idealFontSize or maxHeight', () => {
       expect(() =>

--- a/packages/superset-ui-dimension/test/getBBoxDummyFill.ts
+++ b/packages/superset-ui-dimension/test/getBBoxDummyFill.ts
@@ -1,17 +1,28 @@
-export const SAMPLE_TEXT = 'dummy text. does not really matter';
+let originalFn: () => DOMRect;
 
-export default function addDummyFill() {
+const textToWidth = {
+  paris: 200,
+  tokyo: 300,
+  beijing: 400,
+};
+
+export const SAMPLE_TEXT = Object.keys(textToWidth);
+
+export function addDummyFill() {
+  // @ts-ignore - fix jsdom
+  originalFn = SVGElement.prototype.getBBox;
+
   // @ts-ignore - fix jsdom
   SVGElement.prototype.getBBox = function getBBox() {
-    let width = 200;
+    let width = textToWidth[this.textContent] || 200;
     let height = 20;
 
     if (this.getAttribute('class') === 'test-class') {
-      width = 100;
+      width /= 2;
     }
 
     if (this.style.fontFamily === 'Lobster') {
-      width = 250;
+      width *= 1.25;
     }
 
     if (this.style.fontSize) {
@@ -44,4 +55,9 @@ export default function addDummyFill() {
       bottom: 0,
     };
   };
+}
+
+export function removeDummyFill() {
+  // @ts-ignore - fix jsdom
+  SVGElement.prototype.getBBox = originalFn;
 }

--- a/packages/superset-ui-dimension/test/getMultipleTextDimensions.test.ts
+++ b/packages/superset-ui-dimension/test/getMultipleTextDimensions.test.ts
@@ -1,5 +1,6 @@
 import { getMultipleTextDimensions } from '../src/index';
 import { addDummyFill, removeDummyFill, SAMPLE_TEXT } from './getBBoxDummyFill';
+import promiseTimeout from '../../superset-ui-chart/test/components/promiseTimeout';
 
 describe('getTextDimension(input)', () => {
   describe('returns dimension of the given text', () => {
@@ -189,5 +190,16 @@ describe('getTextDimension(input)', () => {
         },
       ]);
     });
+  });
+  it('cleans up DOM', () => {
+    getMultipleTextDimensions({
+      texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[1]],
+    });
+
+    expect(document.querySelectorAll('svg')).toHaveLength(1);
+
+    return promiseTimeout(() => {
+      expect(document.querySelector('svg')).toBeNull();
+    }, 600);
   });
 });

--- a/packages/superset-ui-dimension/test/getMultipleTextDimensions.test.ts
+++ b/packages/superset-ui-dimension/test/getMultipleTextDimensions.test.ts
@@ -1,0 +1,193 @@
+import { getMultipleTextDimensions } from '../src/index';
+import { addDummyFill, removeDummyFill, SAMPLE_TEXT } from './getBBoxDummyFill';
+
+describe('getTextDimension(input)', () => {
+  describe('returns dimension of the given text', () => {
+    beforeEach(addDummyFill);
+    afterEach(removeDummyFill);
+
+    it('takes an array of text as argument', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[1], ''],
+        }),
+      ).toEqual([
+        {
+          height: 20,
+          width: 200,
+        },
+        {
+          height: 20,
+          width: 300,
+        },
+        {
+          height: 0,
+          width: 0,
+        },
+      ]);
+    });
+    it('handles empty text', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: ['', ''],
+        }),
+      ).toEqual([
+        {
+          height: 0,
+          width: 0,
+        },
+        {
+          height: 0,
+          width: 0,
+        },
+      ]);
+    });
+    it('handles duplicate text', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[0]],
+        }),
+      ).toEqual([
+        {
+          height: 20,
+          width: 200,
+        },
+        {
+          height: 20,
+          width: 200,
+        },
+      ]);
+    });
+    it('accepts provided class via className', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[1]],
+          className: 'test-class',
+        }),
+      ).toEqual([
+        {
+          height: 20,
+          width: 100,
+        },
+        {
+          height: 20,
+          width: 150,
+        },
+      ]);
+    });
+    it('accepts provided style.font', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[1]],
+          style: {
+            font: 'italic 700 30px Lobster',
+          },
+        }),
+      ).toEqual([
+        {
+          height: 30, // 20 * (30/20) [fontSize=30]
+          width: 1125, // 200 * 1.25 [fontFamily=Lobster] * (30/20) [fontSize=30] * 1.5 [fontStyle=italic] * 2 [fontWeight=700]
+        },
+        {
+          height: 30,
+          width: 1688, // 300 * 1.25 [fontFamily=Lobster] * (30/20) [fontSize=30] * 1.5 [fontStyle=italic] * 2 [fontWeight=700]
+        },
+      ]);
+    });
+    it('accepts provided style.fontFamily', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[1]],
+          style: {
+            fontFamily: 'Lobster',
+          },
+        }),
+      ).toEqual([
+        {
+          height: 20,
+          width: 250, // 200 * 1.25 [fontFamily=Lobster]
+        },
+        {
+          height: 20,
+          width: 375, // 300 * 1.25 [fontFamily=Lobster]
+        },
+      ]);
+    });
+    it('accepts provided style.fontSize', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[1]],
+          style: {
+            fontSize: '40px',
+          },
+        }),
+      ).toEqual([
+        {
+          height: 40, // 20 [baseHeight] * (40/20) [fontSize=40]
+          width: 400, // 200 [baseWidth] * (40/20) [fontSize=40]
+        },
+        {
+          height: 40,
+          width: 600, // 300 [baseWidth] * (40/20) [fontSize=40]
+        },
+      ]);
+    });
+    it('accepts provided style.fontStyle', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[1]],
+          style: {
+            fontStyle: 'italic',
+          },
+        }),
+      ).toEqual([
+        {
+          height: 20,
+          width: 300, // 200 [baseWidth] * 1.5 [fontStyle=italic]
+        },
+        {
+          height: 20,
+          width: 450, // 300 [baseWidth] * 1.5 [fontStyle=italic]
+        },
+      ]);
+    });
+    it('accepts provided style.fontWeight', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[1]],
+          style: {
+            fontWeight: 700,
+          },
+        }),
+      ).toEqual([
+        {
+          height: 20,
+          width: 400, // 200 [baseWidth] * 2 [fontWeight=700]
+        },
+        {
+          height: 20,
+          width: 600, // 300 [baseWidth] * 2 [fontWeight=700]
+        },
+      ]);
+    });
+    it('accepts provided style.letterSpacing', () => {
+      expect(
+        getMultipleTextDimensions({
+          texts: [SAMPLE_TEXT[0], SAMPLE_TEXT[1]],
+          style: {
+            letterSpacing: '1.1',
+          },
+        }),
+      ).toEqual([
+        {
+          height: 20,
+          width: 221, // Ceiling(200 [baseWidth] * 1.1 [letterSpacing=1.1])
+        },
+        {
+          height: 20,
+          width: 330, // Ceiling(300 [baseWidth] * 1.1 [letterSpacing=1.1])
+        },
+      ]);
+    });
+  });
+});

--- a/packages/superset-ui-dimension/test/getTextDimension.test.ts
+++ b/packages/superset-ui-dimension/test/getTextDimension.test.ts
@@ -1,5 +1,6 @@
 import { getTextDimension } from '../src/index';
 import { addDummyFill, removeDummyFill, SAMPLE_TEXT } from './getBBoxDummyFill';
+import promiseTimeout from '../../superset-ui-chart/test/components/promiseTimeout';
 
 describe('getTextDimension(input)', () => {
   describe('returns default dimension if getBBox() is not available', () => {
@@ -143,5 +144,16 @@ describe('getTextDimension(input)', () => {
         width: 0,
       });
     });
+  });
+  it('cleans up DOM', () => {
+    getTextDimension({
+      text: SAMPLE_TEXT[0],
+    });
+
+    expect(document.querySelectorAll('svg')).toHaveLength(1);
+
+    return promiseTimeout(() => {
+      expect(document.querySelector('svg')).toBeNull();
+    }, 600);
   });
 });

--- a/packages/superset-ui-dimension/test/getTextDimension.test.ts
+++ b/packages/superset-ui-dimension/test/getTextDimension.test.ts
@@ -1,12 +1,12 @@
 import { getTextDimension } from '../src/index';
-import addDummyFill, { SAMPLE_TEXT } from './addDummyFill';
+import { addDummyFill, removeDummyFill, SAMPLE_TEXT } from './getBBoxDummyFill';
 
 describe('getTextDimension(input)', () => {
   describe('returns default dimension if getBBox() is not available', () => {
     it('returns default value for default dimension', () => {
       expect(
         getTextDimension({
-          text: SAMPLE_TEXT,
+          text: SAMPLE_TEXT[0],
         }),
       ).toEqual({
         height: 20,
@@ -17,7 +17,7 @@ describe('getTextDimension(input)', () => {
       expect(
         getTextDimension(
           {
-            text: SAMPLE_TEXT,
+            text: SAMPLE_TEXT[0],
           },
           {
             height: 30,
@@ -31,23 +31,13 @@ describe('getTextDimension(input)', () => {
     });
   });
   describe('returns dimension of the given text', () => {
-    let originalFn: () => DOMRect;
-
-    beforeEach(() => {
-      // @ts-ignore - fix jsdom
-      originalFn = SVGElement.prototype.getBBox;
-      addDummyFill();
-    });
-
-    afterEach(() => {
-      // @ts-ignore - fix jsdom
-      SVGElement.prototype.getBBox = originalFn;
-    });
+    beforeEach(addDummyFill);
+    afterEach(removeDummyFill);
 
     it('takes text as argument', () => {
       expect(
         getTextDimension({
-          text: SAMPLE_TEXT,
+          text: SAMPLE_TEXT[0],
         }),
       ).toEqual({
         height: 20,
@@ -57,7 +47,7 @@ describe('getTextDimension(input)', () => {
     it('accepts provided class via className', () => {
       expect(
         getTextDimension({
-          text: SAMPLE_TEXT,
+          text: SAMPLE_TEXT[0],
           className: 'test-class',
         }),
       ).toEqual({
@@ -68,7 +58,7 @@ describe('getTextDimension(input)', () => {
     it('accepts provided style.font', () => {
       expect(
         getTextDimension({
-          text: SAMPLE_TEXT,
+          text: SAMPLE_TEXT[0],
           style: {
             font: 'italic 700 30px Lobster',
           },
@@ -81,7 +71,7 @@ describe('getTextDimension(input)', () => {
     it('accepts provided style.fontFamily', () => {
       expect(
         getTextDimension({
-          text: SAMPLE_TEXT,
+          text: SAMPLE_TEXT[0],
           style: {
             fontFamily: 'Lobster',
           },
@@ -94,7 +84,7 @@ describe('getTextDimension(input)', () => {
     it('accepts provided style.fontSize', () => {
       expect(
         getTextDimension({
-          text: SAMPLE_TEXT,
+          text: SAMPLE_TEXT[0],
           style: {
             fontSize: '40px',
           },
@@ -107,7 +97,7 @@ describe('getTextDimension(input)', () => {
     it('accepts provided style.fontStyle', () => {
       expect(
         getTextDimension({
-          text: SAMPLE_TEXT,
+          text: SAMPLE_TEXT[0],
           style: {
             fontStyle: 'italic',
           },
@@ -120,7 +110,7 @@ describe('getTextDimension(input)', () => {
     it('accepts provided style.fontWeight', () => {
       expect(
         getTextDimension({
-          text: SAMPLE_TEXT,
+          text: SAMPLE_TEXT[0],
           style: {
             fontWeight: 700,
           },
@@ -133,7 +123,7 @@ describe('getTextDimension(input)', () => {
     it('accepts provided style.letterSpacing', () => {
       expect(
         getTextDimension({
-          text: SAMPLE_TEXT,
+          text: SAMPLE_TEXT[0],
           style: {
             letterSpacing: '1.1',
           },
@@ -141,6 +131,16 @@ describe('getTextDimension(input)', () => {
       ).toEqual({
         height: 20,
         width: 221, // Ceiling(200 [baseWidth] * 1.1 [letterSpacing=1.1])
+      });
+    });
+    it('handle empty text', () => {
+      expect(
+        getTextDimension({
+          text: '',
+        }),
+      ).toEqual({
+        height: 0,
+        width: 0,
       });
     });
   });

--- a/packages/superset-ui-dimension/test/svg/LazyFactory.test.ts
+++ b/packages/superset-ui-dimension/test/svg/LazyFactory.test.ts
@@ -1,0 +1,49 @@
+import LazyFactory from '../../src/svg/LazyFactory';
+
+describe('LazyFactory', () => {
+  describe('createInContainer()', () => {
+    it('creates node in the specified container', () => {
+      const factory = new LazyFactory(() => document.createElement('div'));
+      const div = factory.createInContainer();
+      const innerDiv = factory.createInContainer(div);
+      expect(div.parentNode).toEqual(document.body);
+      expect(innerDiv.parentNode).toEqual(div);
+    });
+    it('reuses existing', () => {
+      const factoryFn = jest.fn(() => document.createElement('div'));
+      const factory = new LazyFactory(factoryFn);
+      const div1 = factory.createInContainer();
+      const div2 = factory.createInContainer();
+      expect(div1).toBe(div2);
+      expect(factoryFn).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('removeFromContainer', () => {
+    it('removes node from container', () => {
+      const factory = new LazyFactory(() => document.createElement('div'));
+      const div = factory.createInContainer();
+      const innerDiv = factory.createInContainer(div);
+      expect(div.parentNode).toEqual(document.body);
+      expect(innerDiv.parentNode).toEqual(div);
+      factory.removeFromContainer();
+      factory.removeFromContainer(div);
+      expect(div.parentNode).toBeNull();
+      expect(innerDiv.parentNode).toBeNull();
+    });
+    it('does not remove if others are using', () => {
+      const factory = new LazyFactory(() => document.createElement('div'));
+      const div1 = factory.createInContainer();
+      factory.createInContainer();
+      factory.removeFromContainer();
+      expect(div1.parentNode).toEqual(document.body);
+      factory.removeFromContainer();
+      expect(div1.parentNode).toBeNull();
+    });
+    it('does not crash if try to remove already removed node', () => {
+      const factory = new LazyFactory(() => document.createElement('div'));
+      factory.createInContainer();
+      factory.removeFromContainer();
+      expect(() => factory.removeFromContainer()).not.toThrow();
+    });
+  });
+});

--- a/packages/superset-ui-dimension/test/svg/getBBoxCeil.test.ts
+++ b/packages/superset-ui-dimension/test/svg/getBBoxCeil.test.ts
@@ -1,0 +1,39 @@
+import getBBoxCeil from '../../src/svg/getBBoxCeil';
+import createTextNode from '../../src/svg/createTextNode';
+
+describe('getBBoxCeil(node, defaultDimension)', () => {
+  describe('returns default dimension if getBBox() is not available', () => {
+    it('returns default value for default dimension', () => {
+      expect(getBBoxCeil(createTextNode())).toEqual({
+        height: 20,
+        width: 100,
+      });
+    });
+    it('return specified value if specified', () => {
+      expect(
+        getBBoxCeil(createTextNode(), {
+          height: 30,
+          width: 400,
+        }),
+      ).toEqual({
+        height: 30,
+        width: 400,
+      });
+    });
+  });
+  describe('returns ceiling of the svg element', () => {
+    it('converts to ceiling if value is not integer', () => {
+      expect(getBBoxCeil(createTextNode(), { height: 10.6, width: 11.1 })).toEqual({
+        height: 11,
+        width: 12,
+      });
+    });
+
+    it('does nothing if value is integer', () => {
+      expect(getBBoxCeil(createTextNode())).toEqual({
+        height: 20,
+        width: 100,
+      });
+    });
+  });
+});

--- a/packages/superset-ui-dimension/test/svg/updateTextNode.test.ts
+++ b/packages/superset-ui-dimension/test/svg/updateTextNode.test.ts
@@ -1,0 +1,74 @@
+import updateTextNode from '../../src/svg/updateTextNode';
+import createTextNode from '../../src/svg/createTextNode';
+
+describe('updateTextNode(node, options)', () => {
+  it('handles empty options', () => {
+    const node = updateTextNode(createTextNode());
+    expect(node.getAttribute('class')).toEqual('');
+    expect(node.style.font).toEqual('');
+    expect(node.style.fontWeight).toEqual('');
+    expect(node.style.fontSize).toEqual('');
+    expect(node.style.fontStyle).toEqual('');
+    expect(node.style.fontFamily).toEqual('');
+    expect(node.style.letterSpacing).toEqual('');
+    expect(node.textContent).toEqual('');
+  });
+
+  it('handles setting class', () => {
+    const node = updateTextNode(createTextNode(), { className: 'abc' });
+    expect(node.getAttribute('class')).toEqual('abc');
+    expect(node.style.font).toEqual('');
+    expect(node.style.fontWeight).toEqual('');
+    expect(node.style.fontSize).toEqual('');
+    expect(node.style.fontStyle).toEqual('');
+    expect(node.style.fontFamily).toEqual('');
+    expect(node.style.letterSpacing).toEqual('');
+    expect(node.textContent).toEqual('');
+  });
+
+  it('handles setting text', () => {
+    const node = updateTextNode(createTextNode(), { text: 'abc' });
+    expect(node.getAttribute('class')).toEqual('');
+    expect(node.style.font).toEqual('');
+    expect(node.style.fontWeight).toEqual('');
+    expect(node.style.fontSize).toEqual('');
+    expect(node.style.fontStyle).toEqual('');
+    expect(node.style.fontFamily).toEqual('');
+    expect(node.style.letterSpacing).toEqual('');
+    expect(node.textContent).toEqual('abc');
+  });
+
+  it('handles setting font', () => {
+    const node = updateTextNode(createTextNode(), {
+      style: {
+        font: 'italic 30px Lobster 700',
+      },
+    });
+    expect(node.getAttribute('class')).toEqual('');
+    expect(node.style.fontWeight).toEqual('700');
+    expect(node.style.fontSize).toEqual('30px');
+    expect(node.style.fontStyle).toEqual('italic');
+    expect(node.style.fontFamily).toEqual('Lobster');
+    expect(node.style.letterSpacing).toEqual('');
+    expect(node.textContent).toEqual('');
+  });
+
+  it('handles setting specific font style', () => {
+    const node = updateTextNode(createTextNode(), {
+      style: {
+        fontFamily: 'Lobster',
+        fontStyle: 'italic',
+        fontWeight: '700',
+        fontSize: '30px',
+        letterSpacing: 1.1,
+      },
+    });
+    expect(node.getAttribute('class')).toEqual('');
+    expect(node.style.fontWeight).toEqual('700');
+    expect(node.style.fontSize).toEqual('30px');
+    expect(node.style.fontStyle).toEqual('italic');
+    expect(node.style.fontFamily).toEqual('Lobster');
+    expect(node.style.letterSpacing).toEqual('1.1');
+    expect(node.textContent).toEqual('');
+  });
+});


### PR DESCRIPTION
🏆 Enhancements

branching off from ideas in #173.

* Improve `getTextDimension` by lazy creation and deletion of the `svg` and `text` node to avoid creating multiple nodes and reusing existing one when applicable. 
* Add `getMultipleTextDimensions`  This function takes an array of text and compute dimensions in batch, reusing the text node and apply caching.
* The lazy creation and deletion is done via data structure `LazyFactory` that keeps counter of how many time a certain svg/text node is requested, hashed by container. Removal will decrease this counter and really remove the item when counter reaches 0.
* Both `getTextDimension` and `getMultipleTextDimensions` will leave the invisible nodes around for 500ms before removal to support reusability. 
