### PR TITLE
feat: allow reactify callbacks to access props

### DIFF
--- a/packages/superset-ui-chart/src/components/reactify.tsx
+++ b/packages/superset-ui-chart/src/components/reactify.tsx
@@ -53,7 +53,7 @@ export default function reactify<Props extends object>(
     componentWillUnmount() {
       this.container = undefined;
       if (callbacks && callbacks.componentWillUnmount) {
-        callbacks.componentWillUnmount();
+        callbacks.componentWillUnmount.bind(this)();
       }
     }
 


### PR DESCRIPTION
This is needed so that the callbacks passed into this component can perform actions based on props/state on the react component

@xtinec @kristw @williaster 
