### PR TITLE
feat: add Wrapper support and bounding box for dynamic width/height

### DIFF
--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import ErrorBoundary, { ErrorBoundaryProps, FallbackProps } from 'react-error-boundary';
-import { parseLength } from '@superset-ui/dimension';
+import { parseLength, Dimension } from '@superset-ui/dimension';
 import { ParentSize } from '@vx/responsive';
+import { createSelector } from 'reselect';
 import SuperChartCore, { Props as SuperChartCoreProps } from './SuperChartCore';
 import DefaultFallbackComponent from './FallbackComponent';
 import ChartProps, { ChartPropsConfig } from '../models/ChartProps';
@@ -13,16 +14,40 @@ const defaultProps = {
   width: '100%' as string | number,
 };
 
-export type FallbackPropsWithDimension = FallbackProps & { width?: number; height?: number };
+export type FallbackPropsWithDimension = FallbackProps & Partial<Dimension>;
+
+export type WrapperProps = Dimension & {
+  children: ReactNode;
+};
 
 export type Props = Omit<SuperChartCoreProps, 'chartProps'> &
   Omit<ChartPropsConfig, 'width' | 'height'> & {
+    /**
+     * Set this to true to disable error boundary built-in in SuperChart
+     * and let the error propagate to upper level
+     * and handle by yourself
+     */
     disableErrorBoundary?: boolean;
+    /** debounceTime to check for container resize */
     debounceTime?: number;
+    /** Component to render when there are unexpected errors */
     FallbackComponent?: React.ComponentType<FallbackPropsWithDimension>;
+    /** Event listener for unexpected errors from chart */
     onErrorBoundary?: ErrorBoundaryProps['onError'];
+    /** Chart width */
     height?: number | string;
+    /** Chart height */
     width?: number | string;
+    /**
+     * Component to wrap the actual chart
+     * after the dynamic width and height are determined.
+     * This can be useful for handling tooltip z-index, etc.
+     * e.g. <div style={{ position: 'fixed' }} />
+     * You cannot just wrap this same component outside of SuperChart
+     * when using dynamic width or height
+     * because it will clash with auto-sizing.
+     */
+    Wrapper?: React.ComponentType<WrapperProps>;
   };
 
 type PropsWithDefault = Props & Readonly<typeof defaultProps>;
@@ -36,6 +61,27 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
   core?: SuperChartCore | null;
 
   private createChartProps = ChartProps.createSelector();
+
+  private parseDimension = createSelector(
+    ({ inputWidth }: { inputWidth: string | number; inputHeight: string | number }) => inputWidth,
+    ({ inputHeight }) => inputHeight,
+    (inputWidth, inputHeight) => {
+      // Parse them in case they are % or 'auto'
+      const widthInfo = parseLength(inputWidth);
+      const heightInfo = parseLength(inputHeight);
+
+      const style = {
+        height: heightInfo.isDynamic ? '100%' : heightInfo.value,
+        width: widthInfo.isDynamic ? '100%' : widthInfo.value,
+      };
+      const BoundingBox =
+        widthInfo.isDynamic && heightInfo.isDynamic
+          ? React.Fragment
+          : ({ children }: { children: ReactNode }) => <div style={style}>{children}</div>;
+
+      return { BoundingBox, heightInfo, widthInfo };
+    },
+  );
 
   private setRef = (core: SuperChartCore | null) => {
     this.core = core;
@@ -54,26 +100,29 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
       disableErrorBoundary,
       FallbackComponent,
       onErrorBoundary,
+      Wrapper = React.Fragment,
       ...rest
     } = this.props as PropsWithDefault;
 
     const chart = (
-      <SuperChartCore
-        ref={this.setRef}
-        id={id}
-        className={className}
-        chartType={chartType}
-        chartProps={this.createChartProps({
-          ...rest,
-          height,
-          width,
-        })}
-        preTransformProps={preTransformProps}
-        overrideTransformProps={overrideTransformProps}
-        postTransformProps={postTransformProps}
-        onRenderSuccess={onRenderSuccess}
-        onRenderFailure={onRenderFailure}
-      />
+      <Wrapper width={width} height={height}>
+        <SuperChartCore
+          ref={this.setRef}
+          id={id}
+          className={className}
+          chartType={chartType}
+          chartProps={this.createChartProps({
+            ...rest,
+            height,
+            width,
+          })}
+          preTransformProps={preTransformProps}
+          overrideTransformProps={overrideTransformProps}
+          postTransformProps={postTransformProps}
+          onRenderSuccess={onRenderSuccess}
+          onRenderFailure={onRenderFailure}
+        />
+      </Wrapper>
     );
 
     // Include the error boundary by default unless it is specifically disabled.
@@ -94,25 +143,36 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
   render() {
     const { width: inputWidth, height: inputHeight } = this.props as PropsWithDefault;
 
-    // Parse them in case they are % or 'auto'
-    const widthInfo = parseLength(inputWidth);
-    const heightInfo = parseLength(inputHeight);
+    const { heightInfo, widthInfo, BoundingBox } = this.parseDimension({
+      inputHeight,
+      inputWidth,
+    });
 
     // If any of the dimension is dynamic, get parent's dimension
     if (widthInfo.isDynamic || heightInfo.isDynamic) {
       const { debounceTime } = this.props;
 
       return (
-        <ParentSize debounceTime={debounceTime}>
-          {({ width, height }) =>
-            width > 0 &&
-            height > 0 &&
-            this.renderChart(
-              widthInfo.isDynamic ? Math.floor(width * widthInfo.multiplier) : widthInfo.value,
-              heightInfo.isDynamic ? Math.floor(height * heightInfo.multiplier) : heightInfo.value,
-            )
-          }
-        </ParentSize>
+        // bounding box will ensure that when
+        // one dimension is not dynamic
+        // e.g. height = 300
+        // the auto size will be bound to that value
+        // instead of being 100% by default
+        // e.g. height: 300 instead of height: '100%'
+        <BoundingBox>
+          <ParentSize debounceTime={debounceTime}>
+            {({ width, height }) =>
+              width > 0 &&
+              height > 0 &&
+              this.renderChart(
+                widthInfo.isDynamic ? Math.floor(width * widthInfo.multiplier) : widthInfo.value,
+                heightInfo.isDynamic
+                  ? Math.floor(height * heightInfo.multiplier)
+                  : heightInfo.value,
+              )
+            }
+          </ParentSize>
+        </BoundingBox>
       );
     }
 

--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -70,12 +70,28 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
       const widthInfo = parseLength(width);
       const heightInfo = parseLength(height);
 
+      const boxHeight = heightInfo.isDynamic
+        ? // eslint-disable-next-line no-magic-numbers
+          `${heightInfo.multiplier * 100}%`
+        : heightInfo.value;
+      const boxWidth = widthInfo.isDynamic
+        ? // eslint-disable-next-line no-magic-numbers
+          `${widthInfo.multiplier * 100}%`
+        : widthInfo.value;
       const style = {
-        height: heightInfo.isDynamic ? '100%' : heightInfo.value,
-        width: widthInfo.isDynamic ? '100%' : widthInfo.value,
+        height: boxHeight,
+        width: boxWidth,
       };
+
+      // bounding box will ensure that when one dimension is not dynamic
+      // e.g. height = 300
+      // the auto size will be bound to that value instead of being 100% by default
+      // e.g. height: 300 instead of height: '100%'
       const BoundingBox =
-        widthInfo.isDynamic && heightInfo.isDynamic
+        widthInfo.isDynamic &&
+        heightInfo.isDynamic &&
+        widthInfo.multiplier === 1 &&
+        heightInfo.multiplier === 1
           ? React.Fragment
           : ({ children }: { children: ReactNode }) => <div style={style}>{children}</div>;
 
@@ -149,22 +165,14 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
       const { debounceTime } = this.props;
 
       return (
-        // bounding box will ensure that when
-        // one dimension is not dynamic
-        // e.g. height = 300
-        // the auto size will be bound to that value
-        // instead of being 100% by default
-        // e.g. height: 300 instead of height: '100%'
         <BoundingBox>
           <ParentSize debounceTime={debounceTime}>
             {({ width, height }) =>
               width > 0 &&
               height > 0 &&
               this.renderChart(
-                widthInfo.isDynamic ? Math.floor(width * widthInfo.multiplier) : widthInfo.value,
-                heightInfo.isDynamic
-                  ? Math.floor(height * heightInfo.multiplier)
-                  : heightInfo.value,
+                widthInfo.isDynamic ? Math.floor(width) : widthInfo.value,
+                heightInfo.isDynamic ? Math.floor(height) : heightInfo.value,
               )
             }
           </ParentSize>

--- a/packages/superset-ui-chart/src/components/SuperChart.tsx
+++ b/packages/superset-ui-chart/src/components/SuperChart.tsx
@@ -63,12 +63,12 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
   private createChartProps = ChartProps.createSelector();
 
   private parseDimension = createSelector(
-    ({ inputWidth }: { inputWidth: string | number; inputHeight: string | number }) => inputWidth,
-    ({ inputHeight }) => inputHeight,
-    (inputWidth, inputHeight) => {
+    ({ width }: { width: string | number; height: string | number }) => width,
+    ({ height }) => height,
+    (width, height) => {
       // Parse them in case they are % or 'auto'
-      const widthInfo = parseLength(inputWidth);
-      const heightInfo = parseLength(inputHeight);
+      const widthInfo = parseLength(width);
+      const heightInfo = parseLength(height);
 
       const style = {
         height: heightInfo.isDynamic ? '100%' : heightInfo.value,
@@ -141,12 +141,8 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
   }
 
   render() {
-    const { width: inputWidth, height: inputHeight } = this.props as PropsWithDefault;
-
-    const { heightInfo, widthInfo, BoundingBox } = this.parseDimension({
-      inputHeight,
-      inputWidth,
-    });
+    const { heightInfo, widthInfo, BoundingBox } = this.parseDimension(this
+      .props as PropsWithDefault);
 
     // If any of the dimension is dynamic, get parent's dimension
     if (widthInfo.isDynamic || heightInfo.isDynamic) {

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -135,10 +135,17 @@ describe('SuperChart', () => {
       const wrapper = mount(
         <SuperChart chartType={ChartKeys.DILIGENT} debounceTime={1} width="50%" height="125" />,
       );
-      triggerResizeObserver();
+      triggerResizeObserver([{ contentRect: { height: 125, width: 150 } }]);
 
       return promiseTimeout(() => {
         const renderedWrapper = wrapper.render();
+        const boundingBox = renderedWrapper
+          .find('div.test-component')
+          .parent()
+          .parent()
+          .parent();
+        expect(boundingBox.css('width')).toEqual('50%');
+        expect(boundingBox.css('height')).toEqual('125px');
         expect(renderedWrapper.find('div.test-component')).toHaveLength(1);
         expectDimension(renderedWrapper, 150, 125);
       }, 100);
@@ -147,10 +154,17 @@ describe('SuperChart', () => {
       const wrapper = mount(
         <SuperChart chartType={ChartKeys.DILIGENT} debounceTime={1} width="50" height="25%" />,
       );
-      triggerResizeObserver();
+      triggerResizeObserver([{ contentRect: { height: 75, width: 50 } }]);
 
       return promiseTimeout(() => {
         const renderedWrapper = wrapper.render();
+        const boundingBox = renderedWrapper
+          .find('div.test-component')
+          .parent()
+          .parent()
+          .parent();
+        expect(boundingBox.css('width')).toEqual('50px');
+        expect(boundingBox.css('height')).toEqual('25%');
         expect(renderedWrapper.find('div.test-component')).toHaveLength(1);
         expectDimension(renderedWrapper, 50, 75);
       }, 100);

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/first */
-import React, { Children } from 'react';
-import { mount, render } from 'enzyme';
+import React from 'react';
+import { mount } from 'enzyme';
 
 jest.mock('resize-observer-polyfill');
 // @ts-ignore
@@ -170,12 +170,12 @@ describe('SuperChart', () => {
   describe('supports Wrapper', () => {
     function MyWrapper({ width, height, children }: WrapperProps) {
       return (
-        <>
+        <div>
           <div className="wrapper-insert">
             {width}x{height}
           </div>
           {children}
-        </>
+        </div>
       );
     }
 
@@ -186,10 +186,13 @@ describe('SuperChart', () => {
 
       return promiseTimeout(() => {
         const renderedWrapper = wrapper.render();
+        expect(renderedWrapper.find('div.wrapper-insert')).toHaveLength(1);
+        expect(renderedWrapper.find('div.wrapper-insert').text()).toEqual('100x100');
         expect(renderedWrapper.find('div.test-component')).toHaveLength(1);
         expectDimension(renderedWrapper, 100, 100);
-      });
+      }, 100);
     });
+
     it('works when width and height are percent', () => {
       const wrapper = mount(
         <SuperChart
@@ -204,6 +207,8 @@ describe('SuperChart', () => {
 
       return promiseTimeout(() => {
         const renderedWrapper = wrapper.render();
+        expect(renderedWrapper.find('div.wrapper-insert')).toHaveLength(1);
+        expect(renderedWrapper.find('div.wrapper-insert').text()).toEqual('300x300');
         expect(renderedWrapper.find('div.test-component')).toHaveLength(1);
         expectDimension(renderedWrapper, 300, 300);
       }, 100);

--- a/packages/superset-ui-chart/test/components/SuperChart.test.tsx
+++ b/packages/superset-ui-chart/test/components/SuperChart.test.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable import/first */
-import React from 'react';
-import { mount } from 'enzyme';
+import React, { Children } from 'react';
+import { mount, render } from 'enzyme';
 
 jest.mock('resize-observer-polyfill');
 // @ts-ignore
 import { triggerResizeObserver } from 'resize-observer-polyfill';
 import ErrorBoundary from 'react-error-boundary';
 import { SuperChart } from '../../src';
-import RealSuperChart from '../../src/components/SuperChart';
+import RealSuperChart, { WrapperProps } from '../../src/components/SuperChart';
 import { ChartKeys, DiligentChartPlugin, BuggyChartPlugin } from './MockChartPlugins';
 import promiseTimeout from './promiseTimeout';
 
@@ -163,6 +163,49 @@ describe('SuperChart', () => {
         const renderedWrapper = wrapper.render();
         expect(renderedWrapper.find('div.test-component')).toHaveLength(1);
         expectDimension(renderedWrapper, 300, 400);
+      }, 100);
+    });
+  });
+
+  describe('supports Wrapper', () => {
+    function MyWrapper({ width, height, children }: WrapperProps) {
+      return (
+        <>
+          <div className="wrapper-insert">
+            {width}x{height}
+          </div>
+          {children}
+        </>
+      );
+    }
+
+    it('works with width and height that are numbers', () => {
+      const wrapper = mount(
+        <SuperChart chartType={ChartKeys.DILIGENT} width={100} height={100} Wrapper={MyWrapper} />,
+      );
+
+      return promiseTimeout(() => {
+        const renderedWrapper = wrapper.render();
+        expect(renderedWrapper.find('div.test-component')).toHaveLength(1);
+        expectDimension(renderedWrapper, 100, 100);
+      });
+    });
+    it('works when width and height are percent', () => {
+      const wrapper = mount(
+        <SuperChart
+          chartType={ChartKeys.DILIGENT}
+          debounceTime={1}
+          width="100%"
+          height="100%"
+          Wrapper={MyWrapper}
+        />,
+      );
+      triggerResizeObserver();
+
+      return promiseTimeout(() => {
+        const renderedWrapper = wrapper.render();
+        expect(renderedWrapper.find('div.test-component')).toHaveLength(1);
+        expectDimension(renderedWrapper, 300, 300);
       }, 100);
     });
   });

--- a/packages/superset-ui-chart/test/components/createLoadableRenderer.test.tsx
+++ b/packages/superset-ui-chart/test/components/createLoadableRenderer.test.tsx
@@ -76,6 +76,23 @@ describe('createLoadableRenderer', () => {
       }, 10);
     });
 
+    it('onRenderFailure is optional', done => {
+      const loadChartFailure = jest.fn(() => Promise.reject(new Error('Invalid chart')));
+      const FailedRenderer = createLoadableRenderer({
+        loader: {
+          Chart: loadChartFailure,
+        },
+        loading,
+        render,
+      });
+      shallow(<FailedRenderer />);
+      expect(loadChartFailure).toHaveBeenCalledTimes(1);
+      setTimeout(() => {
+        expect(render).not.toHaveBeenCalled();
+        done();
+      }, 10);
+    });
+
     it('renders the lazy-load components', done => {
       const wrapper = shallow(<LoadableRenderer />);
       // lazy-loaded component not rendered immediately

--- a/packages/superset-ui-demo/storybook/stories/superset-ui-chart/SuperChartStories.tsx
+++ b/packages/superset-ui-demo/storybook/stories/superset-ui-chart/SuperChartStories.tsx
@@ -13,8 +13,8 @@ new BuggyChartPlugin().configure({ key: ChartKeys.BUGGY }).register();
 export default [
   {
     renderStory: () => {
-      const width = text('Vis width', '50%');
-      const height = text('Vis height', '75%');
+      const width = text('Vis width', '100%');
+      const height = text('Vis height', '100%');
 
       return (
         <SuperChart
@@ -30,20 +30,19 @@ export default [
   },
   {
     renderStory: () => {
-      const width = text('Vis width', '500');
-      const height = text('Vis height', '300');
+      const width = text('Vis width', '50%');
+      const height = text('Vis height', '50%');
 
       return (
         <SuperChart
           chartType={ChartKeys.DILIGENT}
-          chartProps={{
-            height: Number(height),
-            width: Number(width),
-          }}
+          width={width}
+          height={height}
+          formData={{ hi: 1 }}
         />
       );
     },
-    storyName: 'passing ChartPropsConfig',
+    storyName: '50% of container',
     storyPath: '@superset-ui/chart|SuperChart',
   },
   {
@@ -51,19 +50,29 @@ export default [
       const width = text('Vis width', '500');
       const height = text('Vis height', '300');
 
-      return (
-        <SuperChart
-          chartType={ChartKeys.DILIGENT}
-          chartProps={
-            new ChartProps({
-              height: Number(height),
-              width: Number(width),
-            })
-          }
-        />
-      );
+      return <SuperChart chartType={ChartKeys.DILIGENT} height={height} width={width} />;
     },
-    storyName: 'passing ChartProps',
+    storyName: 'fixed dimension',
+    storyPath: '@superset-ui/chart|SuperChart',
+  },
+  {
+    renderStory: () => {
+      const width = text('Vis width', '500');
+      const height = text('Vis height', '100%');
+
+      return <SuperChart chartType={ChartKeys.DILIGENT} height={height} width={width} />;
+    },
+    storyName: 'fixed width, 100% height',
+    storyPath: '@superset-ui/chart|SuperChart',
+  },
+  {
+    renderStory: () => {
+      const width = text('Vis width', '100%');
+      const height = text('Vis height', '300');
+
+      return <SuperChart chartType={ChartKeys.DILIGENT} height={height} width={width} />;
+    },
+    storyName: 'fixed height, 100% width',
     storyPath: '@superset-ui/chart|SuperChart',
   },
   {
@@ -71,17 +80,7 @@ export default [
       const width = text('Vis width', '500');
       const height = text('Vis height', '300');
 
-      return (
-        <SuperChart
-          chartType={ChartKeys.BUGGY}
-          chartProps={
-            new ChartProps({
-              height: Number(height),
-              width: Number(width),
-            })
-          }
-        />
-      );
+      return <SuperChart chartType={ChartKeys.BUGGY} height={height} width={width} />;
     },
     storyName: 'With error boundary',
     storyPath: '@superset-ui/chart|SuperChart',

--- a/packages/superset-ui-demo/storybook/stories/superset-ui-chart/SuperChartStories.tsx
+++ b/packages/superset-ui-demo/storybook/stories/superset-ui-chart/SuperChartStories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { text } from '@storybook/addon-knobs';
-import { SuperChart, ChartProps } from '../../../../superset-ui-chart/src';
+import { SuperChart } from '../../../../superset-ui-chart/src';
 import {
   DiligentChartPlugin,
   BuggyChartPlugin,
@@ -83,6 +83,28 @@ export default [
       return <SuperChart chartType={ChartKeys.BUGGY} height={height} width={width} />;
     },
     storyName: 'With error boundary',
+    storyPath: '@superset-ui/chart|SuperChart',
+  },
+  {
+    renderStory: () => {
+      const width = text('Vis width', '100%');
+      const height = text('Vis height', '100%');
+
+      return (
+        <SuperChart
+          chartType={ChartKeys.DILIGENT}
+          width={width}
+          height={height}
+          Wrapper={({ children }) => (
+            <div>
+              <div style={{ margin: 10, position: 'fixed' }}>With wrapper!</div>
+              {children}
+            </div>
+          )}
+        />
+      );
+    },
+    storyName: 'With Wrapper',
     storyPath: '@superset-ui/chart|SuperChart',
   },
 ];


### PR DESCRIPTION
## 🏆 Enhancements

### 1. Add bounding box for dynamic `width`/`height` calculation

When either `width` or `height` is already known, such as `width="100%" height={500}`.
Default `<ParentSize>` behavior will set the container style to `{width: '100%', height: '100%'}`, which may exceed the known `width` or `height` values, resulting in undesired blank space on the page. This PR add another `<div>` to wrap it (only when necessary). If both `width` and `height` are dynamic then no bounding box will be added. 

e.g. when want 100% width and 500px height.

```jsx
<div style={{width: '100%', height: 500}}>
  <ParentSize>
    {...}
  </ParentSize>
</div>
```

#### Alternative

Consider including these functionalities in the `@vx/responsive` rewrite.

### 2. Add `Wrapper` prop for `SuperChart`

#### Problem

Inspired by use case in `dataportal`. 

```jsx
// SuperChart with dynamic width/height
<SuperChart width="100%" height="400" chartType="line /> 
```
```jsx
// Rough hierarchy of the code above in the DOM is like this. 
<SuperChart width="100%" height="400"> // can compute dynamic width/height
  <ChartPlugin /> // for illustration purpose only, this is abstracted by SuperChart
</SuperChart>
```

There is a situation when a wrapper needs to be added to fix `z-index` issue such as tooltip.
This won't work because the wrapper will mess with the dynamic width/height calculation.

```jsx
<div style={{position: 'fixed'}}>
  // with the wrapper, now width and height become 0.
  // so the chart will disappear 😱
  <SuperChart width="100%" height="100%" chartType="line" /> 
</div>
```

If we want to insert something in between `SuperChart` and `ChartPlugin` to avoid messing with dynamic `width`/`height`, you either have to 

A. Do not use the built-in `SuperChart` way of determining auto `width` and `height`. Use your own way of computing dynamic `width` & `height`, which is pretty much re-implementing a lot of logic in `SuperChart`.

```jsx
<div style={{ width="100%", height: 400 }}>
  <ParentSize>
    // ...
    <div style={{position: 'fixed'}}>
      <SuperChart width={width} height={height} chartType="line" /> // can compute dynamic width/height
    </div>
    // ...
  </ParentSize>
</div>
```
 
B. Modify the `ChartPlugin` to add the wrapper. Sounds like an overkill.

Both options are undesirable extra work. 

#### Solution

With the changes in this PR.

```jsx
const Wrapper = ({children}) => (
  <div style={{position: 'fixed'}}>{children}</div>
);

return (
  <SuperChart Wrapper={Wrapper} width="100%" height="400" /> 
);
```

## 🏠 Internal

* Add unit test for one missing branch that makes the coverage ~99%. Now the `chart` package is 100% again.