### PR TITLE
feat: Add Encoder

### DIFF
--- a/packages/superset-ui-encodable/src/encoders/ChannelEncoder.ts
+++ b/packages/superset-ui-encodable/src/encoders/ChannelEncoder.ts
@@ -126,4 +126,8 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
   isY() {
     return isY(this.channelType);
   }
+
+  hasLegend() {
+    return this.definition.legend !== false;
+  }
 }

--- a/packages/superset-ui-encodable/src/encoders/Encoder.ts
+++ b/packages/superset-ui-encodable/src/encoders/Encoder.ts
@@ -1,0 +1,163 @@
+import { flatMap } from 'lodash';
+import { Value } from '../types/VegaLite';
+import { ChannelType, ChannelInput } from '../types/Channel';
+import { ChannelDef } from '../types/ChannelDef';
+import { Dataset } from '../types/Data';
+import { Unarray, MayBeArray } from '../types/Base';
+import { isFieldDef, isTypedFieldDef } from '../typeGuards/ChannelDef';
+import { isArray, isNotArray } from '../typeGuards/Base';
+import ChannelEncoder from './ChannelEncoder';
+import { Encoding } from '../types/Encoding';
+
+type AllChannelEncoders<Encoding extends Record<string, MayBeArray<ChannelDef>>> = {
+  readonly [k in keyof Encoding]: Encoding[k] extends any[]
+    ? ChannelEncoder<Unarray<Encoding[k]>>[]
+    : ChannelEncoder<Unarray<Encoding[k]>>;
+};
+
+export default class Encoder<
+  ChannelTypes extends Record<string, ChannelType>,
+  CustomEncoding extends Encoding<keyof ChannelTypes>
+> {
+  readonly encoding: CustomEncoding;
+  readonly channelTypes: ChannelTypes;
+  readonly channels: AllChannelEncoders<CustomEncoding>;
+
+  readonly legends: {
+    [key: string]: (keyof CustomEncoding)[];
+  };
+
+  constructor({
+    channelTypes,
+    encoding,
+  }: {
+    channelTypes: ChannelTypes;
+    encoding: CustomEncoding;
+  }) {
+    this.channelTypes = channelTypes;
+    this.encoding = encoding;
+    const channelNames = this.getChannelNames();
+
+    const channels: { [k in keyof CustomEncoding]?: MayBeArray<ChannelEncoder<ChannelDef>> } = {};
+
+    channelNames.forEach(name => {
+      const channelEncoding = encoding[name];
+      if (isArray(channelEncoding)) {
+        const definitions = channelEncoding;
+        channels[name] = definitions.map(
+          (definition, i) =>
+            new ChannelEncoder({
+              channelType: 'Text',
+              definition,
+              name: `${name}[${i}]`,
+            }),
+        );
+      } else if (isNotArray(channelEncoding)) {
+        const definition = channelEncoding;
+        channels[name] = new ChannelEncoder({
+          channelType: channelTypes[name],
+          definition,
+          name: name as string,
+        });
+      }
+    });
+
+    this.channels = channels as AllChannelEncoders<CustomEncoding>;
+
+    type ChannelName = keyof CustomEncoding;
+
+    // Group the channels that use the same field together
+    // so they can share the same legend.
+    this.legends = {};
+    channelNames
+      .map(name => this.channels[name])
+      .forEach(c => {
+        if (isNotArray(c) && c.hasLegend() && isFieldDef(c.definition)) {
+          const name = c.name as ChannelName;
+          const { field } = c.definition;
+          if (this.legends[field]) {
+            this.legends[field].push(name);
+          } else {
+            this.legends[field] = [name];
+          }
+        }
+      });
+  }
+
+  // /**
+  //  * subclass can override this
+  //  */
+  // createFullSpec(spec: PartialSpec<Encoding, Options>, defaultEncoding?: Encoding) {
+  //   if (typeof defaultEncoding === 'undefined') {
+  //     return spec as FullSpec<Encoding, Options>;
+  //   }
+
+  //   const { encoding, ...rest } = spec;
+
+  //   return {
+  //     ...rest,
+  //     encoding: {
+  //       ...defaultEncoding,
+  //       ...encoding,
+  //     },
+  //   };
+  // }
+
+  getChannelNames() {
+    return Object.keys(this.channelTypes) as (keyof ChannelTypes)[];
+  }
+
+  getChannelsAsArray() {
+    return this.getChannelNames().map(name => this.channels[name]);
+  }
+
+  getGroupBys() {
+    const fields = flatMap(this.getChannelsAsArray())
+      .filter(c => c.isGroupBy())
+      .map(c => (isFieldDef(c.definition) ? c.definition.field : ''))
+      .filter(field => field !== '');
+
+    return Array.from(new Set(fields));
+  }
+
+  // getLegendInfos(data: Dataset) {
+  //   return Object.keys(this.legends)
+  //     .map((field: string) => {
+  //       const channelNames = this.legends[field];
+  //       const channelEncoder = this.channels[channelNames[0]];
+
+  //       if (isNotArray(channelEncoder) && isTypedFieldDef(channelEncoder.definition)) {
+  //         // Only work for nominal channels now
+  //         // TODO: Add support for numerical scale
+  //         if (channelEncoder.definition.type === 'nominal') {
+  //           const domain = channelEncoder.getDomain(data) as string[];
+
+  //           return domain.map((value: ChannelInput) => ({
+  //             field,
+  //             value,
+  //             // eslint-disable-next-line sort-keys
+  //             encodedValues: channelNames.reduce(
+  //               (prev: Partial<Record<keyof Encoding, Value | undefined>>, curr) => {
+  //                 const map = prev;
+  //                 const channel = this.channels[curr];
+  //                 if (isNotArray(channel)) {
+  //                   map[curr] = channel.encodeValue(value);
+  //                 }
+
+  //                 return map;
+  //               },
+  //               {},
+  //             ),
+  //           }));
+  //         }
+  //       }
+
+  //       return [];
+  //     })
+  //     .filter(items => items.length > 0);
+  // }
+
+  hasLegend() {
+    return Object.keys(this.legends).length > 0;
+  }
+}

--- a/packages/superset-ui-encodable/src/encoders/Encoder.ts
+++ b/packages/superset-ui-encodable/src/encoders/Encoder.ts
@@ -41,7 +41,7 @@ export default class Encoder<Config extends EncodingConfig> {
         channels[name] = definitions.map(
           (definition, i) =>
             new ChannelEncoder({
-              channelType: 'Text',
+              channelType: channelTypes[name],
               definition,
               name: `${name}[${i}]`,
             }),

--- a/packages/superset-ui-encodable/src/encoders/Encoder.ts
+++ b/packages/superset-ui-encodable/src/encoders/Encoder.ts
@@ -16,11 +16,11 @@ type AllChannelEncoders<Encoding extends Record<string, MayBeArray<ChannelDef>>>
 };
 
 export default class Encoder<
-  ChannelTypes extends Record<string, ChannelType>,
-  CustomEncoding extends Encoding<keyof ChannelTypes>
+  CustomChannelTypes extends Record<string, ChannelType>,
+  CustomEncoding extends Encoding<keyof CustomChannelTypes>
 > {
   readonly encoding: CustomEncoding;
-  readonly channelTypes: ChannelTypes;
+  readonly channelTypes: CustomChannelTypes;
   readonly channels: AllChannelEncoders<CustomEncoding>;
 
   readonly legends: {
@@ -31,7 +31,7 @@ export default class Encoder<
     channelTypes,
     encoding,
   }: {
-    channelTypes: ChannelTypes;
+    channelTypes: CustomChannelTypes;
     encoding: CustomEncoding;
   }) {
     this.channelTypes = channelTypes;
@@ -84,27 +84,8 @@ export default class Encoder<
       });
   }
 
-  // /**
-  //  * subclass can override this
-  //  */
-  // createFullSpec(spec: PartialSpec<Encoding, Options>, defaultEncoding?: Encoding) {
-  //   if (typeof defaultEncoding === 'undefined') {
-  //     return spec as FullSpec<Encoding, Options>;
-  //   }
-
-  //   const { encoding, ...rest } = spec;
-
-  //   return {
-  //     ...rest,
-  //     encoding: {
-  //       ...defaultEncoding,
-  //       ...encoding,
-  //     },
-  //   };
-  // }
-
   getChannelNames() {
-    return Object.keys(this.channelTypes) as (keyof ChannelTypes)[];
+    return Object.keys(this.channelTypes) as (keyof CustomChannelTypes)[];
   }
 
   getChannelsAsArray() {
@@ -119,43 +100,6 @@ export default class Encoder<
 
     return Array.from(new Set(fields));
   }
-
-  // getLegendInfos(data: Dataset) {
-  //   return Object.keys(this.legends)
-  //     .map((field: string) => {
-  //       const channelNames = this.legends[field];
-  //       const channelEncoder = this.channels[channelNames[0]];
-
-  //       if (isNotArray(channelEncoder) && isTypedFieldDef(channelEncoder.definition)) {
-  //         // Only work for nominal channels now
-  //         // TODO: Add support for numerical scale
-  //         if (channelEncoder.definition.type === 'nominal') {
-  //           const domain = channelEncoder.getDomain(data) as string[];
-
-  //           return domain.map((value: ChannelInput) => ({
-  //             field,
-  //             value,
-  //             // eslint-disable-next-line sort-keys
-  //             encodedValues: channelNames.reduce(
-  //               (prev: Partial<Record<keyof Encoding, Value | undefined>>, curr) => {
-  //                 const map = prev;
-  //                 const channel = this.channels[curr];
-  //                 if (isNotArray(channel)) {
-  //                   map[curr] = channel.encodeValue(value);
-  //                 }
-
-  //                 return map;
-  //               },
-  //               {},
-  //             ),
-  //           }));
-  //         }
-  //       }
-
-  //       return [];
-  //     })
-  //     .filter(items => items.length > 0);
-  // }
 
   hasLegend() {
     return Object.keys(this.legends).length > 0;

--- a/packages/superset-ui-encodable/src/encoders/createEncoderFactory.ts
+++ b/packages/superset-ui-encodable/src/encoders/createEncoderFactory.ts
@@ -2,9 +2,10 @@ import Encoder from './Encoder';
 import { EncodingConfig, DeriveChannelTypes, DeriveEncoding } from '../types/Encoding';
 import mergeEncoding from '../utils/mergeEncoding';
 
-type CreateEncoderFactoryParams<Config extends EncodingConfig> =
+type CreateEncoderFactoryParams<Config extends EncodingConfig> = {
+  channelTypes: DeriveChannelTypes<Config>;
+} & (
   | {
-      channelTypes: DeriveChannelTypes<Config>;
       /**
        * use the default approach to merge default encoding with user-specified encoding
        * if there are missing fields
@@ -12,13 +13,12 @@ type CreateEncoderFactoryParams<Config extends EncodingConfig> =
       defaultEncoding: DeriveEncoding<Config>;
     }
   | {
-      channelTypes: DeriveChannelTypes<Config>;
       /**
        * custom way to complete the encoding
        * if there are missing fields
        */
       completeEncoding: (e: Partial<DeriveEncoding<Config>>) => DeriveEncoding<Config>;
-    };
+    });
 
 export default function createEncoderFactory<Config extends EncodingConfig>(
   params: CreateEncoderFactoryParams<Config>,

--- a/packages/superset-ui-encodable/src/encoders/createEncoderFactory.ts
+++ b/packages/superset-ui-encodable/src/encoders/createEncoderFactory.ts
@@ -5,7 +5,7 @@ import mergeEncoding from '../utils/mergeEncoding';
 
 type CreateEncoderFactoryParams<
   ChannelTypes extends Record<string, ChannelType>,
-  Enc extends Encoding<keyof ChannelTypes>
+  CustomEncoding extends Encoding<keyof ChannelTypes>
 > =
   | {
       channelTypes: ChannelTypes;
@@ -13,7 +13,7 @@ type CreateEncoderFactoryParams<
        * use the default approach to merge default encoding with user-specified encoding
        * if there are missing fields
        */
-      defaultEncoding: Enc;
+      defaultEncoding: CustomEncoding;
     }
   | {
       channelTypes: ChannelTypes;
@@ -21,22 +21,23 @@ type CreateEncoderFactoryParams<
        * custom way to complete the encoding
        * if there are missing fields
        */
-      completeEncoding: (e: Partial<Enc>) => Enc;
+      completeEncoding: (e: Partial<CustomEncoding>) => CustomEncoding;
     };
 
 export default function createEncoderFactory<
-  ChannelTypes extends Record<string, ChannelType>,
-  Enc extends Encoding<keyof ChannelTypes>
->(params: CreateEncoderFactoryParams<ChannelTypes, Enc>) {
+  CustomChannelTypes extends Record<string, ChannelType>,
+  CustomEncoding extends Encoding<keyof CustomChannelTypes>
+>(params: CreateEncoderFactoryParams<CustomChannelTypes, CustomEncoding>) {
   const { channelTypes } = params;
   const completeEncoding =
     'defaultEncoding' in params
-      ? (encoding: Partial<Enc>) => mergeEncoding(params.defaultEncoding, encoding)
+      ? (encoding: Partial<CustomEncoding>) => mergeEncoding(params.defaultEncoding, encoding)
       : params.completeEncoding;
 
   return {
-    create: (encoding: Partial<Enc>) =>
-      new Encoder<ChannelTypes, Enc>({
+    channelTypes,
+    create: (encoding: Partial<CustomEncoding>) =>
+      new Encoder<CustomChannelTypes, CustomEncoding>({
         channelTypes,
         encoding: completeEncoding(encoding),
       }),

--- a/packages/superset-ui-encodable/src/encoders/createEncoderFactory.ts
+++ b/packages/superset-ui-encodable/src/encoders/createEncoderFactory.ts
@@ -1,0 +1,45 @@
+import Encoder from './Encoder';
+import { ChannelType } from '../types/Channel';
+import { Encoding } from '../types/Encoding';
+import mergeEncoding from '../utils/mergeEncoding';
+
+type CreateEncoderFactoryParams<
+  ChannelTypes extends Record<string, ChannelType>,
+  Enc extends Encoding<keyof ChannelTypes>
+> =
+  | {
+      channelTypes: ChannelTypes;
+      /**
+       * use the default approach to merge default encoding with user-specified encoding
+       * if there are missing fields
+       */
+      defaultEncoding: Enc;
+    }
+  | {
+      channelTypes: ChannelTypes;
+      /**
+       * custom way to complete the encoding
+       * if there are missing fields
+       */
+      completeEncoding: (e: Partial<Enc>) => Enc;
+    };
+
+export default function createEncoderFactory<
+  ChannelTypes extends Record<string, ChannelType>,
+  Enc extends Encoding<keyof ChannelTypes>
+>(params: CreateEncoderFactoryParams<ChannelTypes, Enc>) {
+  const { channelTypes } = params;
+  const completeEncoding =
+    'defaultEncoding' in params
+      ? (encoding: Partial<Enc>) => mergeEncoding(params.defaultEncoding, encoding)
+      : params.completeEncoding;
+
+  return {
+    create: (encoding: Partial<Enc>) =>
+      new Encoder<ChannelTypes, Enc>({
+        channelTypes,
+        encoding: completeEncoding(encoding),
+      }),
+    DEFAULT_ENCODING: completeEncoding({}),
+  };
+}

--- a/packages/superset-ui-encodable/src/fillers/completeChannelDef.ts
+++ b/packages/superset-ui-encodable/src/fillers/completeChannelDef.ts
@@ -2,12 +2,14 @@ import { ChannelDef, NonValueDef } from '../types/ChannelDef';
 import { ChannelType } from '../types/Channel';
 import { isFieldDef, isValueDef, isTypedFieldDef } from '../typeGuards/ChannelDef';
 import completeAxisConfig, { CompleteAxisConfig } from './completeAxisConfig';
+import completeLegendConfig, { CompleteLegendConfig } from './completeLegendConfig';
 import completeScaleConfig, { CompleteScaleConfig } from './completeScaleConfig';
 import { Value, ValueDef, Type } from '../types/VegaLite';
 import inferFieldType from './inferFieldType';
 
 export interface CompleteValueDef<Output extends Value = Value> extends ValueDef<Output> {
   axis: false;
+  legend: false;
   scale: false;
   title: '';
 }
@@ -18,6 +20,7 @@ export type CompleteFieldDef<Output extends Value = Value> = Omit<
 > & {
   type: Type;
   axis: CompleteAxisConfig;
+  legend: CompleteLegendConfig;
   scale: CompleteScaleConfig<Output>;
   title: string;
 };
@@ -34,6 +37,7 @@ export default function completeChannelDef<Output extends Value>(
     return {
       ...channelDef,
       axis: false,
+      legend: false,
       scale: false,
       title: '',
     };
@@ -51,6 +55,7 @@ export default function completeChannelDef<Output extends Value>(
   return {
     ...copy,
     axis: completeAxisConfig(channelType, copy),
+    legend: completeLegendConfig(copy),
     scale: completeScaleConfig(channelType, copy),
   };
 }

--- a/packages/superset-ui-encodable/src/fillers/completeChannelDef.ts
+++ b/packages/superset-ui-encodable/src/fillers/completeChannelDef.ts
@@ -55,7 +55,7 @@ export default function completeChannelDef<Output extends Value>(
   return {
     ...copy,
     axis: completeAxisConfig(channelType, copy),
-    legend: completeLegendConfig(copy),
+    legend: completeLegendConfig(channelType, copy),
     scale: completeScaleConfig(channelType, copy),
   };
 }

--- a/packages/superset-ui-encodable/src/fillers/completeLegendConfig.ts
+++ b/packages/superset-ui-encodable/src/fillers/completeLegendConfig.ts
@@ -1,0 +1,17 @@
+import { ChannelDef } from '../types/ChannelDef';
+import { Value } from '../types/VegaLite';
+import { Legend } from '../types/Legend';
+
+export type CompleteLegendConfig = false | Legend;
+
+export default function completeLegendConfig<Output extends Value = Value>(
+  channelDef: ChannelDef<Output>,
+): CompleteLegendConfig {
+  if ('legend' in channelDef) {
+    const { legend } = channelDef;
+
+    return legend === false || legend === null ? false : {};
+  }
+
+  return {};
+}

--- a/packages/superset-ui-encodable/src/fillers/completeLegendConfig.ts
+++ b/packages/superset-ui-encodable/src/fillers/completeLegendConfig.ts
@@ -10,7 +10,13 @@ export default function completeLegendConfig<Output extends Value = Value>(
   if ('legend' in channelDef) {
     const { legend } = channelDef;
 
-    return legend === false || legend === null ? false : {};
+    if (legend === false) {
+      return false;
+    } else if (legend === undefined) {
+      return {};
+    }
+
+    return legend;
   }
 
   return {};

--- a/packages/superset-ui-encodable/src/fillers/completeLegendConfig.ts
+++ b/packages/superset-ui-encodable/src/fillers/completeLegendConfig.ts
@@ -1,23 +1,18 @@
-import { ChannelDef } from '../types/ChannelDef';
 import { Value } from '../types/VegaLite';
 import { Legend } from '../types/Legend';
+import { ChannelType } from '../types/Channel';
+import { ChannelDef } from '../types/ChannelDef';
+import { isXOrY } from '../typeGuards/Channel';
 
 export type CompleteLegendConfig = false | Legend;
 
 export default function completeLegendConfig<Output extends Value = Value>(
+  channelType: ChannelType,
   channelDef: ChannelDef<Output>,
 ): CompleteLegendConfig {
-  if ('legend' in channelDef) {
-    const { legend } = channelDef;
-
-    if (legend === false) {
-      return false;
-    } else if (legend === undefined) {
-      return {};
-    }
-
-    return legend;
+  if ('legend' in channelDef && channelDef.legend !== undefined) {
+    return channelDef.legend;
   }
 
-  return {};
+  return isXOrY(channelType) ? false : {};
 }

--- a/packages/superset-ui-encodable/src/types/Encoding.ts
+++ b/packages/superset-ui-encodable/src/types/Encoding.ts
@@ -1,0 +1,4 @@
+import { MayBeArray } from './Base';
+import { ChannelDef } from './ChannelDef';
+
+export type Encoding<Key extends string | number | symbol> = Record<Key, MayBeArray<ChannelDef>>;

--- a/packages/superset-ui-encodable/src/types/Encoding.ts
+++ b/packages/superset-ui-encodable/src/types/Encoding.ts
@@ -31,6 +31,7 @@ export type DeriveChannelEncoders<Config extends EncodingConfig> = {
 // type Config = {
 //   x: ['X', number];
 //   y: ['Y', number];
+//   size: ['Numeric', number];
 //   tooltip: ['Text', string, 'multiple'];
 // };
 

--- a/packages/superset-ui-encodable/src/types/Encoding.ts
+++ b/packages/superset-ui-encodable/src/types/Encoding.ts
@@ -25,17 +25,3 @@ export type DeriveChannelEncoders<Config extends EncodingConfig> = {
     ? ChannelEncoder<ChannelTypeToDefMap<Config[k]['1']>[Config[k]['0']]>[]
     : ChannelEncoder<ChannelTypeToDefMap<Config[k]['1']>[Config[k]['0']]>;
 };
-
-// // Testing
-
-// type Config = {
-//   x: ['X', number];
-//   y: ['Y', number];
-//   size: ['Numeric', number];
-//   tooltip: ['Text', string, 'multiple'];
-// };
-
-// type ChannelTypes = DeriveChannelTypes<Config>;
-// type ChannelOutputs = DeriveChannelOutputs<Config>;
-// type Encoding = DeriveEncoding<Config>;
-// type ChannelEncoders = DeriveChannelEncoders<Config>;

--- a/packages/superset-ui-encodable/src/types/Encoding.ts
+++ b/packages/superset-ui-encodable/src/types/Encoding.ts
@@ -1,4 +1,40 @@
-import { MayBeArray } from './Base';
-import { ChannelDef } from './ChannelDef';
+import { ChannelType, ChannelTypeToDefMap } from './Channel';
+import { Value } from './VegaLite';
+import ChannelEncoder from '../encoders/ChannelEncoder';
 
-export type Encoding<Key extends string | number | symbol> = Record<Key, MayBeArray<ChannelDef>>;
+export type EncodingConfig = {
+  [k in string]: [ChannelType, Value, 'multiple'?];
+};
+
+export type DeriveChannelTypes<Config extends EncodingConfig> = {
+  readonly [k in keyof Config]: Config[k]['0'];
+};
+
+export type DeriveChannelOutputs<Config extends EncodingConfig> = {
+  readonly [k in keyof Config]: Config[k]['1'];
+};
+
+export type DeriveEncoding<Config extends EncodingConfig> = {
+  [k in keyof Config]: Config[k]['2'] extends 'multiple'
+    ? ChannelTypeToDefMap<Config[k]['1']>[Config[k]['0']][]
+    : ChannelTypeToDefMap<Config[k]['1']>[Config[k]['0']];
+};
+
+export type DeriveChannelEncoders<Config extends EncodingConfig> = {
+  readonly [k in keyof Config]: Config[k]['2'] extends 'multiple'
+    ? ChannelEncoder<ChannelTypeToDefMap<Config[k]['1']>[Config[k]['0']]>[]
+    : ChannelEncoder<ChannelTypeToDefMap<Config[k]['1']>[Config[k]['0']]>;
+};
+
+// // Testing
+
+// type Config = {
+//   x: ['X', number];
+//   y: ['Y', number];
+//   tooltip: ['Text', string, 'multiple'];
+// };
+
+// type ChannelTypes = DeriveChannelTypes<Config>;
+// type ChannelOutputs = DeriveChannelOutputs<Config>;
+// type Encoding = DeriveEncoding<Config>;
+// type ChannelEncoders = DeriveChannelEncoders<Config>;

--- a/packages/superset-ui-encodable/src/types/Legend.ts
+++ b/packages/superset-ui-encodable/src/types/Legend.ts
@@ -1,5 +1,5 @@
-export type Legend = boolean | null;
+export type Legend = {};
 
 export interface WithLegend {
-  legend?: Legend;
+  legend?: boolean | Legend;
 }

--- a/packages/superset-ui-encodable/src/utils/mergeEncoding.ts
+++ b/packages/superset-ui-encodable/src/utils/mergeEncoding.ts
@@ -1,0 +1,11 @@
+import { Encoding } from '../types/Encoding';
+
+export default function mergeEncoding<CustomEncoding extends Encoding<string>>(
+  defaultEncoding: CustomEncoding,
+  encoding: Partial<CustomEncoding>,
+): CustomEncoding {
+  return {
+    ...defaultEncoding,
+    ...encoding,
+  };
+}

--- a/packages/superset-ui-encodable/src/utils/mergeEncoding.ts
+++ b/packages/superset-ui-encodable/src/utils/mergeEncoding.ts
@@ -1,9 +1,9 @@
-import { Encoding } from '../types/Encoding';
+import { EncodingConfig, DeriveEncoding } from '../types/Encoding';
 
-export default function mergeEncoding<CustomEncoding extends Encoding<string>>(
-  defaultEncoding: CustomEncoding,
-  encoding: Partial<CustomEncoding>,
-): CustomEncoding {
+export default function mergeEncoding<Config extends EncodingConfig>(
+  defaultEncoding: DeriveEncoding<Config>,
+  encoding: Partial<DeriveEncoding<Config>>,
+): DeriveEncoding<Config> {
   return {
     ...defaultEncoding,
     ...encoding,

--- a/packages/superset-ui-encodable/test/encoders/ChannelEncoder.test.ts
+++ b/packages/superset-ui-encodable/test/encoders/ChannelEncoder.test.ts
@@ -405,4 +405,29 @@ describe('ChannelEncoder', () => {
       expect(encoder.isXOrY()).toBeFalsy();
     });
   });
+
+  describe('.hasLegend()', () => {
+    it('returns true if channel has a legend', () => {
+      const encoder = new ChannelEncoder({
+        name: 'bubbleColor',
+        channelType: 'Color',
+        definition: {
+          type: 'nominal',
+          field: 'brand',
+        },
+      });
+      expect(encoder.hasLegend()).toBeTruthy();
+    });
+    it('returns false otherwise', () => {
+      const encoder = new ChannelEncoder({
+        name: 'x',
+        channelType: 'X',
+        definition: {
+          type: 'quantitative',
+          field: 'speed',
+        },
+      });
+      expect(encoder.hasLegend()).toBeFalsy();
+    });
+  });
 });

--- a/packages/superset-ui-encodable/test/encoders/Encoder.test.ts
+++ b/packages/superset-ui-encodable/test/encoders/Encoder.test.ts
@@ -1,0 +1,64 @@
+import createEncoderFactory from '../../src/encoders/createEncoderFactory';
+
+describe('Encoder', () => {
+  const factory = createEncoderFactory<{
+    x: ['X', number];
+    y: ['Y', number];
+    color: ['Color', string];
+    shape: ['Category', string];
+    tooltip: ['Text', string, 'multiple'];
+  }>({
+    channelTypes: {
+      x: 'X',
+      y: 'Y',
+      color: 'Color',
+      shape: 'Category',
+      tooltip: 'Text',
+    },
+    defaultEncoding: {
+      x: { type: 'quantitative', field: 'speed' },
+      y: { type: 'quantitative', field: 'price' },
+      color: { type: 'nominal', field: 'brand' },
+      shape: { type: 'nominal', field: 'brand' },
+      tooltip: [{ field: 'make' }, { field: 'model' }],
+    },
+  });
+
+  const encoder = factory.create();
+
+  describe('new Encoder()', () => {
+    it('creates new encoder', () => {
+      expect(encoder).toBeDefined();
+    });
+  });
+  describe('.getChannelNames()', () => {
+    it('returns an array of channel names', () => {
+      expect(encoder.getChannelNames()).toEqual(['x', 'y', 'color', 'shape', 'tooltip']);
+    });
+  });
+  describe('.getChannelEncoders()', () => {
+    it('returns an array of channel encoders', () => {
+      expect(encoder.getChannelEncoders()).toHaveLength(5);
+    });
+  });
+  describe('.getGroupBys()', () => {
+    it('returns an array of groupby fields', () => {
+      expect(encoder.getGroupBys()).toEqual(['brand', 'make', 'model']);
+    });
+  });
+  describe('.hasLegend()', () => {
+    it('returns true if has legend', () => {
+      expect(encoder.hasLegend()).toBeTruthy();
+    });
+    it('returns false if does not have legend', () => {
+      expect(
+        factory
+          .create({
+            color: { type: 'nominal', field: 'brand', legend: false },
+            shape: { value: 'diamond' },
+          })
+          .hasLegend(),
+      ).toBeFalsy();
+    });
+  });
+});

--- a/packages/superset-ui-encodable/test/encoders/createEncoderFactory.test.ts
+++ b/packages/superset-ui-encodable/test/encoders/createEncoderFactory.test.ts
@@ -1,0 +1,38 @@
+import createEncoderFactory from '../../src/encoders/createEncoderFactory';
+
+describe('createEncoderFactory()', () => {
+  it('supports defaultEncoding as fixed value', () => {
+    const factory = createEncoderFactory<{
+      x: ['X', number];
+    }>({
+      channelTypes: {
+        x: 'X',
+      },
+      defaultEncoding: {
+        x: { type: 'quantitative', field: 'speed' },
+      },
+    });
+
+    const encoder = factory.create();
+    expect(encoder.encoding).toEqual({
+      x: { type: 'quantitative', field: 'speed' },
+    });
+  });
+  it('supports completeEncoding for customization', () => {
+    const factory = createEncoderFactory<{
+      color: ['Color', string];
+    }>({
+      channelTypes: {
+        color: 'Color',
+      },
+      completeEncoding: () => ({
+        color: { value: 'red' },
+      }),
+    });
+
+    const encoder = factory.create();
+    expect(encoder.encoding).toEqual({
+      color: { value: 'red' },
+    });
+  });
+});

--- a/packages/superset-ui-encodable/test/fillers/completeChannelDef.test.ts
+++ b/packages/superset-ui-encodable/test/fillers/completeChannelDef.test.ts
@@ -19,6 +19,7 @@ const DEFAULT_OUTPUT = {
     title: 'speed',
     titlePadding: 4,
   },
+  legend: {},
   scale: { type: 'linear', nice: true, clamp: true, zero: true },
 };
 
@@ -49,12 +50,12 @@ describe('completeChannelDef(channelType, channelDef)', () => {
       completeChannelDef('X', {
         value: 1,
       }),
-    ).toEqual({ axis: false, scale: false, title: '', value: 1 });
+    ).toEqual({ axis: false, legend: false, scale: false, title: '', value: 1 });
   });
   it('leaves the title blank for invalid Def', () => {
     expect(
       // @ts-ignore
       completeChannelDef('X', {}),
-    ).toEqual({ axis: false, scale: false, title: '', type: 'quantitative' });
+    ).toEqual({ axis: false, legend: {}, scale: false, title: '', type: 'quantitative' });
   });
 });

--- a/packages/superset-ui-encodable/test/fillers/completeChannelDef.test.ts
+++ b/packages/superset-ui-encodable/test/fillers/completeChannelDef.test.ts
@@ -19,7 +19,7 @@ const DEFAULT_OUTPUT = {
     title: 'speed',
     titlePadding: 4,
   },
-  legend: {},
+  legend: false,
   scale: { type: 'linear', nice: true, clamp: true, zero: true },
 };
 
@@ -56,6 +56,6 @@ describe('completeChannelDef(channelType, channelDef)', () => {
     expect(
       // @ts-ignore
       completeChannelDef('X', {}),
-    ).toEqual({ axis: false, legend: {}, scale: false, title: '', type: 'quantitative' });
+    ).toEqual({ axis: false, legend: false, scale: false, title: '', type: 'quantitative' });
   });
 });

--- a/packages/superset-ui-encodable/test/fillers/completeLegendConfig.test.ts
+++ b/packages/superset-ui-encodable/test/fillers/completeLegendConfig.test.ts
@@ -1,0 +1,30 @@
+import completeLegendConfig from '../../src/fillers/completeLegendConfig';
+
+describe('completeLegendConfig()', () => {
+  it('returns input legend config if legend is defined', () => {
+    expect(
+      completeLegendConfig({
+        type: 'quantitative',
+        field: 'consumption',
+        legend: { a: 1 },
+      }),
+    ).toEqual({ a: 1 });
+  });
+  it('returns default legend config if legend is undefined', () => {
+    expect(
+      completeLegendConfig({
+        type: 'quantitative',
+        field: 'consumption',
+      }),
+    ).toEqual({});
+  });
+  it('returns false if legend is false', () => {
+    expect(
+      completeLegendConfig({
+        type: 'quantitative',
+        field: 'consumption',
+        legend: false,
+      }),
+    ).toEqual(false);
+  });
+});

--- a/packages/superset-ui-encodable/test/fillers/completeLegendConfig.test.ts
+++ b/packages/superset-ui-encodable/test/fillers/completeLegendConfig.test.ts
@@ -3,26 +3,34 @@ import completeLegendConfig from '../../src/fillers/completeLegendConfig';
 describe('completeLegendConfig()', () => {
   it('returns input legend config if legend is defined', () => {
     expect(
-      completeLegendConfig({
-        type: 'quantitative',
-        field: 'consumption',
+      completeLegendConfig('Color', {
+        type: 'nominal',
+        field: 'brand',
         legend: { a: 1 },
       }),
     ).toEqual({ a: 1 });
   });
   it('returns default legend config if legend is undefined', () => {
     expect(
-      completeLegendConfig({
+      completeLegendConfig('X', {
         type: 'quantitative',
         field: 'consumption',
+      }),
+    ).toEqual(false);
+  });
+  it('returns default legend config if legend is undefined and channel is not X or Y', () => {
+    expect(
+      completeLegendConfig('Color', {
+        type: 'nominal',
+        field: 'brand',
       }),
     ).toEqual({});
   });
   it('returns false if legend is false', () => {
     expect(
-      completeLegendConfig({
-        type: 'quantitative',
-        field: 'consumption',
+      completeLegendConfig('Color', {
+        type: 'nominal',
+        field: 'brand',
         legend: false,
       }),
     ).toEqual(false);

--- a/packages/superset-ui-encodable/test/utils/mergeEncoding.test.ts
+++ b/packages/superset-ui-encodable/test/utils/mergeEncoding.test.ts
@@ -1,0 +1,13 @@
+import mergeEncoding from '../../src/utils/mergeEncoding';
+
+describe('mergeEncoding()', () => {
+  it('combines two encoding together', () => {
+    expect(
+      mergeEncoding<{
+        size: ['Numeric', number];
+      }>({ size: { value: 1 } }, {}),
+    ).toEqual({
+      size: { value: 1 },
+    });
+  });
+});


### PR DESCRIPTION
🏆 Enhancements

Add `Encoder` to `@superset-ui/encodable`. An `Encoder` is a utility class created once per chart type. 
* It consists of one or more `ChannelEncoder`
* It takes users' definitions of the channels (`vega-lite` syntax), then resolves ambiguity and produce complete definition and actionable utility functions. 

### Example Usage

The component developer creates an encoder factory once.

```ts
type LineChartEncodingConfig = {
  // channelName: [ChannelType, output type, support multiple fields or not]
  x: ['X', number];
  y: ['Y', number];
  color: ['Color', string];
  tooltip: ['Text', string, 'multiple'];
};

const lineChartEncoderFactory = createEncoderFactory<LineChartEncodingConfig>({
    // This part is manual work to convert the `ChannelType` defined in `LineChartEncodingConfig` above
    // from `type` to `value`. `LineChartEncodingConfig` is the source of truth 
    // and because it is generic for this function, type checking will ensure the only compatible value
    // for channelTypes is exactly like the one below.
    channelTypes: {
      x: 'X',
      y: 'Y',
      color: 'Color',
      tooltip: 'Text',
    },
    // Define default definition for each channel
    defaultEncoding: {
      x: { type: 'quantitative', field: 'x' },
      y: { type: 'quantitative', field: 'y' },
      color: { value: 'black' },
      tooltip: [],
    },
  });

type LineChartEncoding = DeriveEncoding<LineChartEncodingConfig>;
```

The `factory` encapsulates the awkward `channelTypes` and `defaultEncoding`
* which are constants across all `Encoder` instance of this chart
* making it convenient to create a new `Encoder` from `encoding` because `factory.create(encoding)` only needs one argument: `encoding`.

This is how user-specified `encoding` may look like.

```ts
const encoding: LineChartEncoding = {
  x: { type: 'quantitative', field: 'speed', scale: { domain: [0, 100] } },
  y: { type: 'quantitative', field: 'price' },
  color: { type: 'nominal', field: 'brand' },
  tooltip: [{ field: 'make' }, { field: 'model' }],
};
```

Then create an `Encoder` for the incoming `encoding` and use it to facilitate rendering. 

```ts
const encoder = lineChartEncoderFactory.create(encoding);
encoder.channels.x.getValueFromDatum({ speed: 100 }); // 100
encoder.channels.x.encodeDatum({ speed: 100 }); // 1
encoder.getGroupBys(); // ['brand', 'make', 'model']
```