### PR TITLE
feat: add function for getting legend information

### DIFF
--- a/packages/superset-ui-encodable/src/encoders/ChannelEncoder.ts
+++ b/packages/superset-ui-encodable/src/encoders/ChannelEncoder.ts
@@ -3,7 +3,10 @@ import { ChannelType, ChannelInput } from '../types/Channel';
 import { PlainObject, Dataset } from '../types/Data';
 import { ChannelDef } from '../types/ChannelDef';
 import createGetterFromChannelDef, { Getter } from '../parsers/createGetterFromChannelDef';
-import completeChannelDef, { CompleteChannelDef } from '../fillers/completeChannelDef';
+import completeChannelDef, {
+  CompleteChannelDef,
+  CompleteValueDef,
+} from '../fillers/completeChannelDef';
 import createFormatterFromChannelDef from '../parsers/format/createFormatterFromChannelDef';
 import createScaleFromScaleConfig from '../parsers/scale/createScaleFromScaleConfig';
 import identity from '../utils/identity';
@@ -44,7 +47,14 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
     this.formatValue = createFormatterFromChannelDef(this.definition);
 
     const scale = this.definition.scale && createScaleFromScaleConfig(this.definition.scale);
-    this.encodeValue = scale === false ? identity : (value: ChannelInput) => scale(value);
+    if (scale === false) {
+      this.encodeValue =
+        'value' in this.definition
+          ? () => (this.definition as CompleteValueDef<Output>).value
+          : identity;
+    } else {
+      this.encodeValue = (value: ChannelInput) => scale(value);
+    }
     this.scale = scale;
   }
 

--- a/packages/superset-ui-encodable/src/encoders/ChannelEncoder.ts
+++ b/packages/superset-ui-encodable/src/encoders/ChannelEncoder.ts
@@ -80,7 +80,7 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
 
     const { type } = this.definition;
     if (type === 'nominal' || type === 'ordinal') {
-      return Array.from(new Set(data.map(d => this.getValueFromDatum(d)))) as string[];
+      return Array.from(new Set(data.map(d => this.getValueFromDatum(d)))) as ChannelInput[];
     } else if (type === 'quantitative') {
       const extent = d3Extent(data, d => this.getValueFromDatum<number>(d));
 

--- a/packages/superset-ui-encodable/src/encoders/Encoder.ts
+++ b/packages/superset-ui-encodable/src/encoders/Encoder.ts
@@ -106,7 +106,7 @@ export default class Encoder<Config extends EncodingConfig> {
         output: channelEncoders.reduce(
           (prev: Partial<{ [k in keyof Config]: Config[k]['1'] }>, curr) => {
             const map = prev;
-            map[curr.name as keyof Config] = curr.encodeValue(`${input}`) as Value;
+            map[curr.name as keyof Config] = curr.encodeValue(input) as Value;
 
             return map;
           },
@@ -128,14 +128,16 @@ export default class Encoder<Config extends EncodingConfig> {
 
           if (definition.type === 'nominal') {
             return {
+              channelEncoders,
               createLegendItems,
               field,
               items: createLegendItems(firstEncoder.getDomain(data)),
-              type: 'nominal' as const,
+              type: definition.type,
             };
           }
 
           return {
+            channelEncoders,
             createLegendItems,
             field,
             type: definition.type,

--- a/packages/superset-ui-encodable/src/encoders/Encoder.ts
+++ b/packages/superset-ui-encodable/src/encoders/Encoder.ts
@@ -1,7 +1,7 @@
 import { flatMap } from 'lodash';
 import { ChannelDef, TypedFieldDef } from '../types/ChannelDef';
 import { MayBeArray } from '../types/Base';
-import { isFieldDef, isTypedFieldDef } from '../typeGuards/ChannelDef';
+import { isTypedFieldDef } from '../typeGuards/ChannelDef';
 import { isNotArray } from '../typeGuards/Base';
 import ChannelEncoder from './ChannelEncoder';
 import {
@@ -9,6 +9,7 @@ import {
   DeriveEncoding,
   DeriveChannelTypes,
   DeriveChannelEncoders,
+  DeriveSingleChannelEncoder,
 } from '../types/Encoding';
 import { Dataset } from '../types/Data';
 import { Value } from '../types/VegaLite';
@@ -20,7 +21,7 @@ export default class Encoder<Config extends EncodingConfig> {
   readonly channels: DeriveChannelEncoders<Config>;
 
   readonly legends: {
-    [key: string]: (keyof Config)[];
+    [key: string]: DeriveSingleChannelEncoder<Config>[];
   };
 
   constructor({
@@ -67,13 +68,12 @@ export default class Encoder<Config extends EncodingConfig> {
     channelNames
       .map(name => this.channels[name])
       .forEach(c => {
-        if (isNotArray(c) && c.hasLegend() && isFieldDef(c.definition)) {
-          const name = c.name as keyof Config;
+        if (isNotArray(c) && c.hasLegend() && isTypedFieldDef(c.definition)) {
           const { field } = c.definition;
           if (this.legends[field]) {
-            this.legends[field].push(name);
+            this.legends[field].push(c);
           } else {
-            this.legends[field] = [name];
+            this.legends[field] = [c];
           }
         }
       });
@@ -101,32 +101,26 @@ export default class Encoder<Config extends EncodingConfig> {
         // for each field that was encoded
         .map((field: string) => {
           // get all the channels that use this field
-          const channelNames = this.legends[field];
-          // get first channelEncoder
-          const channelEncoder = this.channels[channelNames[0]];
-          // apply type guards
-          if (isNotArray(channelEncoder) && isTypedFieldDef(channelEncoder.definition)) {
-            // NOTE: Only work for nominal channels now
-            // Need to add support for quantitative channels
-            if (channelEncoder.definition.type === 'nominal') {
-              return channelEncoder.getDomain(data).map((value: ChannelInput) => ({
-                field,
-                value,
-                // eslint-disable-next-line sort-keys
-                output: channelNames.reduce(
-                  (prev: Partial<{ [k in keyof Config]: Config[k]['1'] }>, curr) => {
-                    const map = prev;
-                    const channel = this.channels[curr];
-                    if (isNotArray(channel)) {
-                      map[curr] = channel.encodeValue(`${value}`) as Value;
-                    }
+          const channelEncoders = this.legends[field];
+          const firstEncoder = channelEncoders[0];
+          const definition = firstEncoder.definition as TypedFieldDef;
+          // NOTE: Only work for nominal fields now
+          // Need to add support for quantitative fields
+          if (definition.type === 'nominal') {
+            return firstEncoder.getDomain(data).map((value: ChannelInput) => ({
+              field,
+              value,
+              // eslint-disable-next-line sort-keys
+              output: channelEncoders.reduce(
+                (prev: Partial<{ [k in keyof Config]: Config[k]['1'] }>, curr) => {
+                  const map = prev;
+                  map[curr.name as keyof Config] = curr.encodeValue(`${value}`) as Value;
 
-                    return map;
-                  },
-                  {},
-                ),
-              }));
-            }
+                  return map;
+                },
+                {},
+              ),
+            }));
           }
 
           return [];

--- a/packages/superset-ui-encodable/src/encoders/Encoder.ts
+++ b/packages/superset-ui-encodable/src/encoders/Encoder.ts
@@ -9,7 +9,6 @@ import {
   DeriveEncoding,
   DeriveChannelTypes,
   DeriveChannelEncoders,
-  DeriveChannelOutputs,
 } from '../types/Encoding';
 import { Dataset } from '../types/Data';
 import { Value } from '../types/VegaLite';
@@ -107,8 +106,8 @@ export default class Encoder<Config extends EncodingConfig> {
           const channelEncoder = this.channels[channelNames[0]];
           // apply type guards
           if (isNotArray(channelEncoder) && isTypedFieldDef(channelEncoder.definition)) {
-            // Only work for nominal channels now
-            // TODO: Add support for numerical scale
+            // NOTE: Only work for nominal channels now
+            // Need to add support for quantitative channels
             if (channelEncoder.definition.type === 'nominal') {
               return channelEncoder.getDomain(data).map((value: ChannelInput) => ({
                 field,

--- a/packages/superset-ui-encodable/src/types/Encoding.ts
+++ b/packages/superset-ui-encodable/src/types/Encoding.ts
@@ -11,7 +11,9 @@ export type DeriveChannelTypes<Config extends EncodingConfig> = {
 };
 
 export type DeriveChannelOutputs<Config extends EncodingConfig> = {
-  readonly [k in keyof Config]: Config[k]['1'];
+  readonly [k in keyof Config]: Config[k]['2'] extends 'multiple'
+    ? Config[k]['1'][]
+    : Config[k]['1'];
 };
 
 export type DeriveEncoding<Config extends EncodingConfig> = {

--- a/packages/superset-ui-encodable/src/types/Encoding.ts
+++ b/packages/superset-ui-encodable/src/types/Encoding.ts
@@ -27,3 +27,8 @@ export type DeriveChannelEncoders<Config extends EncodingConfig> = {
     ? ChannelEncoder<ChannelTypeToDefMap<Config[k]['1']>[Config[k]['0']]>[]
     : ChannelEncoder<ChannelTypeToDefMap<Config[k]['1']>[Config[k]['0']]>;
 };
+
+export type DeriveSingleChannelEncoder<
+  Config extends EncodingConfig,
+  k extends keyof Config = keyof Config
+> = ChannelEncoder<ChannelTypeToDefMap<Config[k]['1']>[Config[k]['0']]>;

--- a/packages/superset-ui-encodable/test/encoders/Encoder.test.ts
+++ b/packages/superset-ui-encodable/test/encoders/Encoder.test.ts
@@ -46,6 +46,88 @@ describe('Encoder', () => {
       expect(encoder.getGroupBys()).toEqual(['brand', 'make', 'model']);
     });
   });
+  describe('.getLegendInformation()', () => {
+    it('returns information for each field', () => {
+      expect(
+        factory
+          .create({
+            color: { type: 'nominal', field: 'brand', scale: { range: ['red', 'green', 'blue'] } },
+            shape: { type: 'nominal', field: 'brand', scale: { range: ['circle', 'diamond'] } },
+          })
+          .getLegendInformation([{ brand: 'Gucci' }, { brand: 'Prada' }]),
+      ).toEqual([
+        [
+          {
+            field: 'brand',
+            value: 'Gucci',
+            output: {
+              color: 'red',
+              shape: 'circle',
+            },
+          },
+          {
+            field: 'brand',
+            value: 'Prada',
+            output: {
+              color: 'green',
+              shape: 'diamond',
+            },
+          },
+        ],
+      ]);
+    });
+    it('ignore channels that are ValueDef', () => {
+      expect(
+        factory
+          .create({
+            color: { type: 'nominal', field: 'brand', scale: { range: ['red', 'green', 'blue'] } },
+            shape: { value: 'square' },
+          })
+          .getLegendInformation([{ brand: 'Gucci' }, { brand: 'Prada' }]),
+      ).toEqual([
+        [
+          {
+            field: 'brand',
+            value: 'Gucci',
+            output: {
+              color: 'red',
+            },
+          },
+          {
+            field: 'brand',
+            value: 'Prada',
+            output: {
+              color: 'green',
+            },
+          },
+        ],
+      ]);
+    });
+    it('only works for nominal field', () => {
+      expect(
+        factory
+          .create({
+            color: {
+              type: 'quantitative',
+              field: 'price',
+              scale: { range: ['red', 'green', 'blue'] },
+            },
+            shape: { value: 'square' },
+          })
+          .getLegendInformation([{ brand: 'Gucci', price: 10 }, { brand: 'Prada', price: 20 }]),
+      ).toEqual([]);
+    });
+    it('returns empty array if no legend', () => {
+      expect(
+        factory
+          .create({
+            color: { value: 'black' },
+            shape: { value: 'square' },
+          })
+          .getLegendInformation([{ brand: 'Gucci' }, { brand: 'Prada' }]),
+      ).toEqual([]);
+    });
+  });
   describe('.hasLegend()', () => {
     it('returns true if has legend', () => {
       expect(encoder.hasLegend()).toBeTruthy();

--- a/packages/superset-ui-encodable/test/encoders/Encoder.test.ts
+++ b/packages/superset-ui-encodable/test/encoders/Encoder.test.ts
@@ -2,7 +2,7 @@ import createEncoderFactory from '../../src/encoders/createEncoderFactory';
 
 function stripFunction(legendInfo) {
   return legendInfo.map(legendGroup => {
-    const { createLegendItems, ...rest } = legendGroup;
+    const { createLegendItems, channelEncoders, ...rest } = legendGroup;
 
     return { ...rest };
   });


### PR DESCRIPTION
🏆 Enhancements

Add `encoder.getLegendInformation(dataset)`, which generates metadata for rendering legend.

### Example usage

```ts
const legendInfo = factory
  .create({
    color: { 
      type: 'nominal', 
      field: 'brand', 
      scale: { range: ['red', 'green', 'blue'] } 
    },
    radius: { value: 5 },
    shape: { value: 'circle' },
  })
  .getLegendInformation([{ brand: 'Gucci' }, { brand: 'Prada' }]);

// [
//   // legend group information
//   {
//     field: 'brand',
//     type: 'nominal',
//     items: [
//       {
//         input: 'Gucci',
//         output: {
//           color: 'red',
//           radius: 5,
//           shape: 'circle',
//         },
//       },
//       {
//         input: 'Prada',
//         output: {
//           color: 'green',
//           radius: 5,
//           shape: 'circle',
//         },
//       },
//     ],
//   }
// ]
```

This also works with quantitative fields, with small difference. 

```ts
const legendInfo = factory
  .create({
    color: {
      type: 'quantitative',
      field: 'price',
      scale: { domain: [0, 20], range: ['#fff', '#f00'] },
    },
    radius: {
      type: 'quantitative',
      field: 'price',
      scale: { domain: [0, 20], range: [0, 10] },
    },
    shape: { value: 'circle' },
  })
  .getLegendInformation();
```

Unlike the nominal field, `items` is not included in the output, so you cannot use `legendInfo[0].items` directly. Have to create legend items manually from inputs. 

In the future we can implement logic to infer the appropriate inputs from continuous domain and output items the same way the nominal field does.

```ts
legendInfo[0].createLegendItems([0, 10, 20]);

// [
//   {
//     input: 0,
//     output: {
//       color: 'rgb(255, 255, 255)',
//       radius: 0,
//       shape: 'circle',
//     },
//   },
//   {
//     input: 10,
//     output: {
//       color: 'rgb(255, 128, 128)',
//       radius: 5,
//       shape: 'circle',
//     },
//   },
//   {
//     input: 20,
//     output: {
//       color: 'rgb(255, 0, 0)',
//       radius: 10,
//       shape: 'circle',
//     },
//   },
// ]
```
