### PR TITLE
feat(time-format): bump d3-time-format

### DIFF
--- a/packages/superset-ui-time-format/package.json
+++ b/packages/superset-ui-time-format/package.json
@@ -29,7 +29,7 @@
     "@types/d3-time": "^1.0.9",
     "@types/d3-time-format": "^2.1.0",
     "d3-time": "^1.0.10",
-    "d3-time-format": "^2.1.3"
+    "d3-time-format": "^2.2.0"
   },
   "peerDependencies": {
     "@superset-ui/core": "^0.12.0"


### PR DESCRIPTION
🏆 Enhancements

Will allow us to use the `%q` directive for quarter of the year: https://github.com/d3/d3-time-format/releases/tag/v2.2.0

Tested with CI


@kristw @williaster @michellethomas 