### PR TITLE
feat(encodable): only set scale domain if both bounds are defined

### DIFF
--- a/packages/superset-ui-encodable/src/parsers/scale/applyDomain.ts
+++ b/packages/superset-ui-encodable/src/parsers/scale/applyDomain.ts
@@ -1,21 +1,23 @@
+import { isDateTime } from 'vega-lite/build/src/datetime';
 import { Value } from '../../types/VegaLite';
-import { ScaleConfig, D3Scale, TimeScaleConfig } from '../../types/Scale';
+import { ScaleConfig, D3Scale } from '../../types/Scale';
 import parseDateTime from '../parseDateTime';
 import inferElementTypeFromUnionOfArrayTypes from '../../utils/inferElementTypeFromUnionOfArrayTypes';
-import { isTimeScale } from '../../typeGuards/Scale';
+import { isEveryElementDefined } from '../../typeGuards/Base';
 
 export default function applyDomain<Output extends Value>(
   config: ScaleConfig<Output>,
   scale: D3Scale<Output>,
 ) {
-  const { domain, reverse, type } = config;
-  if (typeof domain !== 'undefined') {
-    const processedDomain = reverse ? domain.slice().reverse() : domain;
-    if (isTimeScale(scale, type)) {
-      const timeDomain = processedDomain as TimeScaleConfig['domain'];
-      scale.domain(inferElementTypeFromUnionOfArrayTypes(timeDomain).map(d => parseDateTime(d)));
-    } else {
-      scale.domain(processedDomain);
+  const { domain, reverse } = config;
+  if (typeof domain !== 'undefined' && domain.length > 0) {
+    const processedDomain = inferElementTypeFromUnionOfArrayTypes(
+      reverse ? domain.slice().reverse() : domain,
+    );
+
+    // Only set domain if all items are defined
+    if (isEveryElementDefined(processedDomain)) {
+      scale.domain(processedDomain.map(d => (isDateTime(d) ? parseDateTime(d) : d)));
     }
   }
 }

--- a/packages/superset-ui-encodable/src/parsers/scale/applyDomain.ts
+++ b/packages/superset-ui-encodable/src/parsers/scale/applyDomain.ts
@@ -11,13 +11,15 @@ export default function applyDomain<Output extends Value>(
 ) {
   const { domain, reverse } = config;
   if (typeof domain !== 'undefined' && domain.length > 0) {
-    const processedDomain = inferElementTypeFromUnionOfArrayTypes(
-      reverse ? domain.slice().reverse() : domain,
-    );
+    const processedDomain = inferElementTypeFromUnionOfArrayTypes(domain);
 
     // Only set domain if all items are defined
     if (isEveryElementDefined(processedDomain)) {
-      scale.domain(processedDomain.map(d => (isDateTime(d) ? parseDateTime(d) : d)));
+      scale.domain(
+        (reverse ? processedDomain.slice().reverse() : processedDomain).map(d =>
+          isDateTime(d) ? parseDateTime(d) : d,
+        ),
+      );
     }
   }
 }

--- a/packages/superset-ui-encodable/src/typeGuards/Base.ts
+++ b/packages/superset-ui-encodable/src/typeGuards/Base.ts
@@ -9,3 +9,7 @@ export function isNotArray<T>(maybeArray: T | T[]): maybeArray is T {
 export function isDefined<T>(value: any): value is T {
   return typeof value !== 'undefined' && value !== null;
 }
+
+export function isEveryElementDefined<T>(array: T[]): array is Exclude<T, undefined | null>[] {
+  return array.every(isDefined);
+}

--- a/packages/superset-ui-encodable/src/typeGuards/Scale.ts
+++ b/packages/superset-ui-encodable/src/typeGuards/Scale.ts
@@ -10,6 +10,7 @@ import {
   SymlogScaleConfig,
   TimeScaleConfig,
   UtcScaleConfig,
+  ContinuousD3Scale,
 } from '../types/Scale';
 import { Value, ScaleType } from '../types/VegaLite';
 import { timeScaleTypesSet, continuousScaleTypesSet } from '../parsers/scale/scaleCategories';
@@ -48,6 +49,13 @@ export function isD3Scale<Output extends Value = Value>(
   scale: D3Scale<Output> | CategoricalColorScale,
 ): scale is D3Scale<Output> {
   return !isCategoricalColorScale(scale);
+}
+
+export function isContinuousScale<Output extends Value = Value>(
+  scale: D3Scale<Output> | CategoricalColorScale,
+  scaleType: ScaleType,
+): scale is ContinuousD3Scale<Output> {
+  return scale && continuousScaleTypesSet.has(scaleType);
 }
 
 export function isTimeScale<Output extends Value = Value>(

--- a/packages/superset-ui-encodable/src/types/Scale.ts
+++ b/packages/superset-ui-encodable/src/types/Scale.ts
@@ -40,7 +40,7 @@ export interface CombinedScaleConfig<Output extends Value = Value>
   /**
    * domain of the scale
    */
-  domain?: number[] | string[] | boolean[] | DateTime[];
+  domain?: (number | undefined | null)[] | string[] | boolean[] | (DateTime | undefined | null)[];
   /**
    * range of the scale
    */

--- a/packages/superset-ui-encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
+++ b/packages/superset-ui-encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
@@ -41,7 +41,6 @@ describe('createScaleFromScaleConfig(config)', () => {
             type: 'linear',
             domain: [undefined, 30],
             range: [0, 100],
-            reverse: true,
           });
           expect(scale(10)).toEqual(1000);
         });
@@ -50,7 +49,6 @@ describe('createScaleFromScaleConfig(config)', () => {
             type: 'linear',
             domain: [0, undefined],
             range: [0, 100],
-            reverse: true,
           });
           expect(scale(10)).toEqual(1000);
         });
@@ -59,7 +57,6 @@ describe('createScaleFromScaleConfig(config)', () => {
             type: 'linear',
             domain: [undefined, undefined],
             range: [0, 100],
-            reverse: true,
           });
           expect(scale(10)).toEqual(1000);
         });
@@ -70,7 +67,6 @@ describe('createScaleFromScaleConfig(config)', () => {
             type: 'linear',
             domain: [null, 30],
             range: [0, 100],
-            reverse: true,
           });
           expect(scale(10)).toEqual(1000);
         });
@@ -79,7 +75,6 @@ describe('createScaleFromScaleConfig(config)', () => {
             type: 'linear',
             domain: [0, null],
             range: [0, 100],
-            reverse: true,
           });
           expect(scale(10)).toEqual(1000);
         });
@@ -88,7 +83,6 @@ describe('createScaleFromScaleConfig(config)', () => {
             type: 'linear',
             domain: [null, null],
             range: [0, 100],
-            reverse: true,
           });
           expect(scale(10)).toEqual(1000);
         });

--- a/packages/superset-ui-encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
+++ b/packages/superset-ui-encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
@@ -34,6 +34,66 @@ describe('createScaleFromScaleConfig(config)', () => {
       });
       expect(scale(10)).toEqual(0);
     });
+    describe('does not set domain if domain has undefined or null', () => {
+      describe('undefined', () => {
+        it('min', () => {
+          const scale = createScaleFromScaleConfig({
+            type: 'linear',
+            domain: [undefined, 30],
+            range: [0, 100],
+            reverse: true,
+          });
+          expect(scale(10)).toEqual(1000);
+        });
+        it('max', () => {
+          const scale = createScaleFromScaleConfig({
+            type: 'linear',
+            domain: [0, undefined],
+            range: [0, 100],
+            reverse: true,
+          });
+          expect(scale(10)).toEqual(1000);
+        });
+        it('both', () => {
+          const scale = createScaleFromScaleConfig({
+            type: 'linear',
+            domain: [undefined, undefined],
+            range: [0, 100],
+            reverse: true,
+          });
+          expect(scale(10)).toEqual(1000);
+        });
+      });
+      describe('null', () => {
+        it('min', () => {
+          const scale = createScaleFromScaleConfig({
+            type: 'linear',
+            domain: [null, 30],
+            range: [0, 100],
+            reverse: true,
+          });
+          expect(scale(10)).toEqual(1000);
+        });
+        it('max', () => {
+          const scale = createScaleFromScaleConfig({
+            type: 'linear',
+            domain: [0, null],
+            range: [0, 100],
+            reverse: true,
+          });
+          expect(scale(10)).toEqual(1000);
+        });
+        it('both', () => {
+          const scale = createScaleFromScaleConfig({
+            type: 'linear',
+            domain: [null, null],
+            range: [0, 100],
+            reverse: true,
+          });
+          expect(scale(10)).toEqual(1000);
+        });
+      });
+    });
     it('with color scheme as range', () => {
       getSequentialSchemeRegistry().registerValue(
         'test-scheme',

--- a/packages/superset-ui-encodable/test/typeGuards/Base.test.ts
+++ b/packages/superset-ui-encodable/test/typeGuards/Base.test.ts
@@ -1,4 +1,4 @@
-import { isDefined, isArray, isNotArray } from '../../src/typeGuards/Base';
+import { isDefined, isArray, isNotArray, isEveryElementDefined } from '../../src/typeGuards/Base';
 
 describe('type guards: Base', () => {
   describe('isArray<T>(maybeArray)', () => {
@@ -35,6 +35,20 @@ describe('type guards: Base', () => {
     it('returns false if not defined', () => {
       expect(isDefined(null)).toBeFalsy();
       expect(isDefined(undefined)).toBeFalsy();
+    });
+  });
+  describe('isEveryElementDefined<T>(array)', () => {
+    it('returns true and remove undefined from possible return type', () => {
+      expect(isEveryElementDefined(['a', 'b'])).toBeTruthy();
+      expect(isEveryElementDefined([])).toBeTruthy();
+      const array: (string | undefined)[] = ['a', 'b'];
+      if (isEveryElementDefined(array)) {
+        expect(array.every(a => a.length === 1)).toBeTruthy();
+      }
+    });
+    it('returns false otherwise', () => {
+      expect(isEveryElementDefined([undefined])).toBeFalsy();
+      expect(isEveryElementDefined([undefined, 'a'])).toBeFalsy();
     });
   });
 });

--- a/packages/superset-ui-encodable/test/typeGuards/Scale.test.ts
+++ b/packages/superset-ui-encodable/test/typeGuards/Scale.test.ts
@@ -6,6 +6,7 @@ import {
   isTimeScale,
   isContinuousScaleConfig,
   isScaleConfigWithZero,
+  isContinuousScale,
 } from '../../src/typeGuards/Scale';
 import { HasToString } from '../../src/types/Base';
 
@@ -41,6 +42,14 @@ describe('type guards', () => {
     });
     it('returns false otherwise', () => {
       expect(isCategoricalColorScale(scaleLinear())).toBeFalsy();
+    });
+  });
+  describe('isContinuousScale(scale, type)', () => {
+    it('returns true if type is one of the time scale types', () => {
+      expect(isContinuousScale(scaleLinear(), 'linear')).toBeTruthy();
+    });
+    it('returns false otherwise', () => {
+      expect(isContinuousScale(scaleOrdinal<HasToString, string>(), 'ordinal')).toBeFalsy();
     });
   });
   describe('isTimeScale(scale, type)', () => {


### PR DESCRIPTION
🏆 Enhancements

The `domain` field in `scale` configuration should act like user-specified bounds for the `domain` obtained from dataset. The `applyDomain()` function is called when trying to create a `scale` from the configuration alone, without knowledge about the dataset yet.

* If both `[min, max]` are set, it makes sense to set that `domain` to the `scale` object on initialization immediately because the `domain` from dataset will be overridden by the user-specified `domain`. 
* However, if one or both of `[min, max]` is not set, e.g. `[0, null]`. This `null` value means that max bound should be obtained from dataset. Therefore, the `domain` of `scale` object cannot be set yet until the dataset is known.