### PR TITLE
build: fix lodash type dependencies

### DIFF
--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -29,6 +29,7 @@
     "jest-mock-console": "^1.0.0"
   },
   "dependencies": {
+    "@types/lodash": "4.14.108",
     "lodash": "^4.17.11"
   }
 }


### PR DESCRIPTION
🏠 Internal

* Add `@types/lodash` to dependencies to fix broken build.