### PR TITLE
fix(dimension): set width=0, height=0 in `createHiddenSvgNode`

### DIFF
--- a/packages/superset-ui-dimension/src/svg/createHiddenSvgNode.ts
+++ b/packages/superset-ui-dimension/src/svg/createHiddenSvgNode.ts
@@ -3,8 +3,12 @@ import { SVG_NS } from './constants';
 export default function createHiddenSvgNode() {
   const svgNode = document.createElementNS(SVG_NS, 'svg');
   svgNode.style.position = 'absolute'; // so it won't disrupt page layout
-  svgNode.style.opacity = '0'; // and not visible
-  svgNode.style.pointerEvents = 'none'; // and not capturing mouse events
+  svgNode.style.top = '-100%';
+  svgNode.style.left = '-100%';
+  svgNode.style.width = '0'; // no dimensions
+  svgNode.style.height = '0';
+  svgNode.style.opacity = '0'; // not visible
+  svgNode.style.pointerEvents = 'none'; // won't capture mouse events
 
   return svgNode;
 }


### PR DESCRIPTION
🐛 Bug Fix
This fixes an issue in `@superset-ui/dimensions` where the hidden `svg` used for text measurement has a non-zero `width/height`, and can result in the `svg` affecting layout even though it has `position: absolute`. In our case this actually causes an infinite measurement loop where 

1) the `svg` is added, resulting in a browser scroll bar
2) the `svg` is removed, making the scroll bar go away
3) the screen width change in `2)` from the scroll bar going away triggers the ResizeObserver of a parent component, updating the chart and goes back to `1)` 

I updated it to mirror what we have in `@vx/text` which was fixed [here](https://github.com/hshoff/vx/pull/358).

@kristw 