### PR TITLE
feat(number-format): bump pretty-ms to 5.1.0

### DIFF
--- a/packages/superset-ui-number-format/package.json
+++ b/packages/superset-ui-number-format/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/d3-format": "^1.3.0",
     "d3-format": "^1.3.2",
-    "pretty-ms": "^5.0.0"
+    "pretty-ms": "^5.1.0"
   },
   "peerDependencies": {
     "@superset-ui/core": "^0.12.0"


### PR DESCRIPTION
🏆 Enhancements

Bump `pretty-ms` to `5.1.0` to enable support for `colonNotation` option in `duration-formatter`: https://github.com/sindresorhus/pretty-ms/pull/37