### PR TITLE
docs: add durationFormatter example to number-format README.md

### DIFF
--- a/packages/superset-ui-number-format/README.md
+++ b/packages/superset-ui-number-format/README.md
@@ -48,10 +48,10 @@ NumberFormats.PERCENT_3_POINT // ,.3%
 There is also a formatter based on [pretty-ms](https://www.npmjs.com/package/pretty-ms) that can be used to format time durations:
 
 ```js
-import { createDurationFormatter } from from '@superset-ui-number-format';
+import { createDurationFormatter, formatNumber, getNumberFormatterRegistry } from from '@superset-ui-number-format';
 
-const durationFormatter = createDurationFormatter({ colonNotation: true });
-console.log(durationFormatter(95500))
+getNumberFormatterRegistry().registerValue('my_duration_format', createDurationFormatter({ colonNotation: true });
+console.log(formatNumber('my_duration_format', 95500))
 // prints '1:35.5'
 ```
 

--- a/packages/superset-ui-number-format/README.md
+++ b/packages/superset-ui-number-format/README.md
@@ -45,6 +45,16 @@ NumberFormats.PERCENT // ,.2%
 NumberFormats.PERCENT_3_POINT // ,.3%
 ```
 
+There is also a formatter based on [pretty-ms](https://www.npmjs.com/package/pretty-ms) that can be used to format time durations:
+
+```js
+import { createDurationFormatter } from from '@superset-ui-number-format';
+
+const durationFormatter = createDurationFormatter({ colonNotation: true });
+console.log(durationFormatter(95500))
+// prints '1:35.5'
+```
+
 #### API
 
 `fn(args)`


### PR DESCRIPTION
📜 Documentation
Add example to `superset-ui-number-format` README about how to use `durationFormatter`.