### PR TITLE
feat: make formatTime and formatNumber accept undefined type

### DIFF
--- a/packages/superset-ui-number-format/src/NumberFormatterRegistry.ts
+++ b/packages/superset-ui-number-format/src/NumberFormatterRegistry.ts
@@ -38,7 +38,7 @@ export default class NumberFormatterRegistry extends RegistryWithDefaultKey<
     return formatter;
   }
 
-  format(formatterId: string, value: number | null | undefined): string {
+  format(formatterId: string | undefined, value: number | null | undefined): string {
     return this.get(formatterId)(value);
   }
 }

--- a/packages/superset-ui-number-format/test/NumberFormatterRegistry.test.ts
+++ b/packages/superset-ui-number-format/test/NumberFormatterRegistry.test.ts
@@ -43,5 +43,8 @@ describe('NumberFormatterRegistry', () => {
       expect(registry.format('.2f', 100)).toEqual('100.00');
       expect(registry.format(',d', 100)).toEqual('100');
     });
+    it('falls back to the default formatter if the format is undefined', () => {
+      expect(registry.format(undefined, 1000)).toEqual('1k');
+    });
   });
 });

--- a/packages/superset-ui-time-format/src/TimeFormatterRegistry.ts
+++ b/packages/superset-ui-time-format/src/TimeFormatterRegistry.ts
@@ -31,7 +31,7 @@ export default class TimeFormatterRegistry extends RegistryWithDefaultKey<
     return formatter;
   }
 
-  format(format: string, value: Date | null | undefined): string {
+  format(format: string | undefined, value: Date | null | undefined): string {
     return this.get(format)(value);
   }
 }

--- a/packages/superset-ui-time-format/test/TimeFormatterRegistry.test.ts
+++ b/packages/superset-ui-time-format/test/TimeFormatterRegistry.test.ts
@@ -33,5 +33,8 @@ describe('TimeFormatterRegistry', () => {
       expect(registry.format(TimeFormats.US_DATE, PREVIEW_TIME)).toEqual('02/14/2017');
       expect(registry.format(TimeFormats.TIME, PREVIEW_TIME)).toEqual('11:22:33');
     });
+    it('falls back to the default formatter if the format is undefined', () => {
+      expect(registry.format(undefined, PREVIEW_TIME)).toEqual('2017-02-14 11:22:33');
+    });
   });
 });


### PR DESCRIPTION
🏆 Enhancements

* Make `formatTime` and `formatNumber` handle `undefined` type. The logic is already there, but the argument type was still `string`

cc @ktmud 