### PR TITLE
feat: add validator package

### DIFF
--- a/packages/superset-ui-validator/README.md
+++ b/packages/superset-ui-validator/README.md
@@ -1,0 +1,23 @@
+## @superset-ui/validator
+
+[![Version](https://img.shields.io/npm/v/@superset-ui/validator.svg?style=flat)](https://img.shields.io/npm/v/@superset-ui/validator.svg?style=flat)
+[![David (path)](https://img.shields.io/david/apache-superset/superset-ui.svg?path=packages%2Fsuperset-ui-validator&style=flat-square)](https://david-dm.org/apache-superset/superset-ui?path=packages/superset-ui-validator)
+
+Description
+
+#### Example usage
+
+```js
+import { xxx } from '@superset-ui/validator';
+```
+
+#### API
+
+`fn(args)`
+
+- Do something
+
+### Development
+
+`@data-ui/build-config` is used to manage the build configuration for this package including babel
+builds, jest testing, eslint, and prettier.

--- a/packages/superset-ui-validator/package.json
+++ b/packages/superset-ui-validator/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@superset-ui/validator",
+  "version": "0.0.0",
+  "description": "Superset UI validator",
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "module": "esm/index.js",
+  "files": [
+    "esm",
+    "lib"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apache-superset/superset-ui.git"
+  },
+  "keywords": ["superset"],
+  "author": "Superset",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/apache-superset/superset-ui/issues"
+  },
+  "homepage": "https://github.com/apache-superset/superset-ui#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@superset-ui/translation": "^0.12.0"
+  }
+}

--- a/packages/superset-ui-validator/src/index.ts
+++ b/packages/superset-ui-validator/src/index.ts
@@ -1,0 +1,3 @@
+export { default as validateInteger } from './validateInteger';
+export { default as validateNumber } from './validateNumber';
+export { default as validateNonEmpty } from './validateNonEmpty';

--- a/packages/superset-ui-validator/src/index.ts
+++ b/packages/superset-ui-validator/src/index.ts
@@ -1,3 +1,5 @@
+export { default as legacyValidateInteger } from './legacyValidateInteger';
+export { default as legacyValidateNumber } from './legacyValidateNumber';
 export { default as validateInteger } from './validateInteger';
 export { default as validateNumber } from './validateNumber';
 export { default as validateNonEmpty } from './validateNonEmpty';

--- a/packages/superset-ui-validator/src/legacyValidateInteger.ts
+++ b/packages/superset-ui-validator/src/legacyValidateInteger.ts
@@ -1,0 +1,12 @@
+import { t } from '@superset-ui/translation';
+
+/**
+ * formerly called integer()
+ * @param v
+ */
+export default function legacyValidateInteger(v: unknown) {
+  if (v && (isNaN(v as number) || parseInt(v as string, 10) !== Number(v))) {
+    return t('is expected to be an integer');
+  }
+  return false;
+}

--- a/packages/superset-ui-validator/src/legacyValidateNumber.ts
+++ b/packages/superset-ui-validator/src/legacyValidateNumber.ts
@@ -1,0 +1,12 @@
+import { t } from '@superset-ui/translation';
+
+/**
+ * formerly called numeric()
+ * @param v
+ */
+export default function numeric(v: unknown) {
+  if (v && isNaN(v as number)) {
+    return t('is expected to be a number');
+  }
+  return false;
+}

--- a/packages/superset-ui-validator/src/validateInteger.ts
+++ b/packages/superset-ui-validator/src/validateInteger.ts
@@ -2,7 +2,7 @@ import { t } from '@superset-ui/translation';
 
 export default function validateInteger(v: unknown) {
   if (
-    (typeof v === 'string' && Number.isInteger(Number(v))) ||
+    (typeof v === 'string' && v.trim().length > 0 && Number.isInteger(Number(v.trim()))) ||
     (typeof v === 'number' && Number.isInteger(v))
   ) {
     return false;

--- a/packages/superset-ui-validator/src/validateInteger.ts
+++ b/packages/superset-ui-validator/src/validateInteger.ts
@@ -1,0 +1,12 @@
+import { t } from '@superset-ui/translation';
+
+export default function validateInteger(v: unknown) {
+  if (
+    (typeof v === 'string' && Number.isInteger(Number(v))) ||
+    (typeof v === 'number' && Number.isInteger(v))
+  ) {
+    return false;
+  }
+
+  return t('is expected to be an integer');
+}

--- a/packages/superset-ui-validator/src/validateNonEmpty.ts
+++ b/packages/superset-ui-validator/src/validateNonEmpty.ts
@@ -1,0 +1,8 @@
+import { t } from '@superset-ui/translation';
+
+export default function isNotEmpty(v: unknown) {
+  if (v === null || typeof v === 'undefined' || v === '' || (Array.isArray(v) && v.length === 0)) {
+    return t('cannot be empty');
+  }
+  return false;
+}

--- a/packages/superset-ui-validator/src/validateNonEmpty.ts
+++ b/packages/superset-ui-validator/src/validateNonEmpty.ts
@@ -1,6 +1,6 @@
 import { t } from '@superset-ui/translation';
 
-export default function isNotEmpty(v: unknown) {
+export default function validateNonEmpty(v: unknown) {
   if (v === null || typeof v === 'undefined' || v === '' || (Array.isArray(v) && v.length === 0)) {
     return t('cannot be empty');
   }

--- a/packages/superset-ui-validator/src/validateNumber.ts
+++ b/packages/superset-ui-validator/src/validateNumber.ts
@@ -1,0 +1,12 @@
+import { t } from '@superset-ui/translation';
+
+export default function validateInteger(v: unknown) {
+  if (
+    (typeof v === 'string' && Number.isFinite(Number(v))) ||
+    (typeof v === 'number' && Number.isFinite(v))
+  ) {
+    return false;
+  }
+
+  return t('is expected to be a number');
+}

--- a/packages/superset-ui-validator/src/validateNumber.ts
+++ b/packages/superset-ui-validator/src/validateNumber.ts
@@ -2,7 +2,7 @@ import { t } from '@superset-ui/translation';
 
 export default function validateInteger(v: unknown) {
   if (
-    (typeof v === 'string' && Number.isFinite(Number(v))) ||
+    (typeof v === 'string' && v.trim().length > 0 && Number.isFinite(Number(v.trim()))) ||
     (typeof v === 'number' && Number.isFinite(v))
   ) {
     return false;

--- a/packages/superset-ui-validator/test/legacyValidateInteger.test.ts
+++ b/packages/superset-ui-validator/test/legacyValidateInteger.test.ts
@@ -1,0 +1,20 @@
+import { legacyValidateInteger } from '../src';
+
+describe('legacyValidateInteger()', () => {
+  it('returns the warning message if invalid', () => {
+    expect(legacyValidateInteger(10.1)).toBeTruthy();
+    expect(legacyValidateInteger('abc')).toBeTruthy();
+    expect(legacyValidateInteger(Infinity)).toBeTruthy();
+  });
+  it('returns false if the input is valid', () => {
+    // superset seems to operate on this incorrect behavior at the moment
+    expect(legacyValidateInteger(NaN)).toBeFalsy();
+    expect(legacyValidateInteger(undefined)).toBeFalsy();
+    expect(legacyValidateInteger(null)).toBeFalsy();
+    expect(legacyValidateInteger('')).toBeFalsy();
+
+    expect(legacyValidateInteger(0)).toBeFalsy();
+    expect(legacyValidateInteger(10)).toBeFalsy();
+    expect(legacyValidateInteger('10')).toBeFalsy();
+  });
+});

--- a/packages/superset-ui-validator/test/legacyValidateNumber.test.ts
+++ b/packages/superset-ui-validator/test/legacyValidateNumber.test.ts
@@ -1,0 +1,20 @@
+import { legacyValidateNumber } from '../src';
+
+describe('legacyValidateNumber()', () => {
+  it('returns the warning message if invalid', () => {
+    expect(legacyValidateNumber('abc')).toBeTruthy();
+  });
+  it('returns false if the input is valid', () => {
+    // superset seems to operate on this incorrect behavior at the moment
+    expect(legacyValidateNumber(NaN)).toBeFalsy();
+    expect(legacyValidateNumber(Infinity)).toBeFalsy();
+    expect(legacyValidateNumber(undefined)).toBeFalsy();
+    expect(legacyValidateNumber(null)).toBeFalsy();
+    expect(legacyValidateNumber('')).toBeFalsy();
+
+    expect(legacyValidateNumber(0)).toBeFalsy();
+    expect(legacyValidateNumber(10.1)).toBeFalsy();
+    expect(legacyValidateNumber(10)).toBeFalsy();
+    expect(legacyValidateNumber('10')).toBeFalsy();
+  });
+});

--- a/packages/superset-ui-validator/test/validateInteger.test.ts
+++ b/packages/superset-ui-validator/test/validateInteger.test.ts
@@ -8,6 +8,7 @@ describe('validateInteger()', () => {
     expect(validateInteger('')).toBeTruthy();
   });
   it('returns false if the input is valid', () => {
+    expect(validateInteger(0)).toBeFalsy();
     expect(validateInteger(10)).toBeFalsy();
     expect(validateInteger('10')).toBeFalsy();
   });

--- a/packages/superset-ui-validator/test/validateInteger.test.ts
+++ b/packages/superset-ui-validator/test/validateInteger.test.ts
@@ -3,8 +3,11 @@ import { validateInteger } from '../src';
 describe('validateInteger()', () => {
   it('returns the warning message if invalid', () => {
     expect(validateInteger(10.1)).toBeTruthy();
+    expect(validateInteger(NaN)).toBeTruthy();
+    expect(validateInteger(Infinity)).toBeTruthy();
     expect(validateInteger(undefined)).toBeTruthy();
     expect(validateInteger(null)).toBeTruthy();
+    expect(validateInteger('abc')).toBeTruthy();
     expect(validateInteger('')).toBeTruthy();
   });
   it('returns false if the input is valid', () => {

--- a/packages/superset-ui-validator/test/validateInteger.test.ts
+++ b/packages/superset-ui-validator/test/validateInteger.test.ts
@@ -1,0 +1,14 @@
+import { validateInteger } from '../src';
+
+describe('validateInteger()', () => {
+  it('returns the warning message if invalid', () => {
+    expect(validateInteger(10.1)).toBeTruthy();
+    expect(validateInteger(undefined)).toBeTruthy();
+    expect(validateInteger(null)).toBeTruthy();
+    expect(validateInteger('')).toBeTruthy();
+  });
+  it('returns false if the input is valid', () => {
+    expect(validateInteger(10)).toBeFalsy();
+    expect(validateInteger('10')).toBeFalsy();
+  });
+});

--- a/packages/superset-ui-validator/test/validateNonEmpty.test.ts
+++ b/packages/superset-ui-validator/test/validateNonEmpty.test.ts
@@ -1,0 +1,15 @@
+import { validateNonEmpty } from '../src';
+
+describe('validateNonEmpty()', () => {
+  it('returns the warning message if invalid', () => {
+    expect(validateNonEmpty([])).toBeTruthy();
+    expect(validateNonEmpty(undefined)).toBeTruthy();
+    expect(validateNonEmpty(null)).toBeTruthy();
+    expect(validateNonEmpty('')).toBeTruthy();
+  });
+  it('returns false if the input is valid', () => {
+    expect(validateNonEmpty(0)).toBeFalsy();
+    expect(validateNonEmpty(10)).toBeFalsy();
+    expect(validateNonEmpty('abc')).toBeFalsy();
+  });
+});

--- a/packages/superset-ui-validator/test/validateNumber.test.ts
+++ b/packages/superset-ui-validator/test/validateNumber.test.ts
@@ -1,0 +1,15 @@
+import { validateNumber } from '../src';
+
+describe('validateNumber()', () => {
+  it('returns the warning message if invalid', () => {
+    expect(validateNumber(undefined)).toBeTruthy();
+    expect(validateNumber(null)).toBeTruthy();
+    expect(validateNumber('')).toBeTruthy();
+  });
+  it('returns false if the input is valid', () => {
+    expect(validateNumber(0)).toBeFalsy();
+    expect(validateNumber(10.1)).toBeFalsy();
+    expect(validateNumber(10)).toBeFalsy();
+    expect(validateNumber('10')).toBeFalsy();
+  });
+});

--- a/packages/superset-ui-validator/test/validateNumber.test.ts
+++ b/packages/superset-ui-validator/test/validateNumber.test.ts
@@ -2,8 +2,11 @@ import { validateNumber } from '../src';
 
 describe('validateNumber()', () => {
   it('returns the warning message if invalid', () => {
+    expect(validateNumber(NaN)).toBeTruthy();
+    expect(validateNumber(Infinity)).toBeTruthy();
     expect(validateNumber(undefined)).toBeTruthy();
     expect(validateNumber(null)).toBeTruthy();
+    expect(validateNumber('abc')).toBeTruthy();
     expect(validateNumber('')).toBeTruthy();
   });
   it('returns false if the input is valid', () => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,3 +1,7 @@
+import { configure } from '@superset-ui/translation';
+
+configure();
+
 const caches = {};
 
 class Cache {


### PR DESCRIPTION
🏆 Enhancements

* Move validators from `incubator-superset` for usage in packages

```ts
import { legacyValidateInteger, legacyValidateNumber, validateNonEmpty } from '@superset-ui/validator';
```

There is a non-legacy `validateInteger` and `validateNumber` which has the logical behavior, but will break superset because it seems to expect the wrong output from the legacy functions at the moment.

@rusackas @villebro 