### PR TITLE
feat: make CategoricalScale compatible with D3's ScaleOrdinal

### DIFF
--- a/packages/superset-ui-color/src/CategoricalColorScale.ts
+++ b/packages/superset-ui-color/src/CategoricalColorScale.ts
@@ -78,4 +78,27 @@ export default class CategoricalColorScale extends ExtensibleFunction {
       ...this.parentForcedColors,
     };
   }
+
+  copy() {
+    return this;
+  }
+
+  domain(): { toString(): string }[];
+
+  domain(newDomain: { toString(): string }[]): CategoricalColorScale;
+
+  domain(newDomain?: any): { toString(): string }[] | this {
+    if (typeof newDomain === 'undefined') {
+      return Object.keys(this.getColorMap()) as { toString(): string }[];
+    }
+    return this;
+  }
+
+  range() {
+    return this.colors;
+  }
+
+  unknown() {
+    return this.getColor(undefined);
+  }
 }

--- a/packages/superset-ui-color/test/CategoricalColorScale.test.ts
+++ b/packages/superset-ui-color/test/CategoricalColorScale.test.ts
@@ -1,3 +1,4 @@
+import { ScaleOrdinal } from 'd3-scale';
 import CategoricalColorScale from '../src/CategoricalColorScale';
 
 describe('CategoricalColorScale', () => {
@@ -99,11 +100,23 @@ describe('CategoricalColorScale', () => {
       });
     });
   });
+
   describe('a CategoricalColorScale instance is also a color function itself', () => {
     it('scale(value) returns color similar to calling scale.getColor(value)', () => {
       const scale = new CategoricalColorScale(['blue', 'red', 'green']);
       expect(scale.getColor('pig')).toBe(scale('pig'));
       expect(scale.getColor('cat')).toBe(scale('cat'));
+    });
+  });
+
+  describe("is compatible with D3's scaleOrdinal", () => {
+    it('passes type check', () => {
+      const scale: ScaleOrdinal<{ toString(): string }, string> = new CategoricalColorScale([
+        'blue',
+        'red',
+        'green',
+      ]);
+      expect(scale('pig')).toBe('blue');
     });
   });
 });

--- a/packages/superset-ui-color/test/CategoricalColorScale.test.ts
+++ b/packages/superset-ui-color/test/CategoricalColorScale.test.ts
@@ -101,6 +101,21 @@ describe('CategoricalColorScale', () => {
     });
   });
 
+  describe('.copy()', () => {
+    it('returns a copy', () => {
+      const scale = new CategoricalColorScale(['blue', 'red', 'green']);
+      const copy = scale.copy();
+      expect(copy).not.toBe(scale);
+      expect(copy('cat')).toEqual(scale('cat'));
+      expect(copy.domain()).toEqual(scale.domain());
+      expect(copy.range()).toEqual(scale.range());
+      expect(copy.unknown()).toEqual(scale.unknown());
+    });
+  });
+  describe('.domain()', () => {});
+  describe('.range()', () => {});
+  describe('.unknown()', () => {});
+
   describe('a CategoricalColorScale instance is also a color function itself', () => {
     it('scale(value) returns color similar to calling scale.getColor(value)', () => {
       const scale = new CategoricalColorScale(['blue', 'red', 'green']);

--- a/packages/superset-ui-color/test/CategoricalColorScale.test.ts
+++ b/packages/superset-ui-color/test/CategoricalColorScale.test.ts
@@ -112,9 +112,41 @@ describe('CategoricalColorScale', () => {
       expect(copy.unknown()).toEqual(scale.unknown());
     });
   });
-  describe('.domain()', () => {});
-  describe('.range()', () => {});
-  describe('.unknown()', () => {});
+  describe('.domain()', () => {
+    it('when called without argument, returns domain', () => {
+      const scale = new CategoricalColorScale(['blue', 'red', 'green']);
+      scale.getColor('pig');
+      expect(scale.domain()).toEqual(['pig']);
+    });
+    it('when called with argument, sets domain', () => {
+      const scale = new CategoricalColorScale(['blue', 'red', 'green']);
+      scale.domain(['dog', 'pig', 'cat']);
+      expect(scale('pig')).toEqual('red');
+    });
+  });
+  describe('.range()', () => {
+    it('when called without argument, returns range', () => {
+      const scale = new CategoricalColorScale(['blue', 'red', 'green']);
+      expect(scale.range()).toEqual(['blue', 'red', 'green']);
+    });
+    it('when called with argument, sets range', () => {
+      const scale = new CategoricalColorScale(['blue', 'red', 'green']);
+      scale.range(['pink', 'gray', 'yellow']);
+      expect(scale.range()).toEqual(['pink', 'gray', 'yellow']);
+    });
+  });
+  describe('.unknown()', () => {
+    it('when called without argument, returns output for unknown value', () => {
+      const scale = new CategoricalColorScale(['blue', 'red', 'green']);
+      scale.unknown('#666');
+      expect(scale.unknown()).toEqual('#666');
+    });
+    it('when called with argument, sets output for unknown value', () => {
+      const scale = new CategoricalColorScale(['blue', 'red', 'green']);
+      scale.unknown('#222');
+      expect(scale.unknown()).toEqual('#222');
+    });
+  });
 
   describe('a CategoricalColorScale instance is also a color function itself', () => {
     it('scale(value) returns color similar to calling scale.getColor(value)', () => {
@@ -124,7 +156,7 @@ describe('CategoricalColorScale', () => {
     });
   });
 
-  describe("is compatible with D3's scaleOrdinal", () => {
+  describe("is compatible with D3's ScaleOrdinal", () => {
     it('passes type check', () => {
       const scale: ScaleOrdinal<{ toString(): string }, string> = new CategoricalColorScale([
         'blue',


### PR DESCRIPTION
🏆 Enhancements

`CategoricalScale` was originally written to provide similar functionality with `ScaleOrdinal` but allow color overrides (both at the scale itself and from its parent namespace).

However, due to its different class signature (function names, return types, etc.) from `ScaleOrdinal`, this caused some frictions when adopting it in place of `ScaleOrdinal`, both in Superset and other consumer apps. 

This PR add function `copy`, `domain`, `range` and `unknown` to `CategoricalScale` so it is fully compatible with `ScaleOrdinal` signature. 

```ts
// This is a valid statement in typescript. 
// Developer then can use scale similar to how they use D3's scaleOrdinal
const scale: ScaleOrdinal<{ toString(): string }, string> = new CategoricalColorScale([]);
```

This PR also expose new feature `.unknown()` similar to `D3`'s which allow bucketing of unknown value that are not in the specified domain.

