### PR TITLE
feat: make time formatter handle number and fix formatters type warnings

### DIFF
--- a/packages/superset-ui-core/test/models/ExtensibleFunction.test.ts
+++ b/packages/superset-ui-core/test/models/ExtensibleFunction.test.ts
@@ -1,11 +1,20 @@
 import { ExtensibleFunction } from '../../src';
 
 describe('ExtensibleFunction', () => {
+  interface Func1 {
+    (): number;
+  }
+
   class Func1 extends ExtensibleFunction {
     constructor(x: unknown) {
       super(() => x); // closure
     }
   }
+
+  interface Func2 {
+    (): number;
+  }
+
   class Func2 extends ExtensibleFunction {
     x: unknown;
 

--- a/packages/superset-ui-number-format/src/NumberFormatter.ts
+++ b/packages/superset-ui-number-format/src/NumberFormatter.ts
@@ -11,7 +11,11 @@ export interface NumberFormatterConfig {
   isInvalid?: boolean;
 }
 
-export default class NumberFormatter extends ExtensibleFunction {
+interface NumberFormatter {
+  (value: number): string;
+}
+
+class NumberFormatter extends ExtensibleFunction {
   id: string;
 
   label: string;
@@ -57,3 +61,5 @@ export default class NumberFormatter extends ExtensibleFunction {
     return `${value} => ${this.format(value)}`;
   }
 }
+
+export default NumberFormatter;

--- a/packages/superset-ui-number-format/src/NumberFormatter.ts
+++ b/packages/superset-ui-number-format/src/NumberFormatter.ts
@@ -14,7 +14,7 @@ export interface NumberFormatterConfig {
 // Use type augmentation to indicate that
 // an instance of NumberFormatter is also a function
 interface NumberFormatter {
-  (value: number): string;
+  (value: number | null | undefined): string;
 }
 
 class NumberFormatter extends ExtensibleFunction {

--- a/packages/superset-ui-number-format/src/NumberFormatter.ts
+++ b/packages/superset-ui-number-format/src/NumberFormatter.ts
@@ -11,6 +11,8 @@ export interface NumberFormatterConfig {
   isInvalid?: boolean;
 }
 
+// Use type augmentation to indicate that
+// an instance of NumberFormatter is also a function
 interface NumberFormatter {
   (value: number): string;
 }

--- a/packages/superset-ui-time-format/src/TimeFormatter.ts
+++ b/packages/superset-ui-time-format/src/TimeFormatter.ts
@@ -3,6 +3,8 @@ import { TimeFormatFunction } from './types';
 
 export const PREVIEW_TIME = new Date(Date.UTC(2017, 1, 14, 11, 22, 33));
 
+// Use type augmentation to indicate that
+// an instance of TimeFormatter is also a function
 interface TimeFormatter {
   (value: Date | null | undefined): string;
 }

--- a/packages/superset-ui-time-format/src/TimeFormatter.ts
+++ b/packages/superset-ui-time-format/src/TimeFormatter.ts
@@ -6,7 +6,7 @@ export const PREVIEW_TIME = new Date(Date.UTC(2017, 1, 14, 11, 22, 33));
 // Use type augmentation to indicate that
 // an instance of TimeFormatter is also a function
 interface TimeFormatter {
-  (value: Date | null | undefined): string;
+  (value: Date | number | null | undefined): string;
 }
 
 class TimeFormatter extends ExtensibleFunction {
@@ -27,7 +27,7 @@ class TimeFormatter extends ExtensibleFunction {
     formatFunc: TimeFormatFunction;
     useLocalTime?: boolean;
   }) {
-    super((value: Date | null | undefined) => this.format(value));
+    super((value: Date | number | null | undefined) => this.format(value));
 
     const {
       id = isRequired('config.id'),
@@ -44,12 +44,12 @@ class TimeFormatter extends ExtensibleFunction {
     this.useLocalTime = useLocalTime;
   }
 
-  format(value: Date | null | undefined) {
+  format(value: Date | number | null | undefined) {
     if (value === null || value === undefined) {
       return `${value}`;
     }
 
-    return this.formatFunc(value);
+    return this.formatFunc(value instanceof Date ? value : new Date(value));
   }
 
   preview(value: Date = PREVIEW_TIME) {

--- a/packages/superset-ui-time-format/src/TimeFormatter.ts
+++ b/packages/superset-ui-time-format/src/TimeFormatter.ts
@@ -3,7 +3,11 @@ import { TimeFormatFunction } from './types';
 
 export const PREVIEW_TIME = new Date(Date.UTC(2017, 1, 14, 11, 22, 33));
 
-export default class TimeFormatter extends ExtensibleFunction {
+interface TimeFormatter {
+  (value: Date | null | undefined): string;
+}
+
+class TimeFormatter extends ExtensibleFunction {
   id: string;
 
   label: string;
@@ -50,3 +54,5 @@ export default class TimeFormatter extends ExtensibleFunction {
     return `${value.toUTCString()} => ${this.format(value)}`;
   }
 }
+
+export default TimeFormatter;

--- a/packages/superset-ui-time-format/test/TimeFormatter.test.ts
+++ b/packages/superset-ui-time-format/test/TimeFormatter.test.ts
@@ -45,6 +45,9 @@ describe('TimeFormatter', () => {
     it('handles undefined', () => {
       expect(formatter.format(undefined)).toEqual('undefined');
     });
+    it('handles number, treating it as a timestamp', () => {
+      expect(formatter.format(PREVIEW_TIME.getTime())).toEqual('2017');
+    });
     it('otherwise returns formatted value', () => {
       expect(formatter.format(PREVIEW_TIME)).toEqual('2017');
     });


### PR DESCRIPTION
✨ Enhancement

Add support for time formatter to handle `number`, it will treat the number as timestamp and convert to `Date`. This is consistent with how `d3-time-format` usually works.

🐛 Bug Fix

Fix this warning for `NumberFormatter` and `TimeFormatter` via type augmentation.

```
warning  Unsafe call of an any typed value  @typescript-eslint/no-unsafe-call
```
