### PR TITLE
build: disable commit lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "enzyme-to-json": "^3.4.3",
     "fast-glob": "^3.0.1",
     "fs-extra": "^9.0.0",
-    "husky": "^4.2.1",
+    "husky": "^4.2.5",
     "identity-obj-proxy": "^3.0.0",
     "jest-mock-console": "^1.0.0",
     "lerna": "^3.15.0",
@@ -194,14 +194,12 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {
     "./{packages,plugins}/*/{src,test,storybook}/**/*.{js,jsx,ts,tsx,json,md}": [
-      "yarn prettier --write",
-      "git add"
+      "yarn prettier --write"
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9515,7 +9515,7 @@ humanize-url@^1.0.0:
     normalize-url "^1.0.0"
     strip-url-auth "^1.0.0"
 
-husky@^4.2.1:
+husky@^4.2.5:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.5.tgz#2b4f7622673a71579f901d9885ed448394b5fa36"
   integrity sha512-SYZ95AjKcX7goYVZtVZF2i6XiZcHknw50iXvY7b0MiGoj5RwdgRQNEHdb+gPDPCXKlzwrybjFjkL6FOj8uRhZQ==


### PR DESCRIPTION
🏆 Enhancements
🏠 Internal

Disable commit lint in local development for smoother developer experience.

All changes must go through PR process and we already have [Semantic Pull Request](https://github.com/zeke/semantic-pull-requests) check. We almost always do squash merge, which means what developers committed locally doesn't really matter anyway.
