### PR TITLE
fix: make all filter operators uppercase

### DIFF
--- a/packages/superset-ui-query/src/types/Operator.ts
+++ b/packages/superset-ui-query/src/types/Operator.ts
@@ -2,10 +2,10 @@
 const UNARY_OPERATORS = ['IS NOT NULL', 'IS NULL'] as const;
 
 /** List of operators that require another operand that is a single value */
-const BINARY_OPERATORS = ['=', '!=', '>', '<', '>=', '<=', 'like', 'regex'] as const;
+const BINARY_OPERATORS = ['=', '!=', '>', '<', '>=', '<=', 'LIKE', 'REGEX'] as const;
 
 /** List of operators that require another operand that is a set */
-const SET_OPERATORS = ['in', 'not in'] as const;
+const SET_OPERATORS = ['IN', 'NOT IN'] as const;
 
 //---------------------------------------------------
 // Derived types

--- a/packages/superset-ui-query/test/convertFilter.test.ts
+++ b/packages/superset-ui-query/test/convertFilter.test.ts
@@ -37,12 +37,12 @@ describe('convertFilter', () => {
         expressionType: 'SIMPLE',
         clause: 'WHERE',
         subject: 'toppings',
-        operator: 'in',
+        operator: 'IN',
         comparator: ['boba', 'grass jelly'],
       }),
     ).toEqual({
       col: 'toppings',
-      op: 'in',
+      op: 'IN',
       val: ['boba', 'grass jelly'],
     });
   });

--- a/packages/superset-ui-query/test/types/Filter.test.ts
+++ b/packages/superset-ui-query/test/types/Filter.test.ts
@@ -56,7 +56,7 @@ describe('Filter type guards', () => {
           expressionType: 'SIMPLE',
           clause: 'WHERE',
           subject: 'tea',
-          operator: 'in',
+          operator: 'IN',
           comparator: ['hojicha', 'earl grey'],
         }),
       ).toEqual(true);


### PR DESCRIPTION
🐛 Bug Fix

Currently unary operators are uppercase, while binary and set operators are lowercase, which looks weird. As of [PR 9556](https://github.com/apache/incubator-superset/pull/9556) Superset now expects all filter operators to be uppercase (it does work with lowercase, but this support might be removed at some point).