### PR TITLE
fix: unset row_limit when it's not a number

### DIFF
--- a/packages/superset-ui-query/src/buildQueryObject.ts
+++ b/packages/superset-ui-query/src/buildQueryObject.ts
@@ -33,6 +33,7 @@ export default function buildQueryObject<T extends QueryFormData>(formData: T): 
   } = formData;
 
   const groupbySet = new Set([...columns, ...groupby]);
+  const numericRowLimit = Number(row_limit);
 
   const queryObject: QueryObject = {
     extras: processExtras(formData),
@@ -42,7 +43,7 @@ export default function buildQueryObject<T extends QueryFormData>(formData: T): 
     metrics: processMetrics(formData),
     order_desc: typeof order_desc === 'undefined' ? true : order_desc,
     orderby: [],
-    row_limit: !Number(row_limit) && row_limit !== 0 ? undefined : Number(row_limit),
+    row_limit: row_limit == null || isNaN(numericRowLimit) ? undefined : numericRowLimit,
     since,
     time_range,
     timeseries_limit: limit ? Number(limit) : 0,

--- a/packages/superset-ui-query/src/buildQueryObject.ts
+++ b/packages/superset-ui-query/src/buildQueryObject.ts
@@ -42,7 +42,7 @@ export default function buildQueryObject<T extends QueryFormData>(formData: T): 
     metrics: processMetrics(formData),
     order_desc: typeof order_desc === 'undefined' ? true : order_desc,
     orderby: [],
-    row_limit: Number(row_limit),
+    row_limit: !Number(row_limit) && row_limit !== 0 ? undefined : Number(row_limit),
     since,
     time_range,
     timeseries_limit: limit ? Number(limit) : 0,


### PR DESCRIPTION
🐛 Bug Fix

Recently Superset was changed to not allow row_limit to be null, it can only be unset or a number. This fixes the library to match it

to: @williaster @ktmud @villebro @kristw 