### PR TITLE
build: clean up and test auto release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,11 @@ name: release-workflow
 
 on:
   push:
-    branches:
-      - 'master'
+    branches: ['master']
 
 jobs:
   build:
-    name: Bump version and publish package(s)
+    name: Build and release
 
     runs-on: ubuntu-latest
 
@@ -22,7 +21,7 @@ jobs:
         fetch-depth: 0
     - name: Get tags and filter trigger tags
       run: |
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        git fetch --depth=1 origin "+refs/tags/*:refs/tags/*"
         git fetch --prune --unshallow
         git tag -d `git tag | grep -E '^trigger-'`
 
@@ -43,6 +42,7 @@ jobs:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
+
     - name: Cache yarn
       uses: actions/cache@v1
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -54,34 +54,17 @@ jobs:
 
     - name: Install dependencies
       run: yarn install --frozen-lockfile
+
     - name: Build packages
       run: yarn build
+
     - name: Run unit tests
       run: yarn test
 
-    - name: List changed packages
-      run: yarn list-changed-packages
-
-    - name: Configure npm and git
+    - name: Publish new versions found in package.json
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
-        yarn logout
-        echo "@superset-ui:registry=http://registry.npmjs.org/" > .npmrc
-        echo "registry=http://registry.npmjs.org/" >> .npmrc
         echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
         npm whoami
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git remote set-url origin "https://${GITHUB_TOKEN}@github.com/apache-superset/superset-ui.git" > /dev/null 2>&1
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Bump version and publish package(s)
-      run: |
-        git update-index --assume-unchanged .npmrc
-        git tag -d `git tag | grep -E '^trigger-'`
-        yarn ci:release-from-tag
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+        yarn ci:release-from-tag  # lerna publish from-package

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "clean": "rm -rf ./{packages,plugins}/**/{lib,esm,tsconfig.tsbuildinfo} build/",
     "commit": "superset-commit",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 10",
-    "format": "yarn prettier --write",
     "jest": "NODE_ENV=test nimbus jest --coverage --verbose",
     "lint": "nimbus eslint",
     "lint:fix": "nimbus eslint --fix",
@@ -205,7 +204,7 @@
   },
   "lint-staged": {
     "./{packages,plugins}/*/{src,test,storybook}/**/*.{js,jsx,ts,tsx,json,md}": [
-      "yarn prettier --write"
+      "yarn prettier"
     ]
   }
 }

--- a/packages/superset-ui-demo/package.json
+++ b/packages/superset-ui-demo/package.json
@@ -61,7 +61,7 @@
     "@superset-ui/legacy-plugin-chart-treemap": "0.12.21",
     "@superset-ui/legacy-plugin-chart-word-cloud": "^0.11.15",
     "@superset-ui/legacy-plugin-chart-world-map": "0.12.21",
-    "@superset-ui/legacy-preset-chart-big-number": "0.12.22",
+    "@superset-ui/legacy-preset-chart-big-number": "0.12.23",
     "@superset-ui/number-format": "0.12.21",
     "@superset-ui/plugin-chart-word-cloud": "^0.11.15",
     "@superset-ui/query": "0.12.23",

--- a/plugins/big-number/package.json
+++ b/plugins/big-number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-preset-chart-big-number",
-  "version": "0.12.22",
+  "version": "0.12.23",
   "description": "Superset Legacy Chart - Big Number",
   "sideEffects": [
     "*.css"

--- a/plugins/big-number/src/BigNumber/BigNumber.tsx
+++ b/plugins/big-number/src/BigNumber/BigNumber.tsx
@@ -85,7 +85,7 @@ type BigNumberVisProps = {
   startYAxisAtZero?: boolean;
   timeRangeFixed?: boolean;
   trendLineData?: TimeSeriesDatum[];
-  mainColor: string;
+  mainColor?: string;
 };
 
 class BigNumberVis extends React.PureComponent<BigNumberVisProps, {}> {


### PR DESCRIPTION
🏆 Enhancements

Some minor changes to test auto-release setup by @kristw .

Reading from the code, it seems we are only [bumping versions](https://github.com/lerna/lerna/tree/master/commands/publish#positionals) from manually updated `package.json`.

1. A minor fix to speed up commit hook
2. A minor change in BigNumber to test auto release
3. Clean up some irrelevant code that is not used in the current auto-release process.