### PR TITLE
fix: export superset theme props

### DIFF
--- a/packages/superset-ui-style/src/index.ts
+++ b/packages/superset-ui-style/src/index.ts
@@ -42,3 +42,7 @@ const defaultTheme = {
 export default styled as CreateStyled<typeof defaultTheme>;
 
 export const supersetTheme = defaultTheme;
+
+export interface SupersetThemeProps {
+  theme: typeof defaultTheme;
+}

--- a/packages/superset-ui-style/test/index.test.ts
+++ b/packages/superset-ui-style/test/index.test.ts
@@ -1,4 +1,4 @@
-import styled, { supersetTheme } from '../src';
+import styled, { supersetTheme, SupersetThemeProps } from '../src';
 
 describe('@superset-ui/style package', () => {
   it('exports a theme', () => {
@@ -7,5 +7,12 @@ describe('@superset-ui/style package', () => {
 
   it('exports styled component templater', () => {
     expect(typeof styled.div).toBe('function');
+  });
+
+  it('exports SupersetThemeProps', () => {
+    const props: SupersetThemeProps = {
+      theme: supersetTheme,
+    };
+    expect(typeof props).toBe('object');
   });
 });


### PR DESCRIPTION
🏆 Enhancements
Export SupersetThemeProps interface so that it can be extended when using additional props in styled components. 
