### PR TITLE
fix(plugin-chart-word-cloud): make wordcloud take current formdata

### DIFF
--- a/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-word-cloud/Stories.tsx
+++ b/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-word-cloud/Stories.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
-import { SuperChart } from '@superset-ui/chart';
+import { SuperChart, getChartTransformPropsRegistry } from '@superset-ui/chart';
 import { select, withKnobs } from '@storybook/addon-knobs';
 import {
   WordCloudChartPlugin,
   LegacyWordCloudChartPlugin,
 } from '@superset-ui/plugin-chart-word-cloud';
+import transformProps from '@superset-ui/plugin-chart-word-cloud/lib/plugin/transformProps';
 import data from './data';
 
 new WordCloudChartPlugin().configure({ key: 'word-cloud2' }).register();
 new LegacyWordCloudChartPlugin().configure({ key: 'legacy-word-cloud2' }).register();
+
+// Enable the new WordCloud Props to show case its full features
+// if the control panel is updated to be able to pass formData in the new format.
+getChartTransformPropsRegistry().registerValue('word-cloud2', transformProps);
 
 export default {
   title: 'Chart Plugins|plugin-chart-word-cloud',

--- a/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
+++ b/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
@@ -88,7 +88,8 @@ export default class WordCloud extends React.PureComponent<
 
     cloudLayout()
       .size([width, height])
-      .words(data)
+      // clone the data because cloudLayout mutates input
+      .words(data.map(d => ({ ...d })))
       .padding(5)
       .rotate(ROTATION[rotation] || ROTATION.flat)
       .text(d => encoder.channels.text.getValueFromDatum(d))

--- a/plugins/plugin-chart-word-cloud/src/plugin/index.ts
+++ b/plugins/plugin-chart-word-cloud/src/plugin/index.ts
@@ -2,7 +2,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import buildQuery from './buildQuery';
 import { WordCloudFormData } from '../types';
-import transformProps from './transformProps';
+import transformProps from '../legacyPlugin/transformProps';
 import thumbnail from '../images/thumbnail.png';
 
 const metadata = new ChartMetadata({


### PR DESCRIPTION
🐛 Bug Fix 1

* The WordCloud plugin was written with more flexible api than the original word cloud. (Basically, the `props` are different.) 

#### original wordcloud props
```ts
type OriginalProps = {
  width: number,
  height: number,
  rotation: string,
  data: { size: number, text: string } [];,
  sizeRange: number[],
  colorScheme: string,
}
```

example

```ts
{
  colorScheme: 'd3Category10',
  metric: 'sum__num',
  rotation: 'square',
  series: 'name',
  sizeFrom: '10',
  sizeTo: '70',
}
```

#### new wordcloud props
```ts
type NewProps = {
  width: number;
  height: number;
  rotation?: RotationType;
  data: { [key:string]: any; }[];
  // support a vega-lite / grammar of graphic -style declaration
  // to define encoding for different channels of the word cloud
  // e.g. color, fontSize, fontFamily, fontWeight, text
  encoding?: Partial<WordCloudEncoding>;
}
```

example

```ts
{
  encoding: {
    color: {
      type: 'nominal',
      field: 'name',
      scheme: 'd3Category10',
    },
    fontSize: {
      field: 'sum__num',
      scale: {
        range: [10, 70],
        zero: true,
      },
      type: 'quantitative',
    },
    text: {
      field: 'name',
    },
  },
  rotation: 'square',
}
```

`incubator-superset` passes `formData` to the WordCloud as `props`. What happen in the app is something equivalent to this.

```ts
<WordCloud {...formData} />
```

In the future the `formData` can take more advantage of the new WordCloud API. However, at the moment, `incubator-superset` is still passing the `formData` in original format to the new WordCloud, so we need transformation of the `props` to fit the new WordCloud `props`. 

```ts
<WordCloud {...transform(formData)} />
```

🐛 Bug Fix 2

* Word Cloud layout algorithm also mutates the input, so add cloning step to avoid input mutation. 