### PR TITLE
chore(legacy-preset-chart-nvd3): move bullet chart option parsing from backend to frontend

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/package.json
+++ b/plugins/legacy-preset-chart-nvd3/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@data-ui/xy-chart": "^0.0.84",
+    "@superset-ui/validator": "^0.13.3",
     "d3": "^3.5.17",
     "d3-tip": "^0.9.1",
     "dompurify": "^2.0.6",

--- a/plugins/legacy-preset-chart-nvd3/package.json
+++ b/plugins/legacy-preset-chart-nvd3/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@data-ui/xy-chart": "^0.0.84",
-    "@superset-ui/validator": "^0.13.3",
     "d3": "^3.5.17",
     "d3-tip": "^0.9.1",
     "dompurify": "^2.0.6",
@@ -50,6 +49,7 @@
     "@superset-ui/number-format": "^0.13.0",
     "@superset-ui/time-format": "^0.13.0",
     "@superset-ui/translation": "^0.13.0",
+    "@superset-ui/validator": "^0.13.3",
     "react": "^15 || ^16"
   }
 }

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -253,11 +253,17 @@ function nvd3Vis(element, props) {
     isPieLabelOutside,
     leftMargin,
     lineInterpolation = 'linear',
+    markerLabels,
+    markerLines,
+    markerLineLabels,
+    markers,
     maxBubbleSize,
     onBrushEnd = NOOP,
     onError = NOOP,
     orderBars,
     pieLabelType,
+    rangeLabels,
+    ranges,
     reduceXTicks = false,
     showBarValue,
     showBrush,
@@ -467,6 +473,12 @@ function nvd3Vis(element, props) {
 
       case 'bullet':
         chart = nv.models.bulletChart();
+        data.rangeLabels = rangeLabels;
+        data.ranges = ranges;
+        data.markerLabels = markerLabels;
+        data.markerLines = markerLines;
+        data.markerLineLabels = markerLineLabels;
+        data.markers = markers;
         break;
 
       default:

--- a/plugins/legacy-preset-chart-nvd3/src/transformProps.js
+++ b/plugins/legacy-preset-chart-nvd3/src/transformProps.js
@@ -37,7 +37,8 @@ const grabD3Format = (datasource, targetMetric) => {
 const tokenizeToNumericArray = value => {
   if (value) {
     const tokens = value.split(',');
-    if (tokens.some(validateNumber)) throw new Error('All values should be numeric');
+    if (tokens.some(token => validateNumber(token)))
+      throw new Error('All values should be numeric');
     return tokens.map(token => parseFloat(token));
   }
   return null;

--- a/plugins/legacy-preset-chart-nvd3/src/transformProps.js
+++ b/plugins/legacy-preset-chart-nvd3/src/transformProps.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 import isTruthy from './utils/isTruthy';
-import { tokenizeToNumericArray, tokenizeToStringArray } from './utils/tokenize.ts';
+import { tokenizeToNumericArray, tokenizeToStringArray } from './utils/tokenize';
 import { formatLabel } from './utils';
 
 const NOOP = () => {};

--- a/plugins/legacy-preset-chart-nvd3/src/transformProps.js
+++ b/plugins/legacy-preset-chart-nvd3/src/transformProps.js
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { validateNumber } from '@superset-ui/validator';
 import isTruthy from './utils/isTruthy';
+import { tokenizeToNumericArray, tokenizeToStringArray } from './utils/tokenize';
 import { formatLabel } from './utils';
 
 const NOOP = () => {};
@@ -32,24 +32,6 @@ const grabD3Format = (datasource, targetMetric) => {
   });
 
   return foundFormatter;
-};
-
-const tokenizeToNumericArray = value => {
-  if (value) {
-    const tokens = value.split(',');
-    if (tokens.some(token => validateNumber(token)))
-      throw new Error('All values should be numeric');
-    return tokens.map(token => parseFloat(token));
-  }
-  return null;
-};
-
-const tokenizeToStringArray = value => {
-  if (value) {
-    const tokens = value.split(',');
-    return tokens.map(token => token.trim());
-  }
-  return null;
 };
 
 export default function transformProps(chartProps) {

--- a/plugins/legacy-preset-chart-nvd3/src/transformProps.js
+++ b/plugins/legacy-preset-chart-nvd3/src/transformProps.js
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { validateNumber } from '@superset-ui/validator';
 import isTruthy from './utils/isTruthy';
 import { formatLabel } from './utils';
-import { validateNumber } from '@superset-ui/validator';
 
 const NOOP = () => {};
 
@@ -37,7 +37,7 @@ const grabD3Format = (datasource, targetMetric) => {
 const tokenizeToNumericArray = value => {
   if (value) {
     const tokens = value.split(',');
-    if (tokens.some(validateNumber)) throw Error('All values should be numeric');
+    if (tokens.some(validateNumber)) throw new Error('All values should be numeric');
     return tokens.map(token => parseFloat(token));
   }
   return null;

--- a/plugins/legacy-preset-chart-nvd3/src/transformProps.js
+++ b/plugins/legacy-preset-chart-nvd3/src/transformProps.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 import isTruthy from './utils/isTruthy';
-import { tokenizeToNumericArray, tokenizeToStringArray } from './utils/tokenize';
+import { tokenizeToNumericArray, tokenizeToStringArray } from './utils/tokenize.ts';
 import { formatLabel } from './utils';
 
 const NOOP = () => {};

--- a/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.js
+++ b/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.js
@@ -16,13 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export default function isTruthy(obj) {
-  if (typeof obj === 'boolean') {
-    return obj;
-  }
-  if (typeof obj === 'string') {
-    return ['yes', 'y', 'true', 't', '1'].includes(obj.toLowerCase());
-  }
+import { validateNumber } from '@superset-ui/validator';
 
-  return !!obj;
-}
+const tokenizeToNumericArray = value => {
+  if (value) {
+    const tokens = value.split(',');
+    if (tokens.some(token => validateNumber(token)))
+      throw new Error('All values should be numeric');
+    return tokens.map(token => parseFloat(token));
+  }
+  return null;
+};
+
+const tokenizeToStringArray = value => {
+  if (value) {
+    const tokens = value.split(',');
+    return tokens.map(token => token.trim());
+  }
+  return null;
+};
+
+export { tokenizeToNumericArray, tokenizeToStringArray };

--- a/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.js
+++ b/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.js
@@ -19,7 +19,7 @@
 import { validateNumber } from '@superset-ui/validator';
 
 const tokenizeToNumericArray = value => {
-  if (value) {
+  if (value && value.trim()) {
     const tokens = value.split(',');
     if (tokens.some(token => validateNumber(token)))
       throw new Error('All values should be numeric');
@@ -29,7 +29,7 @@ const tokenizeToNumericArray = value => {
 };
 
 const tokenizeToStringArray = value => {
-  if (value) {
+  if (value && value.trim()) {
     const tokens = value.split(',');
     return tokens.map(token => token.trim());
   }

--- a/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.ts
@@ -18,22 +18,15 @@
  */
 import { validateNumber } from '@superset-ui/validator';
 
-const tokenizeToNumericArray = value => {
-  if (value && value.trim()) {
-    const tokens = value.split(',');
-    if (tokens.some(token => validateNumber(token)))
-      throw new Error('All values should be numeric');
-    return tokens.map(token => parseFloat(token));
-  }
-  return null;
-};
+export function tokenizeToNumericArray(value: string): Number[] | null {
+  if (!value.trim()) return null;
+  const tokens = value.split(',');
+  if (tokens.some(token => validateNumber(token))) throw new Error('All values should be numeric');
+  return tokens.map(token => parseFloat(token));
+}
 
-const tokenizeToStringArray = value => {
-  if (value && value.trim()) {
-    const tokens = value.split(',');
-    return tokens.map(token => token.trim());
-  }
-  return null;
-};
-
-export { tokenizeToNumericArray, tokenizeToStringArray };
+export function tokenizeToStringArray(value: string): string[] | null {
+  if (!value.trim()) return null;
+  const tokens = value.split(',');
+  return tokens.map(token => token.trim());
+}

--- a/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.ts
@@ -18,7 +18,7 @@
  */
 import { validateNumber } from '@superset-ui/validator';
 
-export function tokenizeToNumericArray(value: string): Number[] | null {
+export function tokenizeToNumericArray(value: string): number[] | null {
   if (!value.trim()) return null;
   const tokens = value.split(',');
   if (tokens.some(token => validateNumber(token))) throw new Error('All values should be numeric');

--- a/plugins/legacy-preset-chart-nvd3/test/utils/isTruthy.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/isTruthy.test.js
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import isTruthy from '../../src/utils/isTruthy';
 
 describe('isTruthy', () => {

--- a/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -20,9 +20,9 @@ import { tokenizeToNumericArray, tokenizeToStringArray } from '../../src/utils/t
 
 describe('tokenizeToNumericArray', () => {
   it('evals numeric strings properly', () => {
-    expect(tokenizeToNumericArray('1')).toBe([1]);
-    expect(tokenizeToNumericArray('1,2,3,4')).toBe([1, 2, 3, 4]);
-    expect(tokenizeToNumericArray('   1, 2,   3,    4 ')).toBe([1, 2, 3, 4]);
+    expect(tokenizeToNumericArray('1')).toStrictEqual([1]);
+    expect(tokenizeToNumericArray('1,2,3,4')).toStrictEqual([1, 2, 3, 4]);
+    expect(tokenizeToNumericArray('   1, 2,   3,    4 ')).toStrictEqual([1, 2, 3, 4]);
   });
 
   it('evals empty strings to null', () => {
@@ -37,9 +37,9 @@ describe('tokenizeToNumericArray', () => {
 
 describe('tokenizeToStringArray', () => {
   it('evals numeric strings properly', () => {
-    expect(tokenizeToStringArray('a')).toBe(['a']);
-    expect(tokenizeToStringArray('1,2,3,4')).toBe(['1', '2', '3', '4']);
-    expect(tokenizeToStringArray('1,a,3, bc ,d')).toBe(['1', 'a', '3', 'bc', 'd']);
+    expect(tokenizeToStringArray('a')).toStrictEqual(['a']);
+    expect(tokenizeToStringArray('1,2,3,4')).toStrictEqual(['1', '2', '3', '4']);
+    expect(tokenizeToStringArray('1,a,3, bc ,d')).toStrictEqual(['1', 'a', '3', 'bc', 'd']);
   });
 
   it('evals empty string to null', () => {

--- a/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -25,23 +25,25 @@ describe('tokenizeToNumericArray', () => {
     expect(tokenizeToNumericArray('   1, 2,   3,    4 ')).toBe([1, 2, 3, 4]);
   });
 
-  it('evals empty string to null', () => {
-    expect(tokenizeToNumericArray('')).toBe(null);
+  it('evals empty strings to null', () => {
+    expect(tokenizeToNumericArray('')).toBeNull();
+    expect(tokenizeToNumericArray('    ')).toBeNull();
   });
 
   it('throws error on incorrect string', () => {
-    expect(tokenizeToNumericArray('qwerty,1,2,3')).toBe(new Error());
+    expect(() => tokenizeToNumericArray('qwerty,1,2,3')).toThrow(Error);
   });
 });
 
 describe('tokenizeToStringArray', () => {
   it('evals numeric strings properly', () => {
-    expect(tokenizeToNumericArray('a')).toBe(['a']);
-    expect(tokenizeToNumericArray('1,2,3,4')).toBe(['1', '2', '3', '4']);
-    expect(tokenizeToNumericArray('1,a,3, bc ,d')).toBe(['1', 'a', '3', 'bc', 'd']);
+    expect(tokenizeToStringArray('a')).toBe(['a']);
+    expect(tokenizeToStringArray('1,2,3,4')).toBe(['1', '2', '3', '4']);
+    expect(tokenizeToStringArray('1,a,3, bc ,d')).toBe(['1', 'a', '3', 'bc', 'd']);
   });
 
   it('evals empty string to null', () => {
-    expect(tokenizeToNumericArray('')).toBe(null);
+    expect(tokenizeToStringArray('')).toBeNull();
+    expect(tokenizeToStringArray('    ')).toBeNull();
   });
 });

--- a/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -39,7 +39,7 @@ describe('tokenizeToNumericArray', () => {
 describe('tokenizeToStringArray', () => {
   it('evals numeric strings properly', () => {
     expect(tokenizeToStringArray('a')).toStrictEqual(['a']);
-    expect(tokenizeToStringArray('1.1,2.2,3.0,4')).toStrictEqual(['1', '2', '3.0', '4']);
+    expect(tokenizeToStringArray('1.1 , 2.2, 3.0 ,4')).toStrictEqual(['1.1', '2.2', '3.0', '4']);
     expect(tokenizeToStringArray('1.1,a,3, bc ,d')).toStrictEqual(['1.1', 'a', '3', 'bc', 'd']);
   });
 

--- a/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { tokenizeToNumericArray, tokenizeToStringArray } from '../../src/utils/tokenize';
+import { tokenizeToNumericArray, tokenizeToStringArray } from '../../src/utils/tokenize.ts';
 
 describe('tokenizeToNumericArray', () => {
   it('evals numeric strings properly', () => {
     expect(tokenizeToNumericArray('1')).toStrictEqual([1]);
     expect(tokenizeToNumericArray('1,2,3,4')).toStrictEqual([1, 2, 3, 4]);
+    expect(tokenizeToNumericArray('1.1,2.2,3.0,4')).toStrictEqual([1.1, 2.2, 3, 4]);
     expect(tokenizeToNumericArray('   1, 2,   3,    4 ')).toStrictEqual([1, 2, 3, 4]);
   });
 
@@ -38,8 +39,8 @@ describe('tokenizeToNumericArray', () => {
 describe('tokenizeToStringArray', () => {
   it('evals numeric strings properly', () => {
     expect(tokenizeToStringArray('a')).toStrictEqual(['a']);
-    expect(tokenizeToStringArray('1,2,3,4')).toStrictEqual(['1', '2', '3', '4']);
-    expect(tokenizeToStringArray('1,a,3, bc ,d')).toStrictEqual(['1', 'a', '3', 'bc', 'd']);
+    expect(tokenizeToStringArray('1.1,2.2,3.0,4')).toStrictEqual(['1', '2', '3.0', '4']);
+    expect(tokenizeToStringArray('1.1,a,3, bc ,d')).toStrictEqual(['1.1', 'a', '3', 'bc', 'd']);
   });
 
   it('evals empty string to null', () => {

--- a/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { tokenizeToNumericArray, tokenizeToStringArray } from '../../src/utils/tokenize';
+
+describe('tokenizeToNumericArray', () => {
+  it('evals numeric strings properly', () => {
+    expect(tokenizeToNumericArray('1')).toBe([1]);
+    expect(tokenizeToNumericArray('1,2,3,4')).toBe([1, 2, 3, 4]);
+    expect(tokenizeToNumericArray('   1, 2,   3,    4 ')).toBe([1, 2, 3, 4]);
+  });
+
+  it('evals empty string to null', () => {
+    expect(tokenizeToNumericArray('')).toBe(null);
+  });
+
+  it('throws error on incorrect string', () => {
+    expect(tokenizeToNumericArray('qwerty,1,2,3')).toBe(new Error());
+  });
+});
+
+describe('tokenizeToStringArray', () => {
+  it('evals numeric strings properly', () => {
+    expect(tokenizeToNumericArray('a')).toBe(['a']);
+    expect(tokenizeToNumericArray('1,2,3,4')).toBe(['1', '2', '3', '4']);
+    expect(tokenizeToNumericArray('1,a,3, bc ,d')).toBe(['1', 'a', '3', 'bc', 'd']);
+  });
+
+  it('evals empty string to null', () => {
+    expect(tokenizeToNumericArray('')).toBe(null);
+  });
+});


### PR DESCRIPTION
🏠 Internal

This moves `BulletViz` range and marker parsing logic from the backend to the frontend. Once this PR is merged the relevant logic will be removed from `viz.py`: https://github.com/apache/incubator-superset/blob/5d167afb9499d7ce30c7ea763b19993af347dc23/superset/viz.py#L1094-L1124

Moving this will be necessary to deprecate `viz.py`, as non-datasource related data processing will not be supported in the new chart data API.

# SCREENSHOTS

![image](https://user-images.githubusercontent.com/33317356/80946555-f4fe5000-8df6-11ea-9a04-b7268c455613.png)
![image](https://user-images.githubusercontent.com/33317356/80946584-0a737a00-8df7-11ea-96b4-bd2d00282887.png)

FYI @suddjian @rusackas 