### PR TITLE
chore: pulling in Sunburst controls from incubator-superset

### DIFF
--- a/plugins/legacy-plugin-chart-sunburst/package.json
+++ b/plugins/legacy-plugin-chart-sunburst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-sunburst",
-  "version": "0.13.6",
+  "version": "0.13.5",
   "description": "Superset Legacy Chart - Sunburst",
   "sideEffects": [
     "*.css"

--- a/plugins/legacy-plugin-chart-sunburst/package.json
+++ b/plugins/legacy-plugin-chart-sunburst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-sunburst",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "Superset Legacy Chart - Sunburst",
   "sideEffects": [
     "*.css"
@@ -35,6 +35,7 @@
     "@superset-ui/chart": "^0.13.0",
     "@superset-ui/color": "^0.13.0",
     "@superset-ui/number-format": "^0.13.0",
-    "@superset-ui/translation": "^0.13.0"
+    "@superset-ui/translation": "^0.13.0",
+    "@superset-ui/control-utils": "^0.13.0"
   }
 }

--- a/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t } from '@superset-ui/translation';
+
+export default {
+  controlPanelSections: [
+    {
+      label: t('Query'),
+      expanded: true,
+      controlSetRows: [
+        ['groupby'],
+        ['metric'],
+        ['secondary_metric'],
+        ['adhoc_filters'],
+        ['row_limit'],
+      ],
+    },
+    {
+      label: t('Chart Options'),
+      expanded: true,
+      controlSetRows: [['color_scheme', 'label_colors']],
+    },
+  ],
+  controlOverrides: {
+    metric: {
+      label: t('Primary Metric'),
+      description: t('The primary metric is used to define the arc segment sizes'),
+    },
+    secondary_metric: {
+      label: t('Secondary Metric'),
+      default: null,
+      description: t(
+        '[optional] this secondary metric is used to ' +
+          'define the color as a ratio against the primary metric. ' +
+          'When omitted, the color is categorical and based on labels',
+      ),
+    },
+    groupby: {
+      label: t('Hierarchy'),
+      description: t('This defines the level of the hierarchy'),
+    },
+  },
+};

--- a/plugins/legacy-plugin-chart-sunburst/src/index.js
+++ b/plugins/legacy-plugin-chart-sunburst/src/index.js
@@ -20,6 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['https://bl.ocks.org/kerryrodden/7090426'],
@@ -35,6 +36,7 @@ export default class SunburstChartPlugin extends ChartPlugin {
       loadChart: () => import('./ReactSunburst.js'),
       metadata,
       transformProps,
+      controlPanel,
     });
   }
 }

--- a/plugins/legacy-plugin-chart-sunburst/src/index.js
+++ b/plugins/legacy-plugin-chart-sunburst/src/index.js
@@ -20,7 +20,8 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+// eslint-disable-next-line import/extensions
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['https://bl.ocks.org/kerryrodden/7090426'],

--- a/plugins/legacy-plugin-chart-sunburst/src/index.js
+++ b/plugins/legacy-plugin-chart-sunburst/src/index.js
@@ -20,7 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel';
+import controlPanel from './controlPanel.ts';
 
 const metadata = new ChartMetadata({
   credits: ['https://bl.ocks.org/kerryrodden/7090426'],


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

This pulls in the controls from `incubator-superset`, and bumps the version number of the package. [Another PR](https://github.com/apache/incubator-superset/pull/9746) has been filed on `incubator-superset` to pull in this new package and remove the old controls and shims.

📜 Documentation

🐛 Bug Fix

🏠 Internal
