### PR TITLE
fix(legacy-plugin-world-map): set useLegacyApi to true by default

### DIFF
--- a/plugins/legacy-plugin-chart-world-map/src/index.js
+++ b/plugins/legacy-plugin-chart-world-map/src/index.js
@@ -26,6 +26,7 @@ const metadata = new ChartMetadata({
   description: '',
   name: t('World Map'),
   thumbnail,
+  useLegacyApi: true,
 });
 
 export default class WorldMapChartPlugin extends ChartPlugin {


### PR DESCRIPTION
🐛 Bug Fix

The World Map plugin is currently failing if the new chart data API is enabled in Superset due to `useLegacyApi` not being explicitly set to `true`.

@rusackas @kristw @suddjian @ktmud 