### PR TITLE
fix: Add force to QueryContext

### DIFF
--- a/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
+++ b/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
@@ -24,6 +24,7 @@ describe('ChartPlugin', () => {
   const buildQuery = () => ({
     datasource: { id: 1, type: DatasourceType.Table },
     queries: [{ granularity: 'day' }],
+    force: false,
   });
 
   const controlPanel = { abc: 1 };
@@ -64,6 +65,7 @@ describe('ChartPlugin', () => {
 
         const fn = plugin.loadBuildQuery!() as BuildQueryFunction<QueryFormData>;
         expect(fn(FORM_DATA).queries[0]).toEqual({ granularity: 'day' });
+        expect(fn(FORM_DATA).force).toEqual(false);
       });
       it('uses buildQuery field if specified', () => {
         expect.assertions(1);

--- a/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
+++ b/packages/superset-ui-chart/test/models/ChartPlugin.test.tsx
@@ -56,7 +56,7 @@ describe('ChartPlugin', () => {
         expect(plugin.loadBuildQuery).toBeUndefined();
       });
       it('uses loadBuildQuery field if specified', () => {
-        expect.assertions(1);
+        expect.assertions(2);
         const plugin = new ChartPlugin({
           metadata,
           Chart: FakeChart,

--- a/packages/superset-ui-query/src/buildQueryContext.ts
+++ b/packages/superset-ui-query/src/buildQueryContext.ts
@@ -11,6 +11,7 @@ export default function buildQueryContext(
 ): QueryContext {
   return {
     datasource: new DatasourceKey(formData.datasource).toObject(),
+    force: formData.force || false,
     queries: buildQuery(buildQueryObject(formData)),
   };
 }

--- a/packages/superset-ui-query/src/types/Query.ts
+++ b/packages/superset-ui-query/src/types/Query.ts
@@ -28,13 +28,16 @@ export type QueryObjectMetric = {
 
 export type QueryObjectExtras = Partial<{
   /** HAVING condition for Druid */
-  having_druid: string;
-  druid_time_origin: string;
+  having_druid?: string;
+  druid_time_origin?: string;
   /** HAVING condition for SQLAlchemy */
-  having: string;
-  time_grain_sqla: string;
+  having?: string;
+  relative_start?: string;
+  relative_end?: string;
+  time_grain_sqla?: string;
+  time_range_endpoints?: string[];
   /** WHERE condition */
-  where: string;
+  where?: string;
 }>;
 
 export type QueryObject = {
@@ -77,5 +80,7 @@ export interface QueryContext {
     id: number;
     type: DatasourceType;
   };
+  /** Force refresh of all queries */
+  force: boolean;
   queries: QueryObject[];
 }

--- a/packages/superset-ui-query/src/types/QueryFormData.ts
+++ b/packages/superset-ui-query/src/types/QueryFormData.ts
@@ -45,6 +45,8 @@ export type BaseFormData = {
   row_limit?: string | number | null;
   /** The metric used to order timeseries for limiting */
   timeseries_limit_metric?: QueryFormDataMetric;
+  /** Force refresh */
+  force?: boolean;
 } & TimeRange &
   QueryFormDataMetrics;
 

--- a/packages/superset-ui-query/test/buildQueryContext.test.ts
+++ b/packages/superset-ui-query/test/buildQueryContext.test.ts
@@ -1,7 +1,7 @@
 import { buildQueryContext } from '../src';
 
 describe('buildQueryContext', () => {
-  it('should build datasource for table sources', () => {
+  it('should build datasource for table sources and default force to false', () => {
     const queryContext = buildQueryContext({
       datasource: '5__table',
       granularity_sqla: 'ds',
@@ -9,15 +9,18 @@ describe('buildQueryContext', () => {
     });
     expect(queryContext.datasource.id).toBe(5);
     expect(queryContext.datasource.type).toBe('table');
+    expect(queryContext.force).toBe(false);
   });
 
-  it('should build datasource for druid sources', () => {
+  it('should build datasource for druid sources and set force to true', () => {
     const queryContext = buildQueryContext({
       datasource: '5__druid',
       granularity: 'ds',
       viz_type: 'table',
+      force: true,
     });
     expect(queryContext.datasource.id).toBe(5);
     expect(queryContext.datasource.type).toBe('druid');
+    expect(queryContext.force).toBe(true);
   });
 });


### PR DESCRIPTION
🐛 Bug Fix

Currently the `force` parameter is missing from the `QueryContext` signature, making it impossible to force refresh charts. This PR adds `force` as an optional parameter in `QueryFormData` and defaults to `false` in `QueryContext` when undefined.

@rusackas @suddjian @ktmud @kristw 