### PR TITLE
fix: Remove .ts suffix from NVD3 imports

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/transformProps.js
+++ b/plugins/legacy-preset-chart-nvd3/src/transformProps.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 import isTruthy from './utils/isTruthy';
-import { tokenizeToNumericArray, tokenizeToStringArray } from './utils/tokenize.ts';
+import { tokenizeToNumericArray, tokenizeToStringArray } from './utils/tokenize';
 import { formatLabel } from './utils';
 
 const NOOP = () => {};

--- a/plugins/legacy-preset-chart-nvd3/src/transformProps.js
+++ b/plugins/legacy-preset-chart-nvd3/src/transformProps.js
@@ -17,6 +17,7 @@
  * under the License.
  */
 import isTruthy from './utils/isTruthy';
+// eslint-disable-next-line import/extensions
 import { tokenizeToNumericArray, tokenizeToStringArray } from './utils/tokenize';
 import { formatLabel } from './utils';
 

--- a/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+// eslint-disable-next-line import/extensions
 import { tokenizeToNumericArray, tokenizeToStringArray } from '../../src/utils/tokenize';
 
 describe('tokenizeToNumericArray', () => {

--- a/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { tokenizeToNumericArray, tokenizeToStringArray } from '../../src/utils/tokenize.ts';
+import { tokenizeToNumericArray, tokenizeToStringArray } from '../../src/utils/tokenize';
 
 describe('tokenizeToNumericArray', () => {
   it('evals numeric strings properly', () => {


### PR DESCRIPTION
🐛 Bug Fix

The current released version of NVD3 viz' doesn't work due to the import referencing the `ts` files (the linter forced me to add the suffix). I'm not really sure we should have that check here, as it appears to be causing broken releases.

@kristw @rusackas @ktmud 