### PR TITLE
chore: enforce commit-lint on first commit in branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vx"
   ],
   "license": "Apache-2.0",
-  "devDependencies": {
+  "dependencies": {
     "@airbnb/config-babel": "^3.1.0",
     "@airbnb/config-eslint": "^3.1.0",
     "@airbnb/config-jest": "^3.0.1",
@@ -204,12 +204,16 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "commit-msg": "./scripts/commitlint.js HUSKY_GIT_PARAMS"
     }
   },
   "lint-staged": {
     "./{packages,plugins}/*/{src,test,storybook}/**/*.{js,jsx,ts,tsx,json,md}": [
-      "yarn prettier --write"
+      "yarn prettier"
+    ],
+    "./{packages,plugins}/*.md": [
+      "yarn prettier"
     ]
   }
 }

--- a/packages/superset-ui-chart/README.md
+++ b/packages/superset-ui-chart/README.md
@@ -98,3 +98,4 @@ Coming soon.
 
 `@data-ui/build-config` is used to manage the build configuration for this package including babel
 builds, jest testing, eslint, and prettier.
+

--- a/scripts/commitlint.js
+++ b/scripts/commitlint.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+/**
+ * Check commit messages only for the first commit in branch.
+ */
+const { execSync, spawnSync } = require('child_process');
+
+const envVariable = process.argv[2] || 'GIT_PARAMS';
+
+if (!envVariable || !process.env[envVariable]) {
+  process.stdout.write(`Please provide a commit message via \`${envVariable}={Your Message}\`.\n`);
+  process.exit(0);
+}
+if (execSync('git rev-list --count HEAD ^master', { encoding: 'utf-8' }).trim() === '0') {
+  const { status } = spawnSync(`commitlint`, ['-E', envVariable], { stdio: 'inherit' });
+  process.exit(status);
+}


### PR DESCRIPTION
🏆 Enhancements

🏠 Internal

Since disabled commit-lint in #363, people who didn't install [Refined GitHub ](https://github.com/sindresorhus/refined-github) had been merging PRs without conventional commits.

This re-applies commit-lint to the first commit in branches that are not `master`, so to make sure we will always have conventional commits in master.

Also fixes prettier check in `pre-commit`, as it was unnecessarily slowed down by checking all files.