### PR TITLE
test: codecov ignore tsx/jsx

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,13 +8,14 @@ coverage:
       core-packages-ts:
         target: 100%
         paths:
-          - packages/**/*.js
-          - packages/**/*.ts
+          - "packages"
+          - "!packages/**/*.jsx"
+          - "!packages/**/*.tsx"
       core-packages-tsx:
         target: 50%
         paths:
-          - packages/**/*.jsx
-          - packages/**/*.tsx
+          - "packages/**/*.jsx"
+          - "packages/**/*.tsx"
       plugins:
         target: 0
         paths:


### PR DESCRIPTION
🏆 Enhancements

Follow up on #468 .  `packages/**/*.js` does not exclude `.jsx`. We need to specifically exclude it.