### PR TITLE
fix(legacy-plugin-chart-nvd3): disable bad linting rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
         {
           "files": "*.{js,jsx,ts,tsx}",
           "rules": {
+            "import/extensions": "off",
             "no-plusplus": "off",
             "react/jsx-no-literals": "off",
             "@typescript-eslint/no-explicit-any": [

--- a/packages/superset-ui-demo/storybook/stories/plugins/legacy-plugin-chart-calendar/Stories.tsx
+++ b/packages/superset-ui-demo/storybook/stories/plugins/legacy-plugin-chart-calendar/Stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { SuperChart } from '@superset-ui/chart';
 import CalendarChartPlugin from '@superset-ui/legacy-plugin-chart-calendar';
 import data from './data';
-// eslint-disable-next-line import/extensions
 import dummyDatasource from '../../../shared/dummyDatasource';
 
 new CalendarChartPlugin().configure({ key: 'calendar' }).register();

--- a/plugins/legacy-plugin-chart-sunburst/src/index.js
+++ b/plugins/legacy-plugin-chart-sunburst/src/index.js
@@ -20,7 +20,6 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
-// eslint-disable-next-line import/extensions
 import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({

--- a/plugins/legacy-preset-chart-nvd3/src/Area/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/Area/index.js
@@ -21,7 +21,7 @@ import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import { ANNOTATION_TYPES } from '../vendor/superset/AnnotationTypes';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
@@ -21,7 +21,7 @@ import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import { ANNOTATION_TYPES } from '../vendor/superset/AnnotationTypes';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/Bubble/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/Bubble/index.js
@@ -20,7 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/Bullet/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/Bullet/index.js
@@ -20,7 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/Compare/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/Compare/index.js
@@ -20,7 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -20,7 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/DualLine/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/DualLine/index.js
@@ -20,7 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/Line/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/Line/index.js
@@ -21,7 +21,7 @@ import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import { ANNOTATION_TYPES } from '../vendor/superset/AnnotationTypes';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   canBeAnnotationTypes: [ANNOTATION_TYPES.TIME_SERIES],

--- a/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js
@@ -19,7 +19,7 @@
 import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/Pie/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/Pie/index.js
@@ -20,7 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/TimePivot/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/TimePivot/index.js
@@ -20,7 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],

--- a/plugins/legacy-preset-chart-nvd3/src/transformProps.js
+++ b/plugins/legacy-preset-chart-nvd3/src/transformProps.js
@@ -17,7 +17,6 @@
  * under the License.
  */
 import isTruthy from './utils/isTruthy';
-// eslint-disable-next-line import/extensions
 import { tokenizeToNumericArray, tokenizeToStringArray } from './utils/tokenize';
 import { formatLabel } from './utils';
 

--- a/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-// eslint-disable-next-line import/extensions
 import { tokenizeToNumericArray, tokenizeToStringArray } from '../../src/utils/tokenize';
 
 describe('tokenizeToNumericArray', () => {


### PR DESCRIPTION
🐛 Bug Fix

The `import/extensions` rule makes it impossible to correctly import ts from js.
