### PR TITLE
feat(query): remove redundant metric label truncation

### DIFF
--- a/packages/superset-ui-query/src/convertMetric.ts
+++ b/packages/superset-ui-query/src/convertMetric.ts
@@ -5,9 +5,8 @@ import { AdhocMetric } from './types/Metric';
 function getDefaultLabel(metric: AdhocMetric) {
   if (metric.expressionType === 'SIMPLE') {
     return `${metric.aggregate}(${metric.column.columnName})`;
-  } else {
-    return metric.sqlExpression;
   }
+  return metric.sqlExpression;
 }
 
 export default function convertMetric(metric: QueryFormDataMetric): QueryObjectMetric {

--- a/packages/superset-ui-query/src/convertMetric.ts
+++ b/packages/superset-ui-query/src/convertMetric.ts
@@ -2,19 +2,12 @@ import { QueryFormDataMetric } from './types/QueryFormData';
 import { QueryObjectMetric } from './types/Query';
 import { AdhocMetric } from './types/Metric';
 
-export const LABEL_MAX_LENGTH = 43;
-
 function getDefaultLabel(metric: AdhocMetric) {
-  let label: string;
   if (metric.expressionType === 'SIMPLE') {
-    label = `${metric.aggregate}(${metric.column.columnName})`;
+    return `${metric.aggregate}(${metric.column.columnName})`;
   } else {
-    label = metric.sqlExpression;
+    return metric.sqlExpression;
   }
-
-  return label.length <= LABEL_MAX_LENGTH
-    ? label
-    : `${label.slice(0, Math.max(0, LABEL_MAX_LENGTH - 3))}...`;
 }
 
 export default function convertMetric(metric: QueryFormDataMetric): QueryObjectMetric {
@@ -24,9 +17,6 @@ export default function convertMetric(metric: QueryFormDataMetric): QueryObjectM
       label: metric,
     };
   } else {
-    // Note we further sanitize the metric label for BigQuery datasources
-    // TODO: move this logic to the client once client has more info on the
-    // the datasource
     const label = metric.label ?? getDefaultLabel(metric);
     formattedMetric = {
       ...metric,

--- a/packages/superset-ui-query/test/convertMetric.test.ts
+++ b/packages/superset-ui-query/test/convertMetric.test.ts
@@ -1,5 +1,4 @@
 import { ColumnType, convertMetric } from '../src';
-import { LABEL_MAX_LENGTH } from '../src/convertMetric';
 
 describe('convertMetric', () => {
   it('should handle string metric name', () => {
@@ -54,14 +53,5 @@ describe('convertMetric', () => {
       label: 'foo',
       sqlExpression: 'COUNT(sum_girls)',
     });
-  });
-
-  it('should truncate labels if they are too long', () => {
-    expect(
-      convertMetric({
-        expressionType: 'SQL',
-        sqlExpression: 'COUNT(verrrrrrrrry_loooooooooooooooooooooong_string)',
-      }).label.length,
-    ).toBeLessThanOrEqual(LABEL_MAX_LENGTH);
   });
 });


### PR DESCRIPTION
🏆 Enhancements
When working on another PR I noticed this redundant metric label mutation logic. For some time now, the Superset backend has supported arbitrary column/metric names, despite restrictions in the database. Check https://github.com/apache/incubator-superset/pull/5827 for more context.
