### PR TITLE
fix(time-format): remove week number

### DIFF
--- a/packages/superset-ui-time-format/src/factories/getTimeFormatterForGranularity.ts
+++ b/packages/superset-ui-time-format/src/factories/getTimeFormatterForGranularity.ts
@@ -23,8 +23,6 @@ import { TimeGranularity } from '../types';
 
 // Translate time granularity to d3-format
 const MINUTE = '%Y-%m-%d %H:%M';
-const SUNDAY_BASED_WEEK = '%Y-%m-%d W%U';
-const MONDAY_BASED_WEEK = '%Y-%m-%d W%W';
 const { DATABASE_DATE, DATABASE_DATETIME } = TimeFormats;
 
 // search for `builtin_time_grains` in incubator-superset/superset/db_engine_specs/base.py
@@ -38,14 +36,14 @@ const formats = {
   'PT0.5H': MINUTE, // half hour
   PT1H: '%Y-%m-%d %H:00', // hour
   P1D: DATABASE_DATE, // day
-  P1W: MONDAY_BASED_WEEK, // week
+  P1W: DATABASE_DATE, // week
   P1M: '%Y-%m', // month
   'P0.25Y': '%Y Q%q', // quarter
   P1Y: '%Y', // year
-  '1969-12-28T00:00:00Z/P1W': SUNDAY_BASED_WEEK, // 'week_start_sunday'
-  '1969-12-29T00:00:00Z/P1W': MONDAY_BASED_WEEK, // 'week_start_monday'
-  'P1W/1970-01-03T00:00:00Z': SUNDAY_BASED_WEEK, // 'week_ending_saturday'
-  'P1W/1970-01-04T00:00:00Z': MONDAY_BASED_WEEK, // 'week_ending_sunday'
+  '1969-12-28T00:00:00Z/P1W': DATABASE_DATE, // 'week_start_sunday'
+  '1969-12-29T00:00:00Z/P1W': DATABASE_DATE, // 'week_start_monday'
+  'P1W/1970-01-03T00:00:00Z': DATABASE_DATE, // 'week_ending_saturday'
+  'P1W/1970-01-04T00:00:00Z': DATABASE_DATE, // 'week_ending_sunday'
 };
 
 export default function getTimeFormatterForGranularity(granularity?: TimeGranularity) {

--- a/packages/superset-ui-time-format/src/factories/getTimeFormatterForGranularity.ts
+++ b/packages/superset-ui-time-format/src/factories/getTimeFormatterForGranularity.ts
@@ -38,7 +38,7 @@ const formats = {
   'PT0.5H': MINUTE, // half hour
   PT1H: '%Y-%m-%d %H:00', // hour
   P1D: DATABASE_DATE, // day
-  P1W: SUNDAY_BASED_WEEK, // week
+  P1W: MONDAY_BASED_WEEK, // week
   P1M: '%Y-%m', // month
   'P0.25Y': '%Y Q%q', // quarter
   P1Y: '%Y', // year

--- a/packages/superset-ui-time-format/test/factories/getTimeFormatterForGranularity.test.ts
+++ b/packages/superset-ui-time-format/test/factories/getTimeFormatterForGranularity.test.ts
@@ -20,7 +20,7 @@ describe('getTimeFormatterForGranularity()', () => {
     expect(getFormatter('PT0.5H')(date)).toBe('2020-05-10 11:10');
     expect(getFormatter('PT1H')(date)).toBe('2020-05-10 11:00');
     expect(getFormatter('P1D')(date)).toBe('2020-05-10');
-    expect(getFormatter('P1W')(date)).toBe('2020-05-10 W19');
+    expect(getFormatter('P1W')(date)).toBe('2020-05-10 W18');
     expect(getFormatter('P1M')(date)).toBe('2020-05');
     expect(getFormatter('P0.25Y')(date)).toBe('2020 Q2');
     expect(getFormatter('P1Y')(date)).toBe('2020');

--- a/packages/superset-ui-time-format/test/factories/getTimeFormatterForGranularity.test.ts
+++ b/packages/superset-ui-time-format/test/factories/getTimeFormatterForGranularity.test.ts
@@ -20,15 +20,15 @@ describe('getTimeFormatterForGranularity()', () => {
     expect(getFormatter('PT0.5H')(date)).toBe('2020-05-10 11:10');
     expect(getFormatter('PT1H')(date)).toBe('2020-05-10 11:00');
     expect(getFormatter('P1D')(date)).toBe('2020-05-10');
-    expect(getFormatter('P1W')(date)).toBe('2020-05-10 W18');
+    expect(getFormatter('P1W')(date)).toBe('2020-05-10');
     expect(getFormatter('P1M')(date)).toBe('2020-05');
     expect(getFormatter('P0.25Y')(date)).toBe('2020 Q2');
     expect(getFormatter('P1Y')(date)).toBe('2020');
     // sunday based week
-    expect(getFormatter('1969-12-28T00:00:00Z/P1W')(date)).toBe('2020-05-10 W19');
-    expect(getFormatter('P1W/1970-01-03T00:00:00Z')(date)).toBe('2020-05-10 W19');
+    expect(getFormatter('1969-12-28T00:00:00Z/P1W')(date)).toBe('2020-05-10');
+    expect(getFormatter('P1W/1970-01-03T00:00:00Z')(date)).toBe('2020-05-10');
     // monday based week
-    expect(getFormatter('1969-12-29T00:00:00Z/P1W')(date)).toBe('2020-05-10 W18');
-    expect(getFormatter('P1W/1970-01-04T00:00:00Z')(date)).toBe('2020-05-10 W18');
+    expect(getFormatter('1969-12-29T00:00:00Z/P1W')(date)).toBe('2020-05-10');
+    expect(getFormatter('P1W/1970-01-04T00:00:00Z')(date)).toBe('2020-05-10');
   });
 });


### PR DESCRIPTION
🐛 Bug Fix

Most databases, including [ISO standards](https://en.wikipedia.org/wiki/ISO_8601#Durations), actually uses Monday as the first day of a week. The default week time grain in Superset (`P1W`) should translate to Monday-based weeks, too.