### PR TITLE
fix(legacy-plugin-chart-parallel-coordinates): remove .ts ext from import in para

### DIFF
--- a/plugins/legacy-plugin-chart-parallel-coordinates/src/index.js
+++ b/plugins/legacy-plugin-chart-parallel-coordinates/src/index.js
@@ -20,7 +20,7 @@ import { t } from '@superset-ui/translation';
 import { ChartMetadata, ChartPlugin } from '@superset-ui/chart';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
-import controlPanel from './controlPanel.ts';
+import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   credits: ['https://syntagmatic.github.io/parallel-coordinates'],


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix
 Remove .ts ext from import in para. causing error in superset.
🏠 Internal
