### PR TITLE
fix(legacy-plugin-chart-table): parse numeric pageLength

### DIFF
--- a/plugins/legacy-plugin-chart-table/src/transformProps.ts
+++ b/plugins/legacy-plugin-chart-table/src/transformProps.ts
@@ -138,7 +138,7 @@ export default function transformProps(chartProps: TableChartProps): DataTablePr
     showCellBars,
     includeSearch,
     orderDesc,
-    pageLength: typeof pageLength === 'string' ? parseInt(pageLength, 10) || 0 : 0,
+    pageLength: typeof pageLength === 'string' ? parseInt(pageLength, 10) || 0 : pageLength,
     tableTimestampFormat,
     filters,
     emitFilter: tableFilter === true,

--- a/plugins/legacy-plugin-chart-table/test/ReactDataTable.test.tsx
+++ b/plugins/legacy-plugin-chart-table/test/ReactDataTable.test.tsx
@@ -24,7 +24,23 @@ import testData from './testData';
 
 describe('legacy-table', () => {
   // Can test more prop transformation here. Not needed for now.
-  describe('transformProps', () => {});
+  describe('transformProps', () => {
+    it('should parse pageLength', () => {
+      expect(transformProps(testData.basic).pageLength).toBe(20);
+      expect(
+        transformProps({
+          ...testData.basic,
+          formData: { ...testData.basic.formData, pageLength: '20' },
+        }).pageLength,
+      ).toBe(20);
+      expect(
+        transformProps({
+          ...testData.basic,
+          formData: { ...testData.basic.formData, pageLength: '' },
+        }).pageLength,
+      ).toBe(0);
+    });
+  });
 
   describe('ReactDataTable', () => {
     let wrap: CommonWrapper; // the ReactDataTable wraper

--- a/plugins/legacy-plugin-chart-table/test/testData.ts
+++ b/plugins/legacy-plugin-chart-table/test/testData.ts
@@ -26,7 +26,7 @@ const basicFormData = {
   showCellBars: true,
   includeSearch: false,
   orderDesc: true,
-  pageLength: 0,
+  pageLength: 20,
   metrics: [],
   percentMetrics: null,
   timeseriesLimitMetric: null,


### PR DESCRIPTION
🐛 Bug Fix

Pagination for table chart had stopped working because `pageLength` param somehow is not string any more.

This fix makes `transformProps` handle both numeric and string values and added unit tests.