### PR TITLE
fix: resolves query issue where wordcloud had no words

### DIFF
--- a/plugins/plugin-chart-word-cloud/src/plugin/buildQuery.ts
+++ b/plugins/plugin-chart-word-cloud/src/plugin/buildQuery.ts
@@ -6,6 +6,7 @@ export default function buildQuery(formData: WordCloudFormData) {
   return buildQueryContext(formData, baseQueryObject => [
     {
       ...baseQueryObject,
+      groupby: [formData.series],
     },
   ]);
 }


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix
Word cloud chart was not getting any words back from the API. This resolves that issue. I think it was an accidental deletion in another PR. 

🏠 Internal
