### PR TITLE
fix: nvd3 annotation tooltip

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.css
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.css
@@ -154,7 +154,8 @@
   font-weight: normal;
 }
 
-.d3-tip.nv-event-annotation-layer-table {
+.d3-tip.nv-event-annotation-layer-table,
+.d3-tip.nv-event-annotation-layer-NATIVE {
   width: 200px;
   border-radius: 2px;
   background-color: #484848;
@@ -164,7 +165,8 @@
   color: #fff;
 }
 
-.d3-tip.nv-event-annotation-layer-table::after {
+.d3-tip.nv-event-annotation-layer-table::after,
+.d3-tip.nv-event-annotation-layer-NATIVE::after {
   content: '\25BC';
   font-size: 14px;
   color: #484848;


### PR DESCRIPTION
🐛 Bug Fix

It looks like a long time ago, the `sourceType` field for annotations was migrated from being `table` to `NATIVE`. This broke the tooltip for annotations. Since I'm quite unfamiliar with this code, and for backwards compatibility, I've left the old selector in but also added the new one which should resolve the issue.

New class name in superset:
![image](https://user-images.githubusercontent.com/7409244/82944281-c257fb00-9f4f-11ea-84bd-973759bf7b50.png)

to: @ktmud @graceguo-supercat @kristw 