### PR TITLE
feat: allow developer to get supersetclient instance

### DIFF
--- a/packages/superset-ui-connection/src/SupersetClient.ts
+++ b/packages/superset-ui-connection/src/SupersetClient.ts
@@ -3,12 +3,12 @@ import { ClientConfig, RequestConfig, SupersetClientInterface } from './types';
 
 let singletonClient: SupersetClientClass | undefined;
 
-function getInstance(maybeClient: SupersetClientClass | undefined): SupersetClientClass {
-  if (!maybeClient) {
+function getInstance(): SupersetClientClass {
+  if (!singletonClient) {
     throw new Error('You must call SupersetClient.configure(...) before calling other methods');
   }
 
-  return maybeClient;
+  return singletonClient;
 }
 
 const SupersetClient: SupersetClientInterface = {
@@ -17,15 +17,15 @@ const SupersetClient: SupersetClientInterface = {
 
     return singletonClient;
   },
-  delete: (request: RequestConfig) => getInstance(singletonClient).delete(request),
-  get: (request: RequestConfig) => getInstance(singletonClient).get(request),
+  delete: (request: RequestConfig) => getInstance().delete(request),
+  get: (request: RequestConfig) => getInstance().get(request),
   getInstance,
-  init: (force?: boolean) => getInstance(singletonClient).init(force),
-  isAuthenticated: () => getInstance(singletonClient).isAuthenticated(),
-  post: (request: RequestConfig) => getInstance(singletonClient).post(request),
-  put: (request: RequestConfig) => getInstance(singletonClient).put(request),
-  reAuthenticate: () => getInstance(singletonClient).init(/* force = */ true),
-  request: (request: RequestConfig) => getInstance(singletonClient).request(request),
+  init: (force?: boolean) => getInstance().init(force),
+  isAuthenticated: () => getInstance().isAuthenticated(),
+  post: (request: RequestConfig) => getInstance().post(request),
+  put: (request: RequestConfig) => getInstance().put(request),
+  reAuthenticate: () => getInstance().init(/* force = */ true),
+  request: (request: RequestConfig) => getInstance().request(request),
   reset: () => {
     singletonClient = undefined;
   },


### PR DESCRIPTION
🏆  Enhancements

In the existing implementation, `SupersetClient.getInstance()` will always throw error unless you also pass a `SupersetClient` instance as an argument. Then it will just return what you pass in as an argument back. 

I believe the original intention was to force developer to call `SupersetClient.configure()` before calling `.getInstance()` but even after calling `.configure()`. The `.getInstance()` itself is still not useful by itself. Calling it without argument, hoping to obtained the configured `SupersetClient` results in an `Error`. (I want to get the host name from the already configured singleton) and if I already have the `SupersetClient` instance, I would not bother calling this function.

This PR modifies the code to preserve the original intention, but allow `.getInstance()` to return the configured `SupersetClient` if it already exists. (The only way for it to exist is somebody must have called `.configure()` before that.)

Technically this is breaking but I have checked the relevant repositories and none call `.getInstance()` (not surprising though given its limited usefulness, if any)
