### PR TITLE
build: allow building only one (or more) package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,12 @@ yarn install
 yarn build
 ```
 
+To build only selected packages or plugins,
+
+```bash
+yarn build "*chart-table"
+```
+
 ### File organization
 
 [lerna](https://github.com/lerna/lerna/) and [yarn](https://yarnpkg.com) are used to manage versions

--- a/README.md
+++ b/README.md
@@ -85,12 +85,6 @@ should be written in Typescript.
 Please read the [contributing guidelines](CONTRIBUTING.md) which include development environment
 setup and other things you should know about coding in this repo.
 
-To build only selected plugins,
-
-```bash
-node scripts/build.js "*legacy-plugin-chart-table"
-```
-
 ### License
 
 Apache-2.0

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "node ./scripts/build.js",
-    "build:assets": "node ./scripts/buildAssets.js",
+    "build:assets": "node ./scripts/copyAssets.js",
     "babel": "yarn babel:cjs && yarn babel:esm",
     "babel:cjs": "nimbus babel --clean --workspaces=\"@superset-ui/!(demo|generator-superset)\" --config-file=../../babel.config.js",
     "babel:esm": "nimbus babel --clean --workspaces=\"@superset-ui/!(demo|generator-superset)\" --esm --config-file=../../babel.config.js",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Superset UI",
   "private": true,
   "scripts": {
-    "build": "yarn babel && yarn type && yarn build:assets",
+    "build": "node ./scripts/build.js",
+    "build:assets": "node ./scripts/buildAssets.js",
     "babel": "yarn babel:cjs && yarn babel:esm",
     "babel:cjs": "nimbus babel --clean --workspaces=\"@superset-ui/!(demo|generator-superset)\" --config-file=../../babel.config.js",
     "babel:esm": "nimbus babel --clean --workspaces=\"@superset-ui/!(demo|generator-superset)\" --esm --config-file=../../babel.config.js",
-    "build:assets": "node ./scripts/buildAssets.js",
     "demo": "cd packages/superset-ui-demo && yarn demo:build",
     "demo:clean": "cd packages/superset-ui-demo && yarn demo:clean",
     "storybook": "cd packages/superset-ui-demo && yarn storybook",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -18,15 +18,17 @@ const run = cmd => {
   }
 };
 
+const BABEL_CONFIG = '--config-file=../../babel.config.js';
+
 if (glob) {
   // lint is slow, so not turning it on by default
   if (extraArgs.includes('--lint')) {
     run(`nimbus eslint {packages,plugins}/${glob}/{src,test}`);
   }
-  run(`nimbus babel --clean --workspaces="@superset-ui/${glob}"`);
-  run(`nimbus babel --clean --workspaces="@superset-ui/${glob}" --esm`);
+  run(`nimbus babel --clean --workspaces="@superset-ui/${glob}" ${BABEL_CONFIG}`);
+  run(`nimbus babel --clean --workspaces="@superset-ui/${glob}" --esm ${BABEL_CONFIG}`);
   run(`nimbus typescript --build --workspaces="@superset-ui/${glob}"`);
   require('./buildAssets');
 } else {
-  run('yarn build');
+  run('yarn babel && yarn type && yarn build:assets');
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,4 @@
 #!/bin/env node
-/* eslint-disable no-console */
 /**
  * Build plugins specified by globs
  */
@@ -11,6 +10,7 @@ const extraArgs = process.argv.slice(2);
 process.env.PATH = `./node_modules/.bin:${process.env.PATH}`;
 
 const run = cmd => {
+  // eslint-disable-next-line no-console
   console.log(`>> ${cmd}`);
   const [p, ...args] = cmd.split(' ');
   const runner = spawnSync;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,7 @@
+#!/bin/env node
+/* eslint-disable no-console */
 /**
- * Build only plugins specified by globs
+ * Build plugins specified by globs
  */
 const { spawnSync } = require('child_process');
 
@@ -28,7 +30,10 @@ if (glob) {
   run(`nimbus babel --clean --workspaces="@superset-ui/${glob}" ${BABEL_CONFIG}`);
   run(`nimbus babel --clean --workspaces="@superset-ui/${glob}" --esm ${BABEL_CONFIG}`);
   run(`nimbus typescript --build --workspaces="@superset-ui/${glob}"`);
-  require('./buildAssets');
+  // eslint-disable-next-line global-require
+  require('./copyAssets');
 } else {
-  run('yarn babel && yarn type && yarn build:assets');
+  run('yarn babel');
+  run('yarn type');
+  run('yarn build:assets');
 }

--- a/scripts/copyAssets.js
+++ b/scripts/copyAssets.js
@@ -1,6 +1,8 @@
-/* eslint-disable import/no-extraneous-dependencies, no-console */
+#!/bin/env node
+/* eslint-disable no-console */
 const fg = require('fast-glob');
 const fs = require('fs-extra');
+
 const pkgGlob = process.argv[2] || '*';
 
 const packages = fg.sync([`{packages,plugins}/${pkgGlob}`], {


### PR DESCRIPTION
🏆 Enhancements

The script used for building one package (`scirpts/build.js`) is broken. This PR fixes it and adds it to `yarn build`.
