### PR TITLE
style(control-utils): fix type reexport warning in babel

### DIFF
--- a/packages/superset-ui-control-utils/src/ColumnOption.tsx
+++ b/packages/superset-ui-control-utils/src/ColumnOption.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 
-export type Column = {
+export type ColumnOptionColumn = {
   column_name: string;
   groupby?: string;
   verbose_name?: string;
@@ -33,12 +33,12 @@ export type Column = {
   filterable?: boolean;
 };
 
-export type Props = {
-  column: Column;
+export type ColumnOptionProps = {
+  column: ColumnOptionColumn;
   showType?: boolean;
 };
 
-export function ColumnOption({ column, showType = false }: Props) {
+export function ColumnOption({ column, showType = false }: ColumnOptionProps) {
   const hasExpression = column.expression && column.expression !== column.column_name;
 
   let columnType = column.type;
@@ -71,3 +71,5 @@ export function ColumnOption({ column, showType = false }: Props) {
     </span>
   );
 }
+
+export default ColumnOption;

--- a/packages/superset-ui-control-utils/src/ColumnTypeLabel.tsx
+++ b/packages/superset-ui-control-utils/src/ColumnTypeLabel.tsx
@@ -18,11 +18,11 @@
  */
 import React from 'react';
 
-export type Props = {
+export type ColumnTypeLabelProps = {
   type: string;
 };
 
-export function ColumnTypeLabel({ type }: Props) {
+export function ColumnTypeLabel({ type }: ColumnTypeLabelProps) {
   let stringIcon = '';
   if (typeof type !== 'string') {
     stringIcon = '?';
@@ -51,3 +51,5 @@ export function ColumnTypeLabel({ type }: Props) {
 
   return <span>{typeIcon}</span>;
 }
+
+export default ColumnTypeLabel;

--- a/packages/superset-ui-control-utils/src/InfoTooltipWithTrigger.tsx
+++ b/packages/superset-ui-control-utils/src/InfoTooltipWithTrigger.tsx
@@ -22,7 +22,7 @@ import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 
 const tooltipStyle: React.CSSProperties = { wordWrap: 'break-word' };
 
-interface Props {
+export interface InfoTooltipWithTriggerProps {
   label?: string;
   tooltip?: string;
   icon?: string;
@@ -32,7 +32,7 @@ interface Props {
   className?: string;
 }
 
-export default function InfoTooltipWithTrigger({
+export function InfoTooltipWithTrigger({
   label,
   tooltip,
   bsStyle,
@@ -40,7 +40,7 @@ export default function InfoTooltipWithTrigger({
   icon = 'info-circle',
   className = 'text-muted',
   placement = 'right',
-}: Props) {
+}: InfoTooltipWithTriggerProps) {
   const iconClass = `fa fa-${icon} ${className} ${bsStyle ? `text-${bsStyle}` : ''}`;
   const iconEl = (
     <i
@@ -75,3 +75,5 @@ export default function InfoTooltipWithTrigger({
     </OverlayTrigger>
   );
 }
+
+export default InfoTooltipWithTrigger;

--- a/packages/superset-ui-control-utils/src/index.ts
+++ b/packages/superset-ui-control-utils/src/index.ts
@@ -8,11 +8,7 @@ export const internalSharedControls = sharedControlsModule;
 export const sections = sectionModules;
 export { D3_FORMAT_DOCS, D3_FORMAT_OPTIONS, D3_TIME_FORMAT_OPTIONS } from './D3Formatting';
 export { formatSelectOptions, formatSelectOptionsForRange } from './selectOptions';
-export { default as InfoTooltipWithTrigger } from './InfoTooltipWithTrigger';
-export {
-  ColumnOption,
-  Props as ColumnOptionProps,
-  Column as ColumnOptionColumn,
-} from './ColumnOption';
-export { ColumnTypeLabel, Props as ColumnTypeLabelProps } from './ColumnTypeLabel';
-export { mainMetric, Metric } from './mainMetric';
+export * from './InfoTooltipWithTrigger';
+export * from './ColumnOption';
+export * from './ColumnTypeLabel';
+export * from './mainMetric';

--- a/packages/superset-ui-control-utils/src/shared-controls.tsx
+++ b/packages/superset-ui-control-utils/src/shared-controls.tsx
@@ -71,7 +71,7 @@ import { legacyValidateInteger, validateNonEmpty } from '@superset-ui/validator'
 
 import { formatSelectOptions } from './selectOptions';
 import { mainMetric, Metric } from './mainMetric';
-import { ColumnOption, Column as ColumnOptionColumn } from './ColumnOption';
+import { ColumnOption, ColumnOptionColumn } from './ColumnOption';
 import { TIME_FILTER_LABELS } from './constants';
 
 const categoricalSchemeRegistry = getCategoricalSchemeRegistry();

--- a/packages/superset-ui-control-utils/test/ColumnOption.test.tsx
+++ b/packages/superset-ui-control-utils/test/ColumnOption.test.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 
-import { ColumnOption, Props as ColumnOptionProps } from '../src/ColumnOption';
+import { ColumnOption, ColumnOptionProps } from '../src/ColumnOption';
 import { ColumnTypeLabel } from '../src/ColumnTypeLabel';
 import InfoTooltipWithTrigger from '../src/InfoTooltipWithTrigger';
 

--- a/packages/superset-ui-control-utils/test/ColumnTypeLabel.test.tsx
+++ b/packages/superset-ui-control-utils/test/ColumnTypeLabel.test.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { ColumnTypeLabel, Props } from '../src/ColumnTypeLabel';
+import { ColumnTypeLabel, ColumnTypeLabelProps } from '../src/ColumnTypeLabel';
 
 describe('ColumnOption', () => {
   const defaultProps = {
@@ -28,7 +28,7 @@ describe('ColumnOption', () => {
 
   const props = { ...defaultProps };
 
-  function getWrapper(overrides: Partial<Props>) {
+  function getWrapper(overrides: Partial<ColumnTypeLabelProps>) {
     const wrapper = shallow(<ColumnTypeLabel {...props} {...overrides} />);
     return wrapper;
   }


### PR DESCRIPTION
🐛 Bug Fix

🏠 Internal

`export { xxx as }` [throws a "type not found" warning](https://github.com/babel/babel/issues/8639) in babel.

```
WARNING in ./node_modules/@superset-ui/control-utils/src/index.ts 11:0-104
"export 'Column' (reexported as 'ColumnOptionColumn') was not found in './ColumnOption'

WARNING in ./node_modules/@superset-ui/control-utils/src/index.ts 13:0-50
"export 'Metric' was not found in './mainMetric'

WARNING in ./node_modules/@superset-ui/control-utils/src/index.ts 11:0-104
"export 'Props' (reexported as 'ColumnOptionProps') was not found in './ColumnOption'

WARNING in ./node_modules/@superset-ui/control-utils/src/index.ts 12:0-83
"export 'Props' (reexported as 'ColumnTypeLabelProps') was not found in './ColumnTypeLabel'
```

We should probably avoid reexporting with aliases, even if means typing becomes a little more verbose.

cc @suddjian @rusackas @kristw 