### PR TITLE
fix: annotation PropType for formula annotations

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/PropTypes.js
+++ b/plugins/legacy-preset-chart-nvd3/src/PropTypes.js
@@ -74,6 +74,6 @@ export const annotationLayerType = PropTypes.shape({
   showMarkers: PropTypes.bool,
   sourceType: PropTypes.string,
   style: PropTypes.string,
-  value: PropTypes.number,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   width: PropTypes.number,
 });


### PR DESCRIPTION
🐛 Bug Fix
The PropType for `annotationLayerType.value` is missing `string` type required for formulas, causing warnings:

![image](https://user-images.githubusercontent.com/33317356/84362256-9dad8580-abd5-11ea-96c4-2cf3700ef66f.png)
