### PR TITLE
build: fix typing rebuild for single packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "lint-staged": "^10.0.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-test-renderer": "^16.13.1"
+    "react-test-renderer": "^16.13.1",
+    "rimraf": "^3.0.2"
   },
   "engines": {
     "node": ">=10.10.0",
@@ -94,7 +95,10 @@
   ],
   "nimbus": {
     "drivers": [
-      { "driver": "babel", "strategy": "none" },
+      {
+        "driver": "babel",
+        "strategy": "none"
+      },
       "eslint",
       "jest",
       "prettier",
@@ -197,6 +201,8 @@
     },
     "typescript": {
       "compilerOptions": {
+        "rootDir": "./src",
+        "declaration": true,
         "emitDeclarationOnly": true,
         "composite": true,
         "resolveJsonModule": true

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,6 +2,7 @@
 /**
  * Build plugins specified by globs
  */
+const rimraf = require('rimraf');
 const { spawnSync } = require('child_process');
 
 const glob = process.argv[2];
@@ -27,6 +28,7 @@ if (glob) {
   if (extraArgs.includes('--lint')) {
     run(`nimbus eslint {packages,plugins}/${glob}/{src,test}`);
   }
+  rimraf.sync(`./{packages,plugins}/${glob}/{lib,esm,tsconfig.tsbuildinfo}`);
   run(`nimbus babel --clean --workspaces="@superset-ui/${glob}" ${BABEL_CONFIG}`);
   run(`nimbus babel --clean --workspaces="@superset-ui/${glob}" --esm ${BABEL_CONFIG}`);
   run(`nimbus typescript --build --workspaces="@superset-ui/${glob}"`);


### PR DESCRIPTION
🐛 Bug Fix

Sometimes build a single package via `yarn build "*package-name"` does not update rebuild the type declaration files. This PR fixes it by cleaning the existing built files first.