### PR TITLE
feat(legacy-table-chart): add query mode switch

### DIFF
--- a/packages/superset-ui-chart-controls/package.json
+++ b/packages/superset-ui-chart-controls/package.json
@@ -28,6 +28,7 @@
   "peerDependencies": {
     "@superset-ui/color": "^0.14.0",
     "@superset-ui/query": "^0.14.0",
+    "@superset-ui/style": "^0.14.0",
     "@superset-ui/translation": "^0.14.0",
     "@superset-ui/validator": "^0.14.0",
     "react": "^16.13.1"

--- a/packages/superset-ui-chart-controls/src/components/RadioButtonControl.tsx
+++ b/packages/superset-ui-chart-controls/src/components/RadioButtonControl.tsx
@@ -18,7 +18,7 @@
  */
 import React, { ReactText, ReactNode, MouseEvent, useCallback } from 'react';
 import styled from '@superset-ui/style';
-import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
+import { InfoTooltipWithTrigger } from './InfoTooltipWithTrigger';
 
 export interface RadioButtonOption {
   label: string;

--- a/packages/superset-ui-chart-controls/src/index.ts
+++ b/packages/superset-ui-chart-controls/src/index.ts
@@ -18,4 +18,7 @@ export * from './components/ColumnOption';
 export * from './components/ColumnTypeLabel';
 export * from './components/MetricOption';
 
+// React control components
+export * from './components/RadioButtonControl';
+
 export * from './types';

--- a/packages/superset-ui-chart-controls/src/index.ts
+++ b/packages/superset-ui-chart-controls/src/index.ts
@@ -12,6 +12,7 @@ export const sections = sectionModules;
 export { D3_FORMAT_DOCS, D3_FORMAT_OPTIONS, D3_TIME_FORMAT_OPTIONS } from './utils/D3Formatting';
 export { formatSelectOptions, formatSelectOptionsForRange } from './utils/selectOptions';
 export * from './utils/mainMetric';
+export * from './utils/expandControlConfig';
 
 export * from './components/InfoTooltipWithTrigger';
 export * from './components/ColumnOption';

--- a/packages/superset-ui-chart-controls/src/shared-controls/components.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/components.tsx
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import RadioButtonControl from '../components/RadioButtonControl';
+
+export * from '../components/RadioButtonControl';
+
+/**
+ * Aliases for Control Components
+ */
+export default {
+  RadioButtonControl,
+};

--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -42,17 +42,17 @@ import {
 } from '@superset-ui/color';
 import { legacyValidateInteger, validateNonEmpty } from '@superset-ui/validator';
 
-import { formatSelectOptions } from './utils/selectOptions';
-import { mainMetric, Metric } from './utils/mainMetric';
-import { TIME_FILTER_LABELS } from './constants';
+import { formatSelectOptions } from '../utils/selectOptions';
+import { mainMetric, Metric } from '../utils/mainMetric';
+import { TIME_FILTER_LABELS } from '../constants';
 import {
   SharedControlConfig,
   ColumnMeta,
   DatasourceMeta,
   ExtraControlProps,
   SelectControlConfig,
-} from './types';
-import { ColumnOption } from './components/ColumnOption';
+} from '../types';
+import { ColumnOption } from '../components/ColumnOption';
 
 const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
 const sequentialSchemeRegistry = getSequentialSchemeRegistry();

--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -133,6 +133,9 @@ export type InternalControlType =
   | 'AdhocFilterControlVerifiedOptions'
   | keyof SharedControlComponents; // expanded in `expandControlConfig`
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ControlType = InternalControlType | React.ComponentType<any>;
+
 export type TabOverride = 'data' | boolean;
 
 /**
@@ -163,14 +166,14 @@ export type TabOverride = 'data' | boolean;
  *    be visibile.
  */
 export interface BaseControlConfig<
-  T = unknown,
+  T extends ControlType = ControlType,
   O extends SelectOption = SelectOption,
   V = unknown
 > {
   type: T;
   label?: ReactNode;
   description?: ReactNode;
-  default?: unknown;
+  default?: V;
   renderTrigger?: boolean;
   validators?: ControlValueValidator<T, O, V>[];
   warning?: ReactNode;
@@ -274,16 +277,11 @@ export interface OverrideSharedControlItem<A extends SharedControlAlias = Shared
   override: Partial<SharedControls[A]>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type CustomControlItem<P = any> = P extends SharedControlAlias
-  ? {
-      name: P;
-      config: SharedControls[P];
-    }
-  : {
-      name: string;
-      config: CustomControlConfig<P>;
-    };
+export type CustomControlItem = {
+  name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config: BaseControlConfig<any, any, any>;
+};
 
 // use ReactElement instead of ReactNode because `string`, `number`, etc. may
 // interfere with other ControlSetItem types

--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -172,7 +172,7 @@ export interface BaseControlConfig<T = unknown> {
   // override control panel state props
   mapStateToProps?: (
     state: ControlPanelState,
-    control: this,
+    control: ControlConfig<T>,
     actions?: ControlPanelActionDispatchers,
   ) => ExtraControlProps;
   tabOverride?: TabOverride;
@@ -227,10 +227,10 @@ export type SharedControlConfig<
 /** --------------------------------------------
  * Custom controls
  * --------------------------------------------- */
-export type CustomComponentControlConfig<P = unknown> = BaseControlConfig<
-  InternalControlType | React.ComponentType<P>
-> &
-  Omit<P, 'onChange' | 'hovered'>; // two run-time properties from superset-frontend/src/explore/components/Control.jsx
+export type CustomComponentControlConfig<
+  P = unknown,
+  T = InternalControlType | React.ComponentType<P>
+> = BaseControlConfig<T> & Omit<P, 'onChange' | 'hovered'>; // two run-time properties from superset-frontend/src/explore/components/Control.jsx
 
 // Catch-all ControlConfig
 //  - if T == known control types, return SharedControlConfig,
@@ -238,11 +238,13 @@ export type CustomComponentControlConfig<P = unknown> = BaseControlConfig<
 export type ControlConfig<
   T extends InternalControlType | unknown = InternalControlType,
   O extends SelectOption = SelectOption
-> = T extends InternalControlType ? SharedControlConfig<T, O> : CustomComponentControlConfig<T>;
+> = T extends InternalControlType
+  ? SharedControlConfig<T, O>
+  : CustomComponentControlConfig<unknown, T>;
 
-/** --------------------------------------------
+/** ===========================================================
  * Chart plugin control panel config
- * --------------------------------------------- */
+ * ========================================================= */
 export type SharedControlAlias = keyof typeof sharedControls;
 
 export type SharedSectionAlias =
@@ -264,16 +266,11 @@ export interface CustomControlItem<P = any> {
   config: CustomComponentControlConfig<P>;
 }
 
-export type ControlSetItem =
-  | SharedControlAlias
-  | OverrideSharedControlItem
-  | CustomControlItem
-  // use ReactElement instead of ReactNode because `string`, `number`, etc. may
-  // interfere with other ControlSetItem types
-  | ReactElement
-  | null;
-
+// use ReactElement instead of ReactNode because `string`, `number`, etc. may
+// interfere with other ControlSetItem types
 export type ExpandedControlItem = CustomControlItem | ReactElement | null;
+
+export type ControlSetItem = SharedControlAlias | OverrideSharedControlItem | ExpandedControlItem;
 
 export type ControlSetRow = ControlSetItem[];
 

--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -22,7 +22,8 @@ import { QueryFormData } from '@superset-ui/query';
 import sharedControls from './shared-controls';
 import sharedControlComponents from './shared-controls/components';
 
-type AnyDict = Record<string, unknown>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDict = Record<string, any>;
 interface Action {
   type: string;
 }
@@ -82,10 +83,11 @@ export interface ControlPanelActionDispatchers {
 export type ExtraControlProps = AnyDict;
 
 // Ref:superset-frontend/src/explore/store.js
-export type ControlState<
-  T extends InternalControlType | unknown = InternalControlType,
-  O extends SelectOption = SelectOption
-> = ControlConfig<T, O> & ExtraControlProps;
+export type ControlState<T = ControlType, O extends SelectOption = SelectOption> = ControlConfig<
+  T,
+  O
+> &
+  ExtraControlProps;
 
 export interface ControlStateMapping {
   [key: string]: ControlState;
@@ -169,7 +171,7 @@ export interface BaseControlConfig<
   T extends ControlType = ControlType,
   O extends SelectOption = SelectOption,
   V = unknown
-> {
+> extends AnyDict {
   type: T;
   label?: ReactNode;
   description?: ReactNode;
@@ -186,11 +188,10 @@ export interface BaseControlConfig<
   ) => ExtraControlProps;
   tabOverride?: TabOverride;
   visibility?: (props: ControlPanelsContainerProps) => boolean;
-  [key: string]: unknown;
 }
 
 export interface ControlValueValidator<
-  T = unknown,
+  T = ControlType,
   O extends SelectOption = SelectOption,
   V = unknown
 > {
@@ -253,7 +254,7 @@ export type CustomControlConfig<P = {}> = BaseControlConfig<React.ComponentType<
 //  - if T is object, assume a CustomComponent
 //  - otherwise assume it's a custom component control
 export type ControlConfig<
-  T extends InternalControlType | object | unknown = unknown,
+  T = AnyDict,
   O extends SelectOption = SelectOption
 > = T extends InternalControlType
   ? SharedControlConfig<T, O>

--- a/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
+++ b/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
@@ -29,7 +29,7 @@ export function expandControlType(controlType: ControlType) {
 }
 
 /**
- * Expand shorthand control config item to full config in the format of
+ * Expand a shorthand control config item to full config in the format of
  *   {
  *     name: ...,
  *     config: {

--- a/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
+++ b/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { ReactElement } from 'react';
 import sharedControls from '../shared-controls';
 import sharedControlComponents from '../shared-controls/components';
 import { ControlType, ControlSetItem, ExpandedControlItem, ControlOverrides } from '../types';
@@ -38,7 +38,7 @@ export function expandControlType(controlType: ControlType) {
  *     }
  *   }
  */
-export default function expandControlConfig(
+export function expandControlConfig(
   control: ControlSetItem,
   controlOverrides: ControlOverrides = {},
 ): ExpandedControlItem {
@@ -55,7 +55,7 @@ export default function expandControlConfig(
   }
   // JSX/React element or NULL
   if (!control || typeof control === 'string' || React.isValidElement(control)) {
-    return <>control</>;
+    return control as ReactElement;
   }
   // already fully expanded control config
   if ('name' in control && 'config' in control) {

--- a/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
+++ b/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
@@ -19,10 +19,10 @@
 import React from 'react';
 import sharedControls from '../shared-controls';
 import sharedControlComponents from '../shared-controls/components';
-import { ControlSetItem, ExpandedControlItem, ControlOverrides } from '../types';
+import { ControlType, ControlSetItem, ExpandedControlItem, ControlOverrides } from '../types';
 
-export function expandControlType(controlType: string) {
-  if (controlType in sharedControlComponents) {
+export function expandControlType(controlType: ControlType) {
+  if (typeof controlType === 'string' && controlType in sharedControlComponents) {
     return sharedControlComponents[controlType as keyof typeof sharedControlComponents];
   }
   return controlType;
@@ -57,13 +57,13 @@ export default function expandControlConfig(
   if (!control || typeof control === 'string' || React.isValidElement(control)) {
     return <>control</>;
   }
-  // already fully expanded contron config
+  // already fully expanded control config
   if ('name' in control && 'config' in control) {
     return {
       ...control,
       config: {
         ...control.config,
-        type: expandControlType(control.config.type),
+        type: expandControlType(control.config.type as ControlType),
       },
     };
   }

--- a/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
+++ b/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import sharedControls from '../shared-controls';
+import sharedControlComponents from '../shared-controls/components';
+import { ControlSetItem, ExpandedControlItem, ControlOverrides } from '../types';
+
+export function expandControlType(controlType: string) {
+  if (controlType in sharedControlComponents) {
+    return sharedControlComponents[controlType as keyof typeof sharedControlComponents];
+  }
+  return controlType;
+}
+
+/**
+ * Expand shorthand control config item to full config in the format of
+ *   {
+ *     name: ...,
+ *     config: {
+ *        type: ...,
+ *        ...
+ *     }
+ *   }
+ */
+export default function expandControlConfig(
+  control: ControlSetItem,
+  controlOverrides: ControlOverrides = {},
+): ExpandedControlItem {
+  // one of the named shared controls
+  if (typeof control === 'string' && control in sharedControls) {
+    const name = control;
+    return {
+      name,
+      config: {
+        ...sharedControls[name],
+        ...controlOverrides[name],
+      },
+    };
+  }
+  // JSX/React element or NULL
+  if (!control || typeof control === 'string' || React.isValidElement(control)) {
+    return <>control</>;
+  }
+  // already fully expanded contron config
+  if ('name' in control && 'config' in control) {
+    return {
+      ...control,
+      config: {
+        ...control.config,
+        type: expandControlType(control.config.type),
+      },
+    };
+  }
+  // apply overrides with shared controls
+  if ('override' in control && control.name in sharedControls) {
+    const { name, override } = control;
+    return {
+      name,
+      config: {
+        ...sharedControls[name],
+        ...override,
+      },
+    };
+  }
+  return null;
+}

--- a/packages/superset-ui-chart-controls/src/utils/selectOptions.ts
+++ b/packages/superset-ui-chart-controls/src/utils/selectOptions.ts
@@ -31,9 +31,9 @@ export function formatSelectOptions<T extends Formattable>(
 }
 
 /**
- * outputs array of arrays
- * formatSelectOptionsForRange(1, 5)
- * returns [[1,'1'], [2,'2'], [3,'3'], [4,'4'], [5,'5']]
+ * Outputs array of arrays
+ *   >> formatSelectOptionsForRange(1, 5)
+ *   >> [[1,'1'], [2,'2'], [3,'3'], [4,'4'], [5,'5']]
  */
 export function formatSelectOptionsForRange(start: number, end: number) {
   const options: Formatted[] = [];

--- a/packages/superset-ui-chart-controls/test/utils/expandControlConfig.test.tsx
+++ b/packages/superset-ui-chart-controls/test/utils/expandControlConfig.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { expandControlConfig, sharedControls } from '../../src';
+
+describe('expandControlConfig()', () => {
+  it('expands shared control alias', () => {
+    expect(expandControlConfig('metrics')).toEqual({
+      name: 'metrics',
+      config: sharedControls.metrics,
+    });
+  });
+  it('expands control with overrides', () => {
+    expect(
+      expandControlConfig({
+        name: 'metrics',
+        override: {
+          label: 'Custom Metric',
+        },
+      }),
+    ).toEqual({
+      name: 'metrics',
+      config: {
+        ...sharedControls.metrics,
+        label: 'Custom Metric',
+      },
+    });
+  });
+  it('leave full control untouched', () => {
+    const input = {
+      name: 'metrics',
+      config: {
+        type: 'SelectControl',
+        label: 'Custom Metric',
+      },
+    };
+    expect(expandControlConfig(input)).toEqual(input);
+  });
+  it('leave NULL and ReactElement untouched', () => {
+    expect(expandControlConfig(null)).toBeNull();
+    const input = <h1>Test</h1>;
+    expect(expandControlConfig(input)).toBe(input);
+  });
+  it('leave unknown text untouched', () => {
+    const input = 'superset-ui';
+    expect(expandControlConfig(input as never)).toBe(input);
+  });
+});

--- a/plugins/legacy-plugin-chart-table/package.json
+++ b/plugins/legacy-plugin-chart-table/package.json
@@ -38,6 +38,7 @@
     "@superset-ui/chart-controls": "^0.14.0",
     "@superset-ui/number-format": "^0.14.0",
     "@superset-ui/query": "^0.14.0",
+    "@superset-ui/style": "^0.14.0",
     "@superset-ui/time-format": "^0.14.0",
     "@superset-ui/translation": "^0.14.0",
     "@superset-ui/validator": "^0.14.0",

--- a/plugins/legacy-plugin-chart-table/src/RadioButtonControl.tsx
+++ b/plugins/legacy-plugin-chart-table/src/RadioButtonControl.tsx
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { ReactText, ReactNode, MouseEvent, useCallback } from 'react';
+import styled from '@superset-ui/style';
+import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
+
+export interface RadioButtonOption {
+  label: string;
+  value: ReactText;
+}
+
+export interface RadioButtonControlProps {
+  label?: ReactNode;
+  description?: string;
+  options: RadioButtonOption[];
+  hovered?: boolean;
+  value?: string;
+  onChange: (opt: string) => void;
+}
+
+const Styles = styled.div`
+  .btn:focus {
+    outline: none;
+  }
+  .control-label + .btn-group {
+    margin-top: 1px;
+  }
+  .btn-group .btn.active {
+    background: ${({ theme }) => theme.colors.secondary.light5};
+    box-shadow: none;
+    font-weight: ${({ theme }) => theme.typography.weights.bold};
+  }
+`;
+
+export default function RadioButtonControl({
+  label: controlLabel,
+  description,
+  value: initialValue,
+  hovered,
+  options,
+  onChange,
+}: RadioButtonControlProps) {
+  const currentValue = initialValue || options[0].value;
+  const onClick = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      onChange(e.currentTarget.value);
+    },
+    [onChange],
+  );
+  return (
+    <Styles>
+      {controlLabel && (
+        <div className="control-label">
+          {controlLabel}{' '}
+          {hovered && description && (
+            <InfoTooltipWithTrigger tooltip={description} placement="top" />
+          )}
+        </div>
+      )}
+      <div className="btn-group btn-group-sm">
+        {options.map(({ label, value }, i) => (
+          <button
+            key={value}
+            type="button"
+            className={`btn btn-default ${options[i].value === currentValue ? 'active' : ''}`}
+            value={value}
+            onClick={onClick}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </Styles>
+  );
+}

--- a/plugins/legacy-plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/legacy-plugin-chart-table/src/controlPanel.tsx
@@ -27,7 +27,7 @@ import {
   ControlStateMapping,
   ControlPanelConfig,
   ControlPanelsContainerProps,
-} from '@superset-ui/chart-controls/src';
+} from '@superset-ui/chart-controls';
 import { validateNonEmpty } from '@superset-ui/validator';
 
 export enum QueryMode {

--- a/plugins/legacy-plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/legacy-plugin-chart-table/src/controlPanel.tsx
@@ -22,15 +22,13 @@ import { t } from '@superset-ui/translation';
 import {
   formatSelectOptions,
   D3_TIME_FORMAT_OPTIONS,
+  ControlConfig,
   ColumnOption,
   ControlStateMapping,
   ControlPanelConfig,
   ControlPanelsContainerProps,
-  CustomComponentControlConfig,
-} from '@superset-ui/chart-controls';
+} from '@superset-ui/chart-controls/src';
 import { validateNonEmpty } from '@superset-ui/validator';
-
-import RadioButtonControl, { RadioButtonControlProps } from './RadioButtonControl';
 
 export enum QueryMode {
   agg = 'agg',
@@ -64,8 +62,8 @@ function isQueryMode(mode: QueryMode) {
 const isAggMode = isQueryMode(QueryMode.agg);
 const isRawMode = isQueryMode(QueryMode.raw);
 
-const queryMode: CustomComponentControlConfig<RadioButtonControlProps> = {
-  type: RadioButtonControl,
+const queryMode: ControlConfig<'RadioButtonControl'> = {
+  type: 'RadioButtonControl',
   label: t('Query Mode'),
   default: QueryMode.agg,
   options: [
@@ -83,18 +81,18 @@ const queryMode: CustomComponentControlConfig<RadioButtonControlProps> = {
   },
 };
 
-const queryModeControl = {
-  name: 'query_mode',
-  config: queryMode,
-};
-
 const config: ControlPanelConfig = {
   controlPanelSections: [
     {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
-        [queryModeControl],
+        [
+          {
+            name: 'query_mode',
+            config: queryMode,
+          },
+        ],
         [
           {
             name: 'groupby',

--- a/plugins/legacy-plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/legacy-plugin-chart-table/src/controlPanel.tsx
@@ -35,8 +35,8 @@ import { smartDateFormatter } from '@superset-ui/time-format';
 export const PAGE_SIZE_OPTIONS = formatSelectOptions<number>([[0, t('All')], 10, 20, 50, 100, 200]);
 
 export enum QueryMode {
-  aggregate = 'AGGREGATE',
-  raw = 'RAW',
+  aggregate = 'aggregate',
+  raw = 'raw',
 }
 
 const QueryModeLabel = {

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -35,8 +35,8 @@ import { smartDateFormatter } from '@superset-ui/time-format';
 export const PAGE_SIZE_OPTIONS = formatSelectOptions<number>([[0, t('All')], 10, 20, 50, 100, 200]);
 
 export enum QueryMode {
-  aggregate = 'AGGREGATE',
-  raw = 'RAW',
+  aggregate = 'aggregate',
+  raw = 'raw',
 }
 
 const QueryModeLabel = {

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -27,6 +27,7 @@ import {
   ControlStateMapping,
   ControlPanelConfig,
   ControlPanelsContainerProps,
+  sharedControls,
 } from '@superset-ui/chart-controls';
 import { validateNonEmpty } from '@superset-ui/validator';
 import { smartDateFormatter } from '@superset-ui/time-format';
@@ -34,23 +35,23 @@ import { smartDateFormatter } from '@superset-ui/time-format';
 export const PAGE_SIZE_OPTIONS = formatSelectOptions<number>([[0, t('All')], 10, 20, 50, 100, 200]);
 
 export enum QueryMode {
-  agg = 'agg',
-  raw = 'raw',
+  aggregate = 'AGGREGATE',
+  raw = 'RAW',
 }
 
 const QueryModeLabel = {
-  [QueryMode.agg]: t('Aggregate'),
+  [QueryMode.aggregate]: t('Aggregate'),
   [QueryMode.raw]: t('Raw Records'),
 };
 
 function getQueryMode(controls: ControlStateMapping): QueryMode {
   const mode = controls?.query_mode?.value;
-  if (mode === QueryMode.agg || mode === QueryMode.raw) {
+  if (mode === QueryMode.aggregate || mode === QueryMode.raw) {
     return mode as QueryMode;
   }
   const groupby = controls?.groupby?.value;
   const hasGroupBy = groupby && (groupby as string[])?.length > 0;
-  return hasGroupBy ? QueryMode.agg : QueryMode.raw;
+  return hasGroupBy ? QueryMode.aggregate : QueryMode.raw;
 }
 
 /**
@@ -62,17 +63,17 @@ function isQueryMode(mode: QueryMode) {
   };
 }
 
-const isAggMode = isQueryMode(QueryMode.agg);
+const isAggMode = isQueryMode(QueryMode.aggregate);
 const isRawMode = isQueryMode(QueryMode.raw);
 
 const queryMode: ControlConfig<'RadioButtonControl'> = {
   type: 'RadioButtonControl',
   label: t('Query Mode'),
-  default: QueryMode.agg,
+  default: QueryMode.aggregate,
   options: [
     {
-      label: QueryModeLabel[QueryMode.agg],
-      value: QueryMode.agg,
+      label: QueryModeLabel[QueryMode.aggregate],
+      value: QueryMode.aggregate,
     },
     {
       label: QueryModeLabel[QueryMode.raw],
@@ -80,8 +81,45 @@ const queryMode: ControlConfig<'RadioButtonControl'> = {
     },
   ],
   mapStateToProps: ({ controls }) => {
-    return { value: getQueryMode(controls as ControlStateMapping) };
+    return { value: getQueryMode(controls) };
   },
+};
+
+const all_columns: typeof sharedControls.groupby = {
+  type: 'SelectControl',
+  label: t('Columns'),
+  description: t('Columns to display'),
+  multi: true,
+  freeForm: true,
+  allowAll: true,
+  commaChoosesOption: false,
+  default: [],
+  optionRenderer: c => <ColumnOption showType column={c} />,
+  valueRenderer: c => <ColumnOption column={c} />,
+  valueKey: 'column_name',
+  mapStateToProps: ({ datasource, controls }) => ({
+    options: datasource?.columns || [],
+    queryMode: getQueryMode(controls),
+  }),
+  visibility: isRawMode,
+};
+
+const percent_metrics: typeof sharedControls.metrics = {
+  type: 'MetricsControl',
+  label: t('Percentage Metrics'),
+  description: t('Metrics for which percentage of total are to be displayed'),
+  multi: true,
+  visibility: isAggMode,
+  mapStateToProps: ({ datasource, controls }) => {
+    return {
+      columns: datasource?.columns || [],
+      savedMetrics: datasource?.metrics || [],
+      datasourceType: datasource?.type,
+      queryMode: getQueryMode(controls),
+    };
+  },
+  default: [],
+  validators: [],
 };
 
 const config: ControlPanelConfig = {
@@ -114,46 +152,13 @@ const config: ControlPanelConfig = {
           },
           {
             name: 'all_columns',
-            config: {
-              type: 'SelectControl',
-              label: t('Columns'),
-              description: t('Columns to display'),
-              multi: true,
-              freeForm: true,
-              allowAll: true,
-              commaChoosesOption: false,
-              default: [],
-              optionRenderer: (c: never) => <ColumnOption showType column={c} />,
-              valueRenderer: (c: never) => <ColumnOption column={c} />,
-              valueKey: 'column_name',
-              mapStateToProps: ({ datasource, controls }) => ({
-                options: datasource?.columns || [],
-                queryMode: getQueryMode(controls),
-              }),
-              visibility: isRawMode,
-            },
+            config: all_columns,
           },
         ],
         [
           {
             name: 'percent_metrics',
-            config: {
-              type: 'MetricsControl',
-              label: t('Percentage Metrics'),
-              description: t('Metrics for which percentage of total are to be displayed'),
-              multi: true,
-              visibility: isAggMode,
-              mapStateToProps: ({ datasource, controls }) => {
-                return {
-                  columns: datasource?.columns || [],
-                  savedMetrics: datasource?.metrics || [],
-                  datasourceType: datasource?.type,
-                  queryMode: getQueryMode(controls),
-                };
-              },
-              default: [],
-              validators: [],
-            },
+            config: percent_metrics,
           },
         ],
         [

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -29,6 +29,7 @@ import {
   ControlPanelsContainerProps,
 } from '@superset-ui/chart-controls';
 import { validateNonEmpty } from '@superset-ui/validator';
+import { smartDateFormatter } from '@superset-ui/time-format';
 
 export const PAGE_SIZE_OPTIONS = formatSelectOptions<number>([[0, t('All')], 10, 20, 50, 100, 200]);
 
@@ -216,7 +217,7 @@ const config: ControlPanelConfig = {
               type: 'SelectControl',
               freeForm: true,
               label: t('Table Timestamp Format'),
-              default: '%Y-%m-%d %H:%M:%S',
+              default: smartDateFormatter.id,
               renderTrigger: true,
               validators: [validateNonEmpty],
               clearable: false,
@@ -233,7 +234,7 @@ const config: ControlPanelConfig = {
               freeForm: true,
               renderTrigger: true,
               label: t('Page Length'),
-              default: 0,
+              default: null,
               choices: PAGE_SIZE_OPTIONS,
               description: t('Rows per page, 0 means no pagination'),
             },

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -144,7 +144,10 @@ const processColumns = memoizeOne(function processColumns(props: TableChartProps
   ] as [typeof metrics, typeof percentMetrics, typeof columns];
 }, isEqualColumns);
 
-const getDefaultPageSize = (
+/**
+ * Automatically set page size based on number of cells.
+ */
+const getPageSize = (
   pageSize: number | string | null | undefined,
   numRecords: number,
   numColumns: number,
@@ -194,7 +197,7 @@ export default function transformProps(chartProps: TableChartProps): TableChartT
     showCellBars,
     sortDesc,
     includeSearch,
-    pageSize: getDefaultPageSize(pageSize, data.length, columns.length),
+    pageSize: getPageSize(pageSize, data.length, columns.length),
     filters,
     emitFilter: tableFilter === true,
     onChangeFilter,


### PR DESCRIPTION
🏆 Enhancements

<img src="https://user-images.githubusercontent.com/335541/84823590-73900500-afd3-11ea-8106-a815bc72ddd0.png" width="300"> <img src="https://user-images.githubusercontent.com/335541/84823553-6410bc00-afd3-11ea-8148-3816702cd844.png" width="300">

Rearrange form controls for Table chart, replace GROUP BY and NOT GROUP BY with a "Query Mode" switch.

Added to both the legacy table and [the new table chart](https://github.com/apache-superset/superset-ui/pull/584).

Superset app also need to be updated to accept the frontend passing in both `all_columns` and `metrics`.

Related: https://github.com/apache/incubator-superset/pull/10113