### PR TITLE
build: clean package-lock.json before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "postrelease": "lerna run deploy-demo",
     "list-changed-packages": "lerna changed",
     "manual-release": "lerna publish --force-publish && yarn postrelease",
-    "ci:create-patch-version": "lerna version patch --yes",
-    "ci:create-minor-version": "lerna version minor --yes",
-    "ci:create-conventional-version": "lerna version --conventional-commits --create-release github --yes",
-    "ci:release-from-tag": "lerna publish from-package --yes",
-    "ci:release-conventional": "lerna publish --conventional-commits --create-release github --yes"
+    "clean-npm-lock": "rm -rf package-lock.json ./{packages,plugins}/*/package-lock.json",
+    "ci:create-patch-version": "yarn clean-npm-lock && lerna version patch --yes",
+    "ci:create-minor-version": "yarn clean-npm-lock && lerna version minor --yes",
+    "ci:create-conventional-version": "yarn clean-npm-lock && lerna version --conventional-commits --create-release github --yes",
+    "ci:release-from-tag": "yarn clean-npm-lock && lerna publish from-package --yes",
+    "ci:release-conventional": "yarn clean-npm-lock && lerna publish --conventional-commits --create-release github --yes"
   },
   "repository": "https://github.com/apache-superset/superset-ui.git",
   "keywords": [


### PR DESCRIPTION
🏆 Enhancements

🏠 Internal

Clean up `package-lock.json` before `lerna` release commands to increase chances of success.