### PR TITLE
fix: got one color wrong when copy pasting

### DIFF
--- a/packages/superset-ui-color/src/colorSchemes/categorical/superset.ts
+++ b/packages/superset-ui-color/src/colorSchemes/categorical/superset.ts
@@ -17,7 +17,7 @@ const schemes = [
       '#3CCCCB',
       '#A38F79',
       // Pastels
-      '#A38F79',
+      '#8FD3E4',
       '#A1A6BD',
       '#ACE1C4',
       '#FEC0A1',


### PR DESCRIPTION
## before
<img width="528" alt="Screen Shot 2020-06-20 at 9 47 04 PM" src="https://user-images.githubusercontent.com/487433/85216946-b2a9b780-b33f-11ea-8f4d-2cb1f1d901a5.png">

## after

<img width="517" alt="Screen Shot 2020-06-20 at 9 46 19 PM" src="https://user-images.githubusercontent.com/487433/85216948-b3424e00-b33f-11ea-8275-64b1415394f2.png">
