### PR TITLE
chore(legacy-plugin-chart-country-map): use peerDependencies

### DIFF
--- a/plugins/legacy-plugin-chart-country-map/package.json
+++ b/plugins/legacy-plugin-chart-country-map/package.json
@@ -28,12 +28,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.14.2",
     "d3": "^3.5.17",
     "d3-array": "^2.0.3",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
+    "@superset-ui/chart-controls": "^0.14.0",
     "@superset-ui/chart": "^0.14.0",
     "@superset-ui/color": "^0.14.0",
     "@superset-ui/number-format": "^0.14.0",


### PR DESCRIPTION
🏠 Internal

Move `@superset-ui/chart-controls` to `peerDependencies` as `lerna create-patch-version` will always used fixed versions and would cause duplicate installations when a parent app updates `@superset-ui/chart-controls` but forgot to update `legacy-plugin-chart-country-map`.

cc @rusackas @pkdotson 