### PR TITLE
chore: upgrade react-table to v7.2.1

### DIFF
--- a/plugins/plugin-chart-table/package.json
+++ b/plugins/plugin-chart-table/package.json
@@ -36,7 +36,7 @@
     "match-sorter": "^4.1.0",
     "memoize-one": "^5.1.1",
     "react-icons": "^3.10.0",
-    "react-table": "^7.2.0",
+    "react-table": "^7.2.1",
     "regenerator-runtime": "^0.13.5",
     "xss": "^1.0.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15348,10 +15348,10 @@ react-syntax-highlighter@^11.0.2:
     prismjs "^1.8.4"
     refractor "^2.4.1"
 
-react-table@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.2.0.tgz#a2d8a84efa610be541103b3c714cacbb15df9d1a"
-  integrity sha512-hcBwPimjwOKQZoaeoQnUYyQNCg3NhjA1xAhKmuxam03sKsxE5NfI4GZ1qJcBQ8CJVj78e1o/lOKCh1AGuPmcnQ==
+react-table@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.2.1.tgz#d85f5a59b6441ccd9e0acddc93c288c54a7de7ee"
+  integrity sha512-cICU3w5yFWTDluz9yFePziEQXGt3PK5R1Va3InP7qMGnZOKm8kv0GiDMli+VOqE1uM1dBYPb9BEad15up1ac6g==
   dependencies:
     "@scarf/scarf" "^1.0.4"
 


### PR DESCRIPTION
🏠 Internal

This is what Superset app will install anyway (when installing `@superset-ui/plugin-chart-table @ ^0.14.2`).
