### PR TITLE
fix(plugin-chart-table): change default queryMode to null

### DIFF
--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -49,9 +49,9 @@ function getQueryMode(controls: ControlStateMapping): QueryMode {
   if (mode === QueryMode.aggregate || mode === QueryMode.raw) {
     return mode as QueryMode;
   }
-  const groupby = controls?.groupby?.value;
-  const hasGroupBy = groupby && (groupby as string[])?.length > 0;
-  return hasGroupBy ? QueryMode.aggregate : QueryMode.raw;
+  const rawColumns = controls?.all_columns?.value;
+  const hasRawColumns = rawColumns && (rawColumns as string[])?.length > 0;
+  return hasRawColumns ? QueryMode.raw : QueryMode.aggregate;
 }
 
 /**
@@ -69,7 +69,7 @@ const isRawMode = isQueryMode(QueryMode.raw);
 const queryMode: ControlConfig<'RadioButtonControl'> = {
   type: 'RadioButtonControl',
   label: t('Query Mode'),
-  default: QueryMode.aggregate,
+  default: null,
   options: [
     {
       label: QueryModeLabel[QueryMode.aggregate],


### PR DESCRIPTION
🐛 Bug Fix

Change default query mode for table chart from `aggregate` to `null` so it can fallback to `getQueryMode` to have better backward compatibility. Currently existing tables in NOT GROUP BY mode will not open the "Raw" tab by default.

Also change `getQueryMode` to use `raw` when `all_columns` is present, to be consistent with the backend.

### Test Plan

Will add a Cypress test in Superset

cc @etr2460 @kristw 