### PR TITLE
feat: update timeout code to return new error format

### DIFF
--- a/packages/superset-ui-connection/src/callApi/rejectAfterTimeout.ts
+++ b/packages/superset-ui-connection/src/callApi/rejectAfterTimeout.ts
@@ -4,7 +4,14 @@ export default function rejectAfterTimeout<T>(timeout: number) {
     setTimeout(
       () =>
         reject({
-          error: 'Request timed out',
+          errors: [
+            {
+              error_type: 'FRONTEND_TIMEOUT_ERROR',
+              extra: { timeout },
+              level: 'error',
+              message: 'Request timed out',
+            },
+          ],
           statusText: 'timeout',
         }),
       timeout,

--- a/packages/superset-ui-connection/test/callApi/callApiAndParseWithTimeout.test.ts
+++ b/packages/superset-ui-connection/test/callApi/callApiAndParseWithTimeout.test.ts
@@ -100,7 +100,14 @@ describe('callApiAndParseWithTimeout()', () => {
       } catch (error) {
         expect(fetchMock.calls(mockTimeoutUrl)).toHaveLength(1);
         expect(error).toEqual({
-          error: 'Request timed out',
+          errors: [
+            {
+              error_type: 'FRONTEND_TIMEOUT_ERROR',
+              extra: { timeout: 1 },
+              level: 'error',
+              message: 'Request timed out',
+            },
+          ],
           statusText: 'timeout',
         });
       }


### PR DESCRIPTION
🏆 Enhancements
Now that Superset's frontend has fallback logic for any parts not yet migrated to the new error format, we can update this safely, providing more details and context about the error

to: @ktmud @williaster 