### PR TITLE
fix(legacy-plugin-chart-treemap): incorrect template literal

### DIFF
--- a/plugins/legacy-plugin-chart-treemap/src/Treemap.js
+++ b/plugins/legacy-plugin-chart-treemap/src/Treemap.js
@@ -139,7 +139,7 @@ function Treemap(element, props) {
         d.data.name
           .slice(Math.max(0, d.data.name.lastIndexOf('.') + 1))
           .split(/(?=[A-Z][^A-Z])/g)
-          .concat(`\u00A0{formatNumber(d.value)}`),
+          .concat(`\u00A0${formatNumber(d.value)}`),
       )
       .enter()
       .append('tspan')


### PR DESCRIPTION
🐛 Bug Fix
The string literal on the legacy Treemap viz was missing a `$` sign, causing the expression to be written literally.

### AFTER SCREENSHOT
![image](https://user-images.githubusercontent.com/33317356/88013689-b3439280-cb25-11ea-848c-1026c8c22256.png)
