### PR TITLE
fix(legacy-plugin-chart-pivot-table): formatting non-numeric values

### DIFF
--- a/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
@@ -72,7 +72,11 @@ function PivotTable(element, props) {
         const metric = cols[i];
         const format = columnFormats[metric] || numberFormat || '.3s';
         const tdText = $(this)[0].textContent;
-        if (!Number.isNaN(tdText) && tdText !== '' && tdText.trim().toLowerCase() !== 'null') {
+        if (
+          !Number.isNaN(parseFloat(tdText)) &&
+          tdText !== '' &&
+          tdText.trim().toLowerCase() !== 'null'
+        ) {
           $(this)[0].textContent = formatNumber(format, tdText);
           $(this).attr('data-sort', tdText);
         }

--- a/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
@@ -72,11 +72,7 @@ function PivotTable(element, props) {
         const metric = cols[i];
         const format = columnFormats[metric] || numberFormat || '.3s';
         const tdText = $(this)[0].textContent;
-        if (
-          !Number.isNaN(parseFloat(tdText)) &&
-          tdText !== '' &&
-          tdText.trim().toLowerCase() !== 'null'
-        ) {
+        if (!Number.isNaN(parseFloat(tdText))) {
           $(this)[0].textContent = formatNumber(format, tdText);
           $(this).attr('data-sort', tdText);
         }


### PR DESCRIPTION
🐛 Bug Fix
Currently pivot table tries to numerically format all metric values, irrespective of their format. This is because we're checking if the cell value is not NaN by calling `Number.isNaN()` on the cell value, which will always be false:
```javascript
> Number.isNaN('1.1')
false
> Number.isNaN('1')
false
> Number.isNaN('abc')
false
```
Instead we should first try to parse the value to float:

```javascript
> Number.isNaN(parseFloat('1.1'))
false
> Number.isNaN(parseFloat('1'))
false
> Number.isNaN(parseFloat('abc'))
true
```

This also makes the rest of the if-clause irrelevant:

```javascript
> Number.isNaN(parseFloat(''))
true
> Number.isNaN(parseFloat('null'))
true
```

### SCREENSHOTS

In the example below, the metric `MAX(party)` is non-numeric, while `SUM(voter)` is numeric.
#### BEFORE
![image](https://user-images.githubusercontent.com/33317356/88140115-c58f0080-cbf9-11ea-9809-3530e5946949.png)

#### AFTER
![image](https://user-images.githubusercontent.com/33317356/88140160-e0617500-cbf9-11ea-8791-fc2933bf0bc2.png)
