### PR TITLE
feat(legacy-plugin-chart-rose): add time grain

### DIFF
--- a/plugins/legacy-plugin-chart-rose/src/controlPanel.jsx
+++ b/plugins/legacy-plugin-chart-rose/src/controlPanel.jsx
@@ -246,4 +246,12 @@ export default {
       ],
     },
   ],
+  sectionOverrides: {
+    druidTimeSeries: {
+      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
+    },
+    sqlaTimeSeries: {
+      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
+    },
+  },
 };


### PR DESCRIPTION
🏆 Enhancements
Add time grain to Rose Chart.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/88164641-1106d600-cc1d-11ea-8c7a-ac40624fa0c5.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/88164272-96d65180-cc1c-11ea-9a23-e343e72fd0d3.png)

