### PR TITLE
fix(query): equals operator, duplicate filters and time range endpoints

### DIFF
--- a/packages/superset-ui-query/src/buildQueryObject.ts
+++ b/packages/superset-ui-query/src/buildQueryObject.ts
@@ -36,10 +36,10 @@ export default function buildQueryObject<T extends QueryFormData>(formData: T): 
   const { metrics, groupby, columns } = extractQueryFields(residualFormData, queryFields);
   const groupbySet = new Set([...columns, ...groupby]);
 
-  const extraFilters = extractExtras(formData);
+  const extras = extractExtras(formData);
   const extrasAndfilters = processFilters({
     ...formData,
-    ...extraFilters,
+    ...extras,
   });
 
   return {
@@ -47,7 +47,7 @@ export default function buildQueryObject<T extends QueryFormData>(formData: T): 
     since,
     until,
     granularity,
-    ...extraFilters,
+    ...extras,
     ...extrasAndfilters,
     groupby: processGroupby(Array.from(groupbySet)),
     is_timeseries: groupbySet.has(DTTM_ALIAS),

--- a/packages/superset-ui-query/src/extractExtras.ts
+++ b/packages/superset-ui-query/src/extractExtras.ts
@@ -43,5 +43,10 @@ export default function extractExtras(formData: QueryFormData): Partial<QueryObj
     delete partialQueryObject.granularity_sqla;
     delete partialQueryObject.time_grain_sqla;
   }
+
+  // map time range endpoints:
+  if (formData.time_range_endpoints)
+    partialQueryObject.extras.time_range_endpoints = formData.time_range_endpoints;
+
   return partialQueryObject;
 }

--- a/packages/superset-ui-query/src/processFilters.ts
+++ b/packages/superset-ui-query/src/processFilters.ts
@@ -48,7 +48,7 @@ export default function processFilters(formData: QueryFormData) {
 
     return {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      filters: (formData.filters || []).concat(simpleWhere),
+      filters: simpleWhere,
       extras,
     };
   }

--- a/packages/superset-ui-query/src/types/Operator.ts
+++ b/packages/superset-ui-query/src/types/Operator.ts
@@ -2,7 +2,7 @@
 const UNARY_OPERATORS = ['IS NOT NULL', 'IS NULL'] as const;
 
 /** List of operators that require another operand that is a single value */
-const BINARY_OPERATORS = ['=', '!=', '>', '<', '>=', '<=', 'LIKE', 'REGEX'] as const;
+const BINARY_OPERATORS = ['==', '!=', '>', '<', '>=', '<=', 'LIKE', 'REGEX'] as const;
 
 /** List of operators that require another operand that is a set */
 const SET_OPERATORS = ['IN', 'NOT IN'] as const;

--- a/packages/superset-ui-query/src/types/QueryFormData.ts
+++ b/packages/superset-ui-query/src/types/QueryFormData.ts
@@ -11,6 +11,8 @@ export type QueryFormResidualData = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 };
+export type TimeRangeEndpoint = 'unknown' | 'inclusive' | 'exclusive';
+export type TimeRangeEndpoints = [TimeRangeEndpoint, TimeRangeEndpoint];
 
 // Currently only Binary and Set filters are supported
 export type QueryFields = {
@@ -69,6 +71,7 @@ export type BaseFormData = {
   result_format?: string;
   result_type?: string;
   queryFields?: QueryFields;
+  time_range_endpoints?: TimeRangeEndpoints;
 } & TimeRange &
   QueryFormResidualData;
 

--- a/packages/superset-ui-query/test/convertFilter.test.ts
+++ b/packages/superset-ui-query/test/convertFilter.test.ts
@@ -21,12 +21,12 @@ describe('convertFilter', () => {
         expressionType: 'SIMPLE',
         clause: 'WHERE',
         subject: 'topping',
-        operator: '=',
+        operator: '==',
         comparator: 'grass jelly',
       }),
     ).toEqual({
       col: 'topping',
-      op: '=',
+      op: '==',
       val: 'grass jelly',
     });
   });

--- a/packages/superset-ui-query/test/extractExtras.test.ts
+++ b/packages/superset-ui-query/test/extractExtras.test.ts
@@ -9,7 +9,7 @@ describe('extractExtras', () => {
     filters: [
       {
         col: 'gender',
-        op: '=',
+        op: '==',
         val: 'girl',
       },
     ],
@@ -22,17 +22,17 @@ describe('extractExtras', () => {
         extra_filters: [
           {
             col: '__time_col',
-            op: '=',
+            op: '==',
             val: 'ds2',
           },
           {
             col: '__time_grain',
-            op: '=',
+            op: '==',
             val: 'PT5M',
           },
           {
             col: '__time_range',
-            op: '=',
+            op: '==',
             val: '2009-07-17T00:00:00 : 2020-07-17T00:00:00',
           },
         ],
@@ -44,7 +44,7 @@ describe('extractExtras', () => {
       filters: [
         {
           col: 'gender',
-          op: '=',
+          op: '==',
           val: 'girl',
         },
       ],
@@ -72,7 +72,7 @@ describe('extractExtras', () => {
       filters: [
         {
           col: 'gender',
-          op: '=',
+          op: '==',
           val: 'girl',
         },
         {

--- a/packages/superset-ui-query/test/extractExtras.test.ts
+++ b/packages/superset-ui-query/test/extractExtras.test.ts
@@ -15,10 +15,11 @@ describe('extractExtras', () => {
     ],
   };
 
-  it('should override formData with double underscored date options', () => {
+  it('should populate time range endpoints and override formData with double underscored date options', () => {
     expect(
       extractExtras({
         ...baseQueryFormData,
+        time_range_endpoints: ['inclusive', 'exclusive'],
         extra_filters: [
           {
             col: '__time_col',
@@ -40,6 +41,7 @@ describe('extractExtras', () => {
     ).toEqual({
       extras: {
         time_grain_sqla: 'PT5M',
+        time_range_endpoints: ['inclusive', 'exclusive'],
       },
       filters: [
         {

--- a/packages/superset-ui-query/test/processFilters.test.ts
+++ b/packages/superset-ui-query/test/processFilters.test.ts
@@ -11,6 +11,48 @@ describe('processFilters', () => {
     ).toEqual({});
   });
 
+  it('should merge simple adhoc_filters and filters', () => {
+    expect(
+      processFilters({
+        granularity: 'something',
+        viz_type: 'custom',
+        datasource: 'boba',
+        filters: [
+          {
+            col: 'name',
+            op: '==',
+            val: 'Aaron',
+          },
+        ],
+        adhoc_filters: [
+          {
+            expressionType: 'SIMPLE',
+            clause: 'WHERE',
+            subject: 'gender',
+            operator: 'IS NOT NULL',
+          },
+        ],
+      }),
+    ).toEqual({
+      extras: {
+        having: '',
+        having_druid: [],
+        where: '',
+      },
+      filters: [
+        {
+          col: 'name',
+          op: '==',
+          val: 'Aaron',
+        },
+        {
+          col: 'gender',
+          op: 'IS NOT NULL',
+        },
+      ],
+    });
+  });
+
   it('should handle an empty array', () => {
     expect(
       processFilters({
@@ -47,7 +89,7 @@ describe('processFilters', () => {
             expressionType: 'SIMPLE',
             clause: 'WHERE',
             subject: 'milk',
-            operator: '=',
+            operator: '==',
             comparator: 'almond',
           },
           {
@@ -110,7 +152,7 @@ describe('processFilters', () => {
         },
         {
           col: 'milk',
-          op: '=',
+          op: '==',
           val: 'almond',
         },
       ],

--- a/packages/superset-ui-query/test/types/Filter.test.ts
+++ b/packages/superset-ui-query/test/types/Filter.test.ts
@@ -18,7 +18,7 @@ describe('Filter type guards', () => {
           expressionType: 'SIMPLE',
           clause: 'WHERE',
           subject: 'tea',
-          operator: '=',
+          operator: '==',
           comparator: 'matcha',
         }),
       ).toEqual(false);


### PR DESCRIPTION
🐛 Bug Fix
This fixes three bugs:
1) The equals filter operator was incorrectly a single equals sign. The correct format is double equals signs. This holds true both for simple filters and adhoc filters. Tests updated accordingly.
2) regular (non-reserved) filters from `extra_filters` were being doubly populated in `processFilters`. Bug fixed + test added.
3) `time_range_endpoints` weren't being passed through to `extras`.

A screenshot of an ad-hoc filter's metadata with the equals-operator:
![image](https://user-images.githubusercontent.com/33317356/88362441-2dbe1d80-cd85-11ea-8ee5-9fd6fc35354e.png)
A screenshot of the filter operators that the backend expects filters to comply with (`superset/utils/core.py`):
![image](https://user-images.githubusercontent.com/33317356/88362497-6827ba80-cd85-11ea-8339-9489c589f6e4.png)
A screenshot of how `viz.py` populates extras in `query_obj` from `form_data`:
![image](https://user-images.githubusercontent.com/33317356/88368671-34559080-cd97-11ea-8303-44ba240aae87.png)
`TimeRangeEndpoints` enum expected in backend:
![image](https://user-images.githubusercontent.com/33317356/88368727-4cc5ab00-cd97-11ea-8e7a-02d950251b27.png)
