### PR TITLE
fix: (mapbox) Mapbox not rendering points

### DIFF
--- a/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
+++ b/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
@@ -64,10 +64,11 @@ class MapBox extends React.Component {
     // Get a viewport that fits the given bounds, which all marks to be clustered.
     // Derive lat, lon and zoom from this viewport. This is only done on initial
     // render as the bounds don't update as we pan/zoom in the current design.
+    // A round is done so points don't render on the margins of the map.
     const mercator = new ViewportMercator({
       width,
       height,
-    }).fitBounds(bounds);
+    }).fitBounds([bounds[0].map(Math.floor), bounds[1].map(Math.ceil)]);
     const { latitude, longitude, zoom } = mercator;
 
     this.state = {

--- a/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
+++ b/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
@@ -100,15 +100,20 @@ class MapBox extends React.Component {
       renderWhileDragging,
       rgb,
       hasCustomMetric,
-      bounds,
     } = this.props;
     const { viewport } = this.state;
     const isDragging = viewport.isDragging === undefined ? false : viewport.isDragging;
 
-    // Compute the clusters based on the original bounds and current zoom level. Note when zoom/pan
-    // to an area outside of the original bounds, no additional queries are made to the backend to
-    // retrieve additional data.
-    const bbox = [bounds[0][0], bounds[0][1], bounds[1][0], bounds[1][1]];
+    // Compute the clusters based only on the current viewport
+    const zoomPower = 2 ** (viewport.zoom + 1);
+    const halfHeight = height / zoomPower; // = height / 2 / (2 ** viewport.zoom)
+    const halfWidth = width / zoomPower; // = width / 2 / (2 ** viewport.zoom)
+    const bbox = [
+      viewport.longitude - halfHeight,
+      viewport.latitude - halfWidth,
+      viewport.longitude + halfHeight,
+      viewport.latitude + halfWidth,
+    ];
     const clusters = clusterer.getClusters(bbox, Math.round(viewport.zoom));
 
     return (


### PR DESCRIPTION
🐛 Bug Fix

Related issue on superset repo: [#8479](https://github.com/apache/incubator-superset/issues/8479)
I submited a [PR](https://github.com/apache/incubator-superset/pull/9239) to superset but after going over the mapbox plugin code I think it is better so solve the problem here.

My understanding of the bug:
1. (this part is not a bug) The plugin is always calculating the clusters considering all points. I think it should calculate the clusters that are only within the current viewport.
2. The bounds received as props (calculated on superset ) form a box. All points/clusters are within this box.
The function getClusters does some calculations and due to float precision (I think) some clusters will fall outside that box and won't be displayed.

My solution:
Considering the coordinates of the center of the current viewport, its height and width I calculate the coordinates of the south east and north west points  and use them to calculate the clusters.
To convert between pixels and world coordinates I used [this](https://developers.google.com/maps/documentation/javascript/coordinates#pixel-coordinates).

Example:
Data:
```sql
SELECT 52.34852 AS latitude , -4.8843 AS longitude
UNION
SELECT 51.35091, 4.87888
UNION
SELECT -10.893, -45.835
```

Before:
![before](https://user-images.githubusercontent.com/23409890/88408881-0e96ae80-cdcc-11ea-8ec7-3015d1ffef1e.png)

After
![after](https://user-images.githubusercontent.com/23409890/88409209-8cf35080-cdcc-11ea-949a-ba60c480b6b8.png)

environment:
Docker using on the most recent [commit](https://github.com/apache/incubator-superset/commit/a10b18524827523642bd64724b5b3651c3c27894) of the superset repo