### PR TITLE
fix: charts rerender with zero-height during tab switch

### DIFF
--- a/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -41,13 +41,10 @@ const propTypes = {
 const formatter = getNumberFormatter();
 
 function WorldMap(element, props) {
-  const { data, height, maxBubbleSize, showBubbles } = props;
+  const { data, width, height, maxBubbleSize, showBubbles } = props;
 
   const div = d3.select(element);
   div.classed('superset-legacy-chart-world-map', true);
-
-  const container = element;
-  container.style.height = `${height}px`;
   div.selectAll('*').remove();
 
   // Ignore XXX's to get better normalization
@@ -76,6 +73,8 @@ function WorldMap(element, props) {
 
   const map = new Datamap({
     element,
+    width,
+    height,
     data: processedData,
     fills: {
       defaultFill: '#eee',

--- a/plugins/legacy-plugin-chart-world-map/src/transformProps.js
+++ b/plugins/legacy-plugin-chart-world-map/src/transformProps.js
@@ -17,11 +17,12 @@
  * under the License.
  */
 export default function transformProps(chartProps) {
-  const { height, formData, queryData } = chartProps;
+  const { width, height, formData, queryData } = chartProps;
   const { maxBubbleSize, showBubbles } = formData;
 
   return {
     data: queryData.data,
+    width,
     height,
     maxBubbleSize: parseInt(maxBubbleSize, 10),
     showBubbles,

--- a/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -152,6 +152,9 @@ function StickyWrap({
     if (theadRef.current) {
       const bodyThead = theadRef.current;
       const theadHeight = bodyThead.clientHeight;
+      if (!theadHeight) {
+        return;
+      }
       const fullTableHeight = (bodyThead.parentNode as HTMLTableElement).clientHeight;
       const ths = bodyThead.childNodes[0].childNodes as NodeListOf<HTMLTableHeaderCellElement>;
       const widths = Array.from(ths).map(th => th.clientWidth);


### PR DESCRIPTION
🐛 Bug Fix

Some charts rely on the dimension of mounted chart containers (`container.clientWidth` and `container.clientHeight`), but both values are zero when Bootstrap tabs are still animating. The unfortunate timing leads to some charts unable to re-render when switching tabs after applying filters (see apache/incubator-superset#10349 ).

Ideally we should fix the [Tabs](https://github.com/apache/incubator-superset/blob/221f38099b1a1a93cd0a3fd6b717f9fdce0b4e18/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx#L239) component and only re-render charts when animation finishes but I was not able to find a clean way to do that, so fixing the known broken charts instead.

## Test Plan

Manual testing