### PR TITLE
feat(legacy-plugin-chart-sunburst): add linear color scheme

### DIFF
--- a/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
@@ -34,7 +34,7 @@ export default {
     {
       label: t('Chart Options'),
       expanded: true,
-      controlSetRows: [['color_scheme', 'label_colors']],
+      controlSetRows: [['color_scheme', 'linear_color_scheme']],
     },
   ],
   controlOverrides: {
@@ -50,6 +50,12 @@ export default {
           'define the color as a ratio against the primary metric. ' +
           'When omitted, the color is categorical and based on labels',
       ),
+    },
+    color_scheme: {
+      description: t('When only a primary metric is provided, a categorical color scale is used.'),
+    },
+    linear_color_scheme: {
+      description: t('When a secondary metric is provided, a linear color scale is used.'),
     },
     groupby: {
       label: t('Hierarchy'),

--- a/plugins/legacy-plugin-chart-sunburst/src/transformProps.js
+++ b/plugins/legacy-plugin-chart-sunburst/src/transformProps.js
@@ -18,13 +18,14 @@
  */
 export default function transformProps(chartProps) {
   const { width, height, formData, queryData, datasource } = chartProps;
-  const { colorScheme, metric, secondaryMetric } = formData;
+  const { colorScheme, linearColorScheme, metric, secondaryMetric } = formData;
 
   const returnProps = {
     width,
     height,
     data: queryData.data,
     colorScheme,
+    linearColorScheme,
     metrics: [metric, secondaryMetric],
   };
 


### PR DESCRIPTION
🏆 Enhancements

Currently sunburst chart uses a linear color scheme when using a secondary metric that can't be customized. This adds a linear color control and uses that when the secondary metric is defined.

### Screenshot
![captured (18)](https://user-images.githubusercontent.com/33317356/88788297-d01f3c00-d19d-11ea-8637-214f2c3b198d.gif)
