### PR TITLE
fix: add timeout value to error details in rejectAfterTimeout

### DIFF
--- a/packages/superset-ui-connection/src/callApi/rejectAfterTimeout.ts
+++ b/packages/superset-ui-connection/src/callApi/rejectAfterTimeout.ts
@@ -6,6 +6,7 @@ export default function rejectAfterTimeout<T>(timeout: number) {
         reject({
           error: 'Request timed out',
           statusText: 'timeout',
+          timeout,
         }),
       timeout,
     );

--- a/packages/superset-ui-connection/test/callApi/callApiAndParseWithTimeout.test.ts
+++ b/packages/superset-ui-connection/test/callApi/callApiAndParseWithTimeout.test.ts
@@ -102,6 +102,7 @@ describe('callApiAndParseWithTimeout()', () => {
         expect(error).toEqual({
           error: 'Request timed out',
           statusText: 'timeout',
+          timeout: 1,
         });
       }
     });


### PR DESCRIPTION
🐛 Bug Fix

We're accidentally hardcoding the timeout value in Superset proper, this provides us a way to get the timeout easily, instead of needing to fetch it from one of many possible redux stores.

to: @ktmud @kristw 