### PR TITLE
build: upgrade codecov-action and disable failing_ci_if_error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,4 @@ jobs:
       run: yarn test
 
     - name: Report code coverage
-      uses: codecov/codecov-action@v1.0.12
-      with:
-        token: "${{ secrets.CODECOV_TOKEN }}"
-        fail_ci_if_error: false
+      run: curl -s https://codecov.io/bash | bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     name: Build and test
+    env:
+      CI: 'github'
 
     runs-on: ubuntu-latest
 
@@ -58,6 +60,6 @@ jobs:
       run: yarn test
 
     - name: Report code coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.0.12
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     name: Build and test
     runs-on: ubuntu-18.04
     env:
-      GITHUB_ACTION: "githubAction-${{ github.action }}-${{ github.job }}"
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,5 @@ jobs:
     - name: Report code coverage
       uses: codecov/codecov-action@v1.0.12
       with:
+        token: "${{ secrets.CODECOV_TOKEN }}"
         fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,8 @@ jobs:
       run: yarn test
 
     - name: Report code coverage
-      uses: codecov/codecov-action@v1.0.12
       env:
-        GITHUB_ACTION: "${{ github.action }}-${{ github.job }}"
+        GITHUB_ACTION: "githubAction-${{ github.action }}-${{ github.job }}"
         CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
-      with:
-        fail_ci_if_error: true
+      run: curl -s https://codecov.io/bash | bash
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     name: Build and test
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
@@ -58,4 +58,9 @@ jobs:
       run: yarn test
 
     - name: Report code coverage
-      run: curl -s https://codecov.io/bash | bash
+      uses: codecov/codecov-action@v1.0.12
+      env:
+        GITHUB_ACTION: "${{ github.action }}-${{ github.job }}"
+        CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+      with:
+        fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,10 @@ on:
 jobs:
   build:
     name: Build and test
-
     runs-on: ubuntu-18.04
+    env:
+      GITHUB_ACTION: "githubAction-${{ github.action }}-${{ github.job }}"
+      CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
     strategy:
       matrix:
@@ -58,8 +60,5 @@ jobs:
       run: yarn test
 
     - name: Report code coverage
-      env:
-        GITHUB_ACTION: "githubAction-${{ github.action }}-${{ github.job }}"
-        CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
       run: curl -s https://codecov.io/bash | bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   build:
     name: Build and test
-    env:
-      CI: 'github'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
🏠 Internal

Codecov uploads [have been failing](https://github.com/apache-superset/superset-ui/pull/711/checks?check_run_id=942885439) <strike>for no reason</strike> (because of missing GITHUB_ACTION env variables).

Trying to fix it by:

1. Fix to build on `ubuntu-18.04`
2. Manually add `GITHUB_ACTION` and `CODECOV_TOKEN` env variables.
