### PR TITLE
feat(legacy-plugin-chart-pivot-table): add support for timestamp format

### DIFF
--- a/plugins/legacy-plugin-chart-pivot-table/package.json
+++ b/plugins/legacy-plugin-chart-pivot-table/package.json
@@ -36,6 +36,7 @@
     "@superset-ui/chart": "^0.14.0",
     "@superset-ui/chart-controls": "^0.14.3",
     "@superset-ui/number-format": "^0.14.0",
+    "@superset-ui/time-format": "^0.14.9",
     "@superset-ui/translation": "^0.14.0"
   }
 }

--- a/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
@@ -106,16 +106,16 @@ function PivotTable(element, props) {
         const format = columnFormats[metric] || numberFormat || '.3s';
         const tdText = $(this)[0].textContent;
         const parsedValue = parseFloat(tdText);
-        if (!Number.isNaN(parsedValue)) {
-          $(this)[0].textContent = formatNumber(format, parsedValue);
-          $(this).attr('data-sort', parsedValue);
-        } else {
+        if (Number.isNaN(parsedValue)) {
           const regexMatch = dateRegex.exec(tdText);
           if (regexMatch) {
             const date = new Date(parseFloat(regexMatch[1]));
             $(this)[0].textContent = dateFormatter(date);
             $(this).attr('data-sort', date);
           }
+        } else {
+          $(this)[0].textContent = formatNumber(format, parsedValue);
+          $(this).attr('data-sort', parsedValue);
         }
       });
   });

--- a/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
@@ -20,6 +20,7 @@
 import dt from 'datatables.net-bs';
 import PropTypes from 'prop-types';
 import { formatNumber } from '@superset-ui/number-format';
+import { smartDateFormatter, getTimeFormatter } from '@superset-ui/time-format';
 import fixTableHeight from './utils/fixTableHeight';
 import 'datatables.net-bs/css/dataTables.bootstrap.css';
 
@@ -44,25 +45,37 @@ const propTypes = {
 };
 
 function PivotTable(element, props) {
-  const { data, height, columnFormats, numberFormat, numGroups, verboseMap } = props;
+  const { data, height, columnFormats, dateFormat, numberFormat, numGroups, verboseMap } = props;
 
   const { html, columns } = data;
   const container = element;
   const $container = $(element);
+  const dateFormatter =
+    dateFormat === 'smart_date' ? smartDateFormatter : getTimeFormatter(dateFormat);
 
   // queryData data is a string of html with a single table element
   container.innerHTML = html;
 
   const cols = Array.isArray(columns[0]) ? columns.map(col => col[0]) : columns;
+  // regex to parse dates
+  const dateRegex = /^__timestamp:(-?\d*\.?\d*)$/;
 
   // jQuery hack to set verbose names in headers
   // eslint-disable-next-line func-name-matching
   const replaceCell = function replace() {
     const s = $(this)[0].textContent;
-    $(this)[0].textContent = verboseMap[s] || s;
+    const regexMatch = dateRegex.exec(s);
+    let cellValue;
+    if (regexMatch) {
+      const date = new Date(parseFloat(regexMatch[1]));
+      cellValue = dateFormatter(date);
+    } else {
+      cellValue = verboseMap[s] || s;
+    }
+    $(this)[0].textContent = cellValue;
   };
-  $container.find('thead tr:first th').each(replaceCell);
-  $container.find('thead tr th:first-child').each(replaceCell);
+  $container.find('thead tr th').each(replaceCell);
+  $container.find('tbody tr th').each(replaceCell);
 
   // jQuery hack to format number
   $container.find('tbody tr').each(function eachRow() {
@@ -72,9 +85,10 @@ function PivotTable(element, props) {
         const metric = cols[i];
         const format = columnFormats[metric] || numberFormat || '.3s';
         const tdText = $(this)[0].textContent;
-        if (!Number.isNaN(parseFloat(tdText))) {
-          $(this)[0].textContent = formatNumber(format, tdText);
-          $(this).attr('data-sort', tdText);
+        const parsedValue = parseFloat(tdText);
+        if (!Number.isNaN(parsedValue)) {
+          $(this)[0].textContent = formatNumber(format, parsedValue);
+          $(this).attr('data-sort', parsedValue);
         }
       });
   });

--- a/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.js
@@ -21,6 +21,7 @@ import {
   D3_FORMAT_OPTIONS,
   D3_FORMAT_DOCS,
   formatSelectOptions,
+  D3_TIME_FORMAT_OPTIONS,
 } from '@superset-ui/chart-controls';
 
 export default {
@@ -54,28 +55,16 @@ export default {
               ),
             },
           },
+          null,
+        ],
+        [
           {
             name: 'pivot_margins',
             config: {
               type: 'CheckboxControl',
               label: t('Show totals'),
-              renderTrigger: false,
               default: true,
               description: t('Display total row/column'),
-            },
-          },
-        ],
-        [
-          {
-            name: 'number_format',
-            config: {
-              type: 'SelectControl',
-              freeForm: true,
-              label: t('Number format'),
-              renderTrigger: true,
-              default: 'SMART_NUMBER',
-              choices: D3_FORMAT_OPTIONS,
-              description: D3_FORMAT_DOCS,
             },
           },
           {
@@ -99,6 +88,40 @@ export default {
               label: t('Transpose Pivot'),
               default: false,
               description: t('Swap Groups and Columns'),
+            },
+          },
+        ],
+      ],
+    },
+    {
+      label: t('Options'),
+      expanded: true,
+      controlSetRows: [
+        [
+          {
+            name: 'number_format',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: t('Number format'),
+              renderTrigger: true,
+              default: 'SMART_NUMBER',
+              choices: D3_FORMAT_OPTIONS,
+              description: D3_FORMAT_DOCS,
+            },
+          },
+        ],
+        [
+          {
+            name: 'date_format',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: t('Date format'),
+              renderTrigger: true,
+              choices: D3_TIME_FORMAT_OPTIONS,
+              default: 'smart_date',
+              description: D3_FORMAT_DOCS,
             },
           },
         ],

--- a/plugins/legacy-plugin-chart-pivot-table/src/transformProps.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/transformProps.js
@@ -18,7 +18,7 @@
  */
 export default function transformProps(chartProps) {
   const { height, datasource, formData, queryData } = chartProps;
-  const { groupby, numberFormat } = formData;
+  const { groupby, numberFormat, dateFormat } = formData;
   const { columnFormats, verboseMap } = datasource;
 
   return {
@@ -26,6 +26,7 @@ export default function transformProps(chartProps) {
     data: queryData.data,
     columnFormats,
     numGroups: groupby.length,
+    dateFormat,
     numberFormat,
     verboseMap,
   };

--- a/plugins/legacy-plugin-chart-pivot-table/src/transformProps.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/transformProps.js
@@ -18,16 +18,17 @@
  */
 export default function transformProps(chartProps) {
   const { height, datasource, formData, queryData } = chartProps;
-  const { groupby, numberFormat, dateFormat } = formData;
+  const { timeGrainSqla, groupby, numberFormat, dateFormat } = formData;
   const { columnFormats, verboseMap } = datasource;
 
   return {
-    height,
-    data: queryData.data,
     columnFormats,
-    numGroups: groupby.length,
+    data: queryData.data,
     dateFormat,
+    granularity: timeGrainSqla,
+    height,
     numberFormat,
+    numGroups: groupby.length,
     verboseMap,
   };
 }


### PR DESCRIPTION
🏆 Enhancements

This adds support for formatted dates on `pivot-table`. This is done by prefixing date values with `__timestamp:`, after which they can be identified and parsed into formattable date objects. In addition sorting is done based on the epoch value, meaning that the format won't affect the sorting order. Other changes:
- Add date format
- Move visual options to own tab (currently on `Query` pane)
- use time grain for formatting if smart formatting is selected
- make sorting of numeric values based on the parsed float value, not the text value

### AFTER:
![image](https://user-images.githubusercontent.com/33317356/90022867-b90f3c80-dcbb-11ea-829b-e0ffa1c9f3bd.png)

### BEFORE:
![image](https://user-images.githubusercontent.com/33317356/90023412-67b37d00-dcbc-11ea-915e-7468ca98b854.png)
