### PR TITLE
build: update encodable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "esprint": "^0.7.0",
     "fast-glob": "^3.2.4",
     "fs-extra": "^9.0.0",
+    "global-box": "^1.2.0",
     "husky": "^4.2.5",
     "identity-obj-proxy": "^3.0.0",
     "jest-mock-console": "^1.0.0",

--- a/packages/superset-ui-demo/.storybook/preview.js
+++ b/packages/superset-ui-demo/.storybook/preview.js
@@ -6,6 +6,7 @@ import sequentialD3 from '@superset-ui/color/lib/colorSchemes/sequential/d3';
 import { configure } from '@superset-ui/core';
 import { getCategoricalSchemeRegistry, getSequentialSchemeRegistry } from '@superset-ui/color';
 import { getTimeFormatterRegistry, smartDateFormatter } from '@superset-ui/time-format';
+import { configureEncodable } from '@superset-ui/preset-chart-xy';
 import themeDecorator from "./themeDecorator"
 
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -68,3 +69,4 @@ getTimeFormatterRegistry()
   .registerValue('smart_date', smartDateFormatter)
   .setDefaultKey('smart_date');
 
+configureEncodable();

--- a/packages/superset-ui-demo/package.json
+++ b/packages/superset-ui-demo/package.json
@@ -71,6 +71,7 @@
     "bootstrap": "^3.4.1",
     "core-js": "3.6.5",
     "gh-pages": "^3.0.0",
+    "global-box": "^1.2.0",
     "jquery": "^3.4.1",
     "memoize-one": "^5.1.1",
     "react": "^16.13.1",

--- a/plugins/plugin-chart-choropleth-map/package.json
+++ b/plugins/plugin-chart-choropleth-map/package.json
@@ -31,6 +31,9 @@
     "@superset-ui/chart-composition": "^0.14.0",
     "@superset-ui/core": "^0.15.0",
     "@superset-ui/style": "^0.14.0",
+    "@superset-ui/color": "^0.14.9",
+    "@superset-ui/number-format": "^0.14.9",
+    "@superset-ui/time-format": "^0.14.9",
     "@types/d3-geo": "^1.11.1",
     "@types/geojson": "^7946.0.3",
     "@types/react": "^16.9.43",
@@ -42,7 +45,7 @@
     "@vx/tooltip": "^0.0.197",
     "@vx/zoom": "^0.0.197",
     "d3-geo": "^1.12.0",
-    "encodable": "^0.3.7",
+    "encodable": "^0.7.0",
     "geojson": "^0.5.0",
     "lodash": "^4.17.15",
     "topojson-client": "^3.1.0"

--- a/plugins/plugin-chart-choropleth-map/src/configureEncodable.ts
+++ b/plugins/plugin-chart-choropleth-map/src/configureEncodable.ts
@@ -1,0 +1,47 @@
+import {
+  Encodable,
+  ColorSchemeResolver,
+  TimeFormatResolver,
+  CategoricalColorScaleResolver,
+  defaultColorSchemeResolver,
+  addPrefix,
+} from 'encodable';
+import {
+  CategoricalColorNamespace,
+  getCategoricalSchemeRegistry,
+  getSequentialSchemeRegistry,
+} from '@superset-ui/color';
+import { getNumberFormatter } from '@superset-ui/number-format';
+import { getTimeFormatter, LOCAL_PREFIX, getTimeFormatterRegistry } from '@superset-ui/time-format';
+
+const timeFormat: TimeFormatResolver = ({ format, formatInLocalTime = false } = {}) => {
+  const formatString = formatInLocalTime
+    ? addPrefix(LOCAL_PREFIX, format ?? getTimeFormatterRegistry().getDefaultKey()!)
+    : format;
+
+  return getTimeFormatter(formatString);
+};
+
+const colorSchemeResolver: ColorSchemeResolver = ({ name, type = 'categorical' } = {}) => {
+  if (type === 'sequential') {
+    const scheme = getSequentialSchemeRegistry().get(name);
+
+    return typeof scheme === 'undefined' ? scheme : { type: 'sequential', ...scheme };
+  }
+  if (type === 'categorical') {
+    const scheme = getCategoricalSchemeRegistry().get(name);
+
+    return typeof scheme === 'undefined' ? scheme : { type: 'categorical', ...scheme };
+  }
+  return defaultColorSchemeResolver({ name, type });
+};
+
+const colorScaleResolver: CategoricalColorScaleResolver = ({ name, namespace } = {}) =>
+  CategoricalColorNamespace.getScale(name, namespace);
+
+export default function configureEncodable() {
+  Encodable.setNumberFormatResolver(getNumberFormatter)
+    .setTimeFormatResolver(timeFormat)
+    .setColorSchemeResolver(colorSchemeResolver)
+    .setCategoricalColorScaleResolver(colorScaleResolver);
+}

--- a/plugins/plugin-chart-choropleth-map/src/index.ts
+++ b/plugins/plugin-chart-choropleth-map/src/index.ts
@@ -1,2 +1,6 @@
+import configureEncodable from './configureEncodable';
+
+configureEncodable();
+
 export { default as ChoroplethMapChartPlugin } from './plugin';
 export { maps, mapsLookup } from './maps';

--- a/plugins/plugin-chart-choropleth-map/src/index.ts
+++ b/plugins/plugin-chart-choropleth-map/src/index.ts
@@ -1,6 +1,3 @@
-import configureEncodable from './configureEncodable';
-
-configureEncodable();
-
 export { default as ChoroplethMapChartPlugin } from './plugin';
 export { maps, mapsLookup } from './maps';
+export { default as configureEncodable } from './configureEncodable';

--- a/plugins/plugin-chart-word-cloud/package.json
+++ b/plugins/plugin-chart-word-cloud/package.json
@@ -29,7 +29,9 @@
   },
   "dependencies": {
     "@superset-ui/chart": "^0.14.0",
-    "@superset-ui/color": "^0.14.0",
+    "@superset-ui/color": "^0.14.9",
+    "@superset-ui/number-format": "^0.14.9",
+    "@superset-ui/time-format": "^0.14.9",
     "@superset-ui/core": "^0.15.0",
     "@superset-ui/style": "^0.14.0",
     "@superset-ui/validator": "^0.14.0",
@@ -39,7 +41,7 @@
     "d3-cloud": "^1.2.5",
     "d3-scale": "^3.0.1",
     "emotion-theming": "^10.0.27",
-    "encodable": "^0.3.7"
+    "encodable": "^0.7.0"
   },
   "peerDependencies": {
     "react": "^16.13.1"

--- a/plugins/plugin-chart-word-cloud/src/configureEncodable.ts
+++ b/plugins/plugin-chart-word-cloud/src/configureEncodable.ts
@@ -1,0 +1,47 @@
+import {
+  Encodable,
+  ColorSchemeResolver,
+  TimeFormatResolver,
+  CategoricalColorScaleResolver,
+  defaultColorSchemeResolver,
+  addPrefix,
+} from 'encodable';
+import {
+  CategoricalColorNamespace,
+  getCategoricalSchemeRegistry,
+  getSequentialSchemeRegistry,
+} from '@superset-ui/color';
+import { getNumberFormatter } from '@superset-ui/number-format';
+import { getTimeFormatter, LOCAL_PREFIX, getTimeFormatterRegistry } from '@superset-ui/time-format';
+
+const timeFormat: TimeFormatResolver = ({ format, formatInLocalTime = false } = {}) => {
+  const formatString = formatInLocalTime
+    ? addPrefix(LOCAL_PREFIX, format ?? getTimeFormatterRegistry().getDefaultKey()!)
+    : format;
+
+  return getTimeFormatter(formatString);
+};
+
+const colorSchemeResolver: ColorSchemeResolver = ({ name, type = 'categorical' } = {}) => {
+  if (type === 'sequential') {
+    const scheme = getSequentialSchemeRegistry().get(name);
+
+    return typeof scheme === 'undefined' ? scheme : { type: 'sequential', ...scheme };
+  }
+  if (type === 'categorical') {
+    const scheme = getCategoricalSchemeRegistry().get(name);
+
+    return typeof scheme === 'undefined' ? scheme : { type: 'categorical', ...scheme };
+  }
+  return defaultColorSchemeResolver({ name, type });
+};
+
+const colorScaleResolver: CategoricalColorScaleResolver = ({ name, namespace } = {}) =>
+  CategoricalColorNamespace.getScale(name, namespace);
+
+export default function configureEncodable() {
+  Encodable.setNumberFormatResolver(getNumberFormatter)
+    .setTimeFormatResolver(timeFormat)
+    .setColorSchemeResolver(colorSchemeResolver)
+    .setCategoricalColorScaleResolver(colorScaleResolver);
+}

--- a/plugins/plugin-chart-word-cloud/src/index.ts
+++ b/plugins/plugin-chart-word-cloud/src/index.ts
@@ -1,7 +1,4 @@
-import configureEncodable from './configureEncodable';
-
-configureEncodable();
-
 export { default as WordCloudChartPlugin } from './plugin';
 export { default as LegacyWordCloudChartPlugin } from './legacyPlugin';
 export * from './types';
+export { default as configureEncodable } from './configureEncodable';

--- a/plugins/plugin-chart-word-cloud/src/index.ts
+++ b/plugins/plugin-chart-word-cloud/src/index.ts
@@ -1,3 +1,7 @@
+import configureEncodable from './configureEncodable';
+
+configureEncodable();
+
 export { default as WordCloudChartPlugin } from './plugin';
 export { default as LegacyWordCloudChartPlugin } from './legacyPlugin';
 export * from './types';

--- a/plugins/preset-chart-xy/package.json
+++ b/plugins/preset-chart-xy/package.json
@@ -43,7 +43,7 @@
     "@vx/legend": "^0.0.198",
     "@vx/scale": "^0.0.197",
     "csstype": "^2.6.3",
-    "encodable": "^0.3.4",
+    "encodable": "^0.7.0",
     "lodash": "^4.17.11",
     "reselect": "^4.0.0"
   },

--- a/plugins/preset-chart-xy/src/configureEncodable.ts
+++ b/plugins/preset-chart-xy/src/configureEncodable.ts
@@ -1,0 +1,47 @@
+import {
+  Encodable,
+  ColorSchemeResolver,
+  TimeFormatResolver,
+  CategoricalColorScaleResolver,
+  defaultColorSchemeResolver,
+  addPrefix,
+} from 'encodable';
+import {
+  CategoricalColorNamespace,
+  getCategoricalSchemeRegistry,
+  getSequentialSchemeRegistry,
+} from '@superset-ui/color';
+import { getNumberFormatter } from '@superset-ui/number-format';
+import { getTimeFormatter, LOCAL_PREFIX, getTimeFormatterRegistry } from '@superset-ui/time-format';
+
+const timeFormat: TimeFormatResolver = ({ format, formatInLocalTime = false } = {}) => {
+  const formatString = formatInLocalTime
+    ? addPrefix(LOCAL_PREFIX, format ?? getTimeFormatterRegistry().getDefaultKey()!)
+    : format;
+
+  return getTimeFormatter(formatString);
+};
+
+const colorSchemeResolver: ColorSchemeResolver = ({ name, type = 'categorical' } = {}) => {
+  if (type === 'sequential') {
+    const scheme = getSequentialSchemeRegistry().get(name);
+
+    return typeof scheme === 'undefined' ? scheme : { type: 'sequential', ...scheme };
+  }
+  if (type === 'categorical') {
+    const scheme = getCategoricalSchemeRegistry().get(name);
+
+    return typeof scheme === 'undefined' ? scheme : { type: 'categorical', ...scheme };
+  }
+  return defaultColorSchemeResolver({ name, type });
+};
+
+const colorScaleResolver: CategoricalColorScaleResolver = ({ name, namespace } = {}) =>
+  CategoricalColorNamespace.getScale(name, namespace);
+
+export default function configureEncodable() {
+  Encodable.setNumberFormatResolver(getNumberFormatter)
+    .setTimeFormatResolver(timeFormat)
+    .setColorSchemeResolver(colorSchemeResolver)
+    .setCategoricalColorScaleResolver(colorScaleResolver);
+}

--- a/plugins/preset-chart-xy/src/index.ts
+++ b/plugins/preset-chart-xy/src/index.ts
@@ -1,3 +1,7 @@
+import configureEncodable from './configureEncodable';
+
+configureEncodable();
+
 export { default as BoxPlotChartPlugin } from './BoxPlot';
 export { default as LegacyBoxPlotChartPlugin } from './BoxPlot/legacy';
 export { default as ScatterPlotChartPlugin } from './ScatterPlot';

--- a/plugins/preset-chart-xy/src/index.ts
+++ b/plugins/preset-chart-xy/src/index.ts
@@ -1,10 +1,7 @@
-import configureEncodable from './configureEncodable';
-
-configureEncodable();
-
 export { default as BoxPlotChartPlugin } from './BoxPlot';
 export { default as LegacyBoxPlotChartPlugin } from './BoxPlot/legacy';
 export { default as ScatterPlotChartPlugin } from './ScatterPlot';
 export { default as LegacyScatterPlotChartPlugin } from './ScatterPlot/legacy';
 export { default as LineChartPlugin } from './Line';
 export { default as LegacyLineChartPlugin } from './Line/legacy';
+export { default as configureEncodable } from './configureEncodable';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,6 +1746,37 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@encodable/color@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@encodable/color/-/color-1.0.0.tgz#ceff3fd248501087f3ea91e0f281156451306409"
+  integrity sha512-lUCtXQzJZ/UyQl3vYAzn81ABqMv/PwmXcXDljkojFejqvLJD6yycDFk0WJNwmUXNAfDV8jYfHWYVeI2KiAL3hw==
+  dependencies:
+    "@encodable/registry" "^1.0.0"
+    "@types/d3-interpolate" "^1.3.1"
+    "@types/d3-scale" "^2.2.0"
+    "@types/d3-scale-chromatic" "^1.2.0"
+    d3-interpolate "^1.4.0"
+    d3-scale "^3.2.1"
+    d3-scale-chromatic "^1.5.0"
+
+"@encodable/format@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@encodable/format/-/format-1.0.0.tgz#770c906f677031741001945fa75ce1f18cfc1e93"
+  integrity sha512-byQLk7Tg2iRxS2I0ACzHdj7qqy2/gJrIK6qImArZHUszgrqeE56rTXkrH4tHeoWiXWXJYA9LIOW2+GIPug1kOw==
+  dependencies:
+    "@encodable/registry" "^1.0.0"
+    "@types/d3-format" "^1.3.1"
+    "@types/d3-time" "^1.0.10"
+    "@types/d3-time-format" "^2.1.1"
+    d3-format "^1.4.4"
+    d3-time "^1.1.0"
+    d3-time-format "^2.2.3"
+
+"@encodable/registry@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@encodable/registry/-/registry-1.0.0.tgz#8148ef8561fed6bb49b5b0b49442bb7fcc5a1628"
+  integrity sha512-WYW+PXl++uL2w3hljEBfyaF3jyaSb3DGVZH50i20/SVAUmng8HQOTrAwLYHixJPmHu19M7BnwoyclJrFxMuA5g==
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -3740,11 +3771,6 @@
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.10.tgz#cc658ca319b6355399efc1f5b9e818f1a24bf999"
   integrity sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==
 
-"@types/clone@~0.1.30":
-  version "0.1.30"
-  resolved "https://registry.yarnpkg.com/@types/clone/-/clone-0.1.30.tgz#e7365648c1b42136a59c7d5040637b3b5c83b614"
-  integrity sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -3767,7 +3793,7 @@
   resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-1.2.2.tgz#80cf7cfff7401587b8f89307ba36fe4a576bc7cf"
   integrity sha512-6pBxzJ8ZP3dYEQ4YjQ+NVbQaOflfgXq/JbDiS99oLobM2o72uAST4q6yPxHv6FOTCRC/n35ktuo8pvw/S4M7sw==
 
-"@types/d3-format@^1.3.0":
+"@types/d3-format@^1.3.0", "@types/d3-format@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-1.3.1.tgz#35bf88264bd6bcda39251165bb827f67879c4384"
   integrity sha512-KAWvReOKMDreaAwOjdfQMm0HjcUMlQG47GwqdVKgmm20vTd2pucj0a70c3gUSHrnsmo6H2AMrkBsZU2UhJLq8A==
@@ -3791,7 +3817,12 @@
   resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.8.tgz#48e6945a8ff43ee0a1ce85c8cfa2337de85c7c79"
   integrity sha512-AZGHWslq/oApTAHu9+yH/Bnk63y9oFOMROtqPAtxl5uB6qm1x2lueWdVEjsjjV3Qc2+QfuzKIwIR5MvVBakfzA==
 
-"@types/d3-scale@^2.0.2", "@types/d3-scale@^2.1.1":
+"@types/d3-scale-chromatic@^1.2.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#315367557d51b823bec848614fac095325613fc3"
+  integrity sha512-9/D7cOBKdZdTCPc6re0HeSUFBM0aFzdNdmYggUWT9SRRiYSOa6Ys2xdTwHKgc1WS3gGfwTMatBOdWCS863REsg==
+
+"@types/d3-scale@^2.0.2", "@types/d3-scale@^2.1.1", "@types/d3-scale@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-2.2.0.tgz#e5987a2857365823eb26ed5eb21bc566c4dcf1c0"
   integrity sha512-oQFanN0/PiR2oySHfj+zAAkK1/p4LD32Nt1TMVmzk+bYHk7vgIg/iTXQWitp1cIkDw4LMdcgvO63wL+mNs47YA==
@@ -3805,7 +3836,7 @@
   dependencies:
     "@types/d3-path" "*"
 
-"@types/d3-time-format@^2.1.0":
+"@types/d3-time-format@^2.1.0", "@types/d3-time-format@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-2.1.1.tgz#dd2c79ec4575f1355484ab6b10407824668eba42"
   integrity sha512-tJSyXta8ZyJ52wDDHA96JEsvkbL6jl7wowGmuf45+fAkj5Y+SQOnz0N7/H68OWmPshPsAaWMQh+GAws44IzH3g==
@@ -3847,11 +3878,6 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
-
-"@types/fast-json-stable-stringify@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#40363bb847cb86b2c2e1599f1398d11e8329c921"
-  integrity sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==
 
 "@types/fetch-mock@^6.0.0", "@types/fetch-mock@^6.0.4":
   version "6.0.5"
@@ -3935,6 +3961,18 @@
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+
+"@types/lodash.get@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.6.tgz#0c7ac56243dae0f9f09ab6f75b29471e2e777240"
+  integrity sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.159"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.159.tgz#61089719dc6fdd9c5cb46efc827f2571d1517065"
+  integrity sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg==
 
 "@types/lodash@^4.14.146", "@types/lodash@^4.14.149":
   version "4.14.157"
@@ -5302,11 +5340,6 @@ array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
-
-array-flat-polyfill@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz#1e3a4255be619dfbffbfd1d635c1cf357cd034e7"
-  integrity sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -6776,7 +6809,7 @@ clone@^1.0.0, clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clone@^2.1.1, clone@~2.1.2:
+clone@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
@@ -7574,7 +7607,7 @@ d3-array@1, d3-array@^1.0.2, d3-array@^1.2.0, d3-array@^1.2.1:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
-"d3-array@1.2.0 - 2", d3-array@^2.0.3, d3-array@^2.3.1, d3-array@^2.3.3, d3-array@^2.4.0:
+"d3-array@1.2.0 - 2", d3-array@^2.0.3, d3-array@^2.3.1, d3-array@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
   integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
@@ -7591,17 +7624,10 @@ d3-collection@1, d3-collection@^1.0.2, d3-collection@^1.0.4:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
-d3-color@1, d3-color@^1.2.3, d3-color@^1.4.0, d3-color@^1.4.1:
+d3-color@1, d3-color@^1.2.3, d3-color@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
-
-d3-delaunay@^5.1.3:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-5.2.1.tgz#0c4b280eb00194986ac4a3df9c81d32bf216cb36"
-  integrity sha512-ZZdeJl6cKRyqYVFYK+/meXvWIrAvZsZTD7WSxl4OPXCmuXNgDyACAClAJHD63zL25TA+IJGURUNO7rFseNFCYw==
-  dependencies:
-    delaunator "4"
 
 d3-dispatch@1, d3-dispatch@^1.0.3:
   version "1.0.6"
@@ -7616,30 +7642,12 @@ d3-drag@1:
     d3-dispatch "1"
     d3-selection "1"
 
-d3-dsv@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
-  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
-  dependencies:
-    commander "2"
-    iconv-lite "0.4"
-    rw "1"
-
 d3-ease@1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.6.tgz#ebdb6da22dfac0a22222f2d4da06f66c416a0ec0"
   integrity sha512-SZ/lVU7LRXafqp7XtIcBdxnWl8yyLpgOmzAk0mWBI9gXNzLDx5ybZgnRbH9dN/yY5tzVBqCQ9avltSnqVwessQ==
 
-d3-force@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-2.0.1.tgz#31750eee8c43535301d571195bf9683beda534e2"
-  integrity sha512-zh73/N6+MElRojiUG7vmn+3vltaKon7iD5vB/7r9nUaBeftXMzRo5IWEG63DLBCto4/8vr9i3m9lwr1OTJNiCg==
-  dependencies:
-    d3-dispatch "1"
-    d3-quadtree "1"
-    d3-timer "1"
-
-d3-format@1, d3-format@^1.1.1, d3-format@^1.2.0, d3-format@^1.3.2, d3-format@^1.4.2, d3-format@^1.4.3:
+d3-format@1, d3-format@^1.1.1, d3-format@^1.2.0, d3-format@^1.3.2, d3-format@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.4.tgz#356925f28d0fd7c7983bfad593726fce46844030"
   integrity sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw==
@@ -7651,17 +7659,7 @@ d3-geo-projection@0.2:
   dependencies:
     brfs "^1.3.0"
 
-d3-geo-projection@^2.7.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/d3-geo-projection/-/d3-geo-projection-2.8.1.tgz#80447ef6cc6ab561646d251c20f4882c81879938"
-  integrity sha512-VObmT3vQQgU7IxkDwyIuOrWK4AS2OHyvucp1vHo98WE7DvAN+VcS3Pf/oKenszPfbMtHusOfQNBLEMyGHguvTg==
-  dependencies:
-    commander "2"
-    d3-array "1"
-    d3-geo "^1.10.0"
-    resolve "^1.1.10"
-
-d3-geo@^1.10.0, d3-geo@^1.11.9, d3-geo@^1.12.0:
+d3-geo@^1.12.0:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.12.1.tgz#7fc2ab7414b72e59fbcbd603e80d9adc029b035f"
   integrity sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==
@@ -7680,15 +7678,10 @@ d3-interpolate@1, d3-interpolate@^1.1.3, d3-interpolate@^1.2.0, d3-interpolate@^
   dependencies:
     d3-color "1"
 
-d3-path@1, d3-path@^1.0.5, d3-path@^1.0.9:
+d3-path@1, d3-path@^1.0.5:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
   integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
-
-d3-quadtree@1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.7.tgz#ca8b84df7bb53763fe3c2f24bd435137f4e53135"
-  integrity sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==
 
 d3-queue@1:
   version "1.2.3"
@@ -7721,6 +7714,14 @@ d3-sankey@^0.4.2:
   dependencies:
     d3-array "1"
     d3-collection "1"
+    d3-interpolate "1"
+
+d3-scale-chromatic@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#54e333fc78212f439b14641fb55801dd81135a98"
+  integrity sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==
+  dependencies:
+    d3-color "1"
     d3-interpolate "1"
 
 d3-scale@^1.0.5, d3-scale@^1.0.6:
@@ -7764,7 +7765,7 @@ d3-selection@1, d3-selection@^1.0.3, d3-selection@^1.1.0, d3-selection@^1.3.0, d
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.1.tgz#98eedbbe085fbda5bafa2f9e3f3a2f4d7d622a98"
   integrity sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA==
 
-d3-shape@^1.0.6, d3-shape@^1.2.0, d3-shape@^1.3.7:
+d3-shape@^1.0.6, d3-shape@^1.2.0:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
   integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
@@ -7776,7 +7777,7 @@ d3-svg-legend@^1.x:
   resolved "https://registry.yarnpkg.com/d3-svg-legend/-/d3-svg-legend-1.13.0.tgz#6217478c9add9d62cb333617e1961311a41a4db3"
   integrity sha1-YhdHjJrdnWLLMzYX4ZYTEaQaTbM=
 
-d3-time-format@2, d3-time-format@^2.2.0, d3-time-format@^2.2.1, d3-time-format@^2.2.2, d3-time-format@^2.2.3:
+d3-time-format@2, d3-time-format@^2.2.0, d3-time-format@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.2.3.tgz#0c9a12ee28342b2037e5ea1cf0b9eb4dd75f29cb"
   integrity sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==
@@ -7788,7 +7789,7 @@ d3-time@1, d3-time@^1.0.10, d3-time@^1.0.11, d3-time@^1.1.0:
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
-d3-timer@1, d3-timer@^1.0.10, d3-timer@^1.0.9:
+d3-timer@1, d3-timer@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
   integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
@@ -8029,11 +8030,6 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
-
-delaunator@4:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
-  integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -8511,43 +8507,24 @@ emotion-theming@^10.0.19, emotion-theming@^10.0.27:
     "@emotion/weak-memoize" "0.2.5"
     hoist-non-react-statics "^3.3.0"
 
-encodable@^0.3.4:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/encodable/-/encodable-0.3.5.tgz#4d273623f86680939474b555183753c4976b3cc6"
-  integrity sha512-ofpVxFEYwFjgk94syrbdTc4nn6nxOO8rvJTieFz/Ko7V5oJMDpYwJYO87eL5xbc84XqD07vUJp50Zi54y+WAhw==
+encodable@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/encodable/-/encodable-0.7.0.tgz#22f1e64dd6afc30060051278dd40d37c4a77807f"
+  integrity sha512-ZHH6sALIPp5svU/he/C8Y1lh7ml9lWVACtqi+3k0oVyxePqu3bIN7hC9V8OBZH4TW4Ef+NfGMkrcPWcrJRA/GA==
   dependencies:
+    "@encodable/color" "^1.0.0"
+    "@encodable/format" "^1.0.0"
     "@types/d3-array" "^2.0.0"
     "@types/d3-interpolate" "^1.3.1"
     "@types/d3-scale" "^2.1.1"
     "@types/d3-time" "^1.0.10"
-    "@types/lodash" "^4.14.149"
+    "@types/lodash.get" "^4.4.6"
     d3-array "^2.3.1"
     d3-interpolate "^1.3.2"
     d3-scale "^3.0.1"
     d3-time "^1.0.11"
-    lodash "^4.17.15"
+    lodash.get "^4.4.2"
     reselect "^4.0.0"
-    vega "^5.9.1"
-    vega-lite "~4.1.0"
-
-encodable@^0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/encodable/-/encodable-0.3.7.tgz#6906ab4b03be36108f70a4f3288882b601caec1c"
-  integrity sha512-aFbrhAsxPUN+OMZ28+N2tOqaeIFs4I1t/Li9+WmQwPFONrsu7InwMehLR3XTOQjmo+ucCBcSV9ABjQqMawgKNw==
-  dependencies:
-    "@types/d3-array" "^2.0.0"
-    "@types/d3-interpolate" "^1.3.1"
-    "@types/d3-scale" "^2.1.1"
-    "@types/d3-time" "^1.0.10"
-    "@types/lodash" "^4.14.149"
-    d3-array "^2.3.1"
-    d3-interpolate "^1.3.2"
-    d3-scale "^3.0.1"
-    d3-time "^1.0.11"
-    lodash "^4.17.15"
-    reselect "^4.0.0"
-    vega "^5.9.1"
-    vega-lite "~4.1.0"
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -9347,7 +9324,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-deep-equal@^3.1.1, fast-deep-equal@~3.1.1:
+fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
@@ -9381,7 +9358,7 @@ fast-glob@^3.0.4, fast-glob@^3.2.2, fast-glob@^3.2.4:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@~2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -10221,6 +10198,11 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, gl
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-box@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/global-box/-/global-box-1.2.0.tgz#009f681e6fef6eb6f8aff00be732d23de4be0acd"
+  integrity sha512-IgpqqAYWNG3eluK1tsCkI8Uxff16+OYWLEhDS/QrfkfmbRQ/tVlBXZfURn5tSoPPT6wtmeJp7VKhXrcc5jl/1A==
+
 global-cache@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/global-cache/-/global-cache-1.2.1.tgz#39ca020d3dd7b3f0934c52b75363f8d53312c16d"
@@ -10780,7 +10762,7 @@ iconv-lite@0.2:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.2.11.tgz#1ce60a3a57864a292d1321ff4609ca4bb965adc8"
   integrity sha1-HOYKOleGSiktEyH/RgnKS7llrcg=
 
-iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -12114,11 +12096,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
-
-json-stringify-pretty-compact@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz#e77c419f52ff00c45a31f07f4c820c2433143885"
-  integrity sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==
 
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -16026,7 +16003,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.1.10, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@1.x, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -17726,11 +17703,6 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@~1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
-
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
@@ -18140,326 +18112,6 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
-
-vega-canvas@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/vega-canvas/-/vega-canvas-1.2.1.tgz#ee0586e2a1f096f6a5d1710df61ef501562c2bd4"
-  integrity sha512-k/S3EPeJ37D7fYDhv4sEg7fNWVpLheQY7flfLyAmJU7aSwCMgw8cZJi0CKHchJeculssfH+41NCqvRB1QtaJnw==
-
-vega-crossfilter@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/vega-crossfilter/-/vega-crossfilter-4.0.1.tgz#9fab0dc5445e846d732c83ac2b5a72225bc6fdf1"
-  integrity sha512-wLNS4JzKaOLj8EAzI/v8XBJjUWMRWYSu6EeQF4o9Opq/78u87Ol9Lc5I27UHsww5dNNH/tHubAV4QPIXnGOp5Q==
-  dependencies:
-    d3-array "^2.0.3"
-    vega-dataflow "^5.1.0"
-    vega-util "^1.8.0"
-
-vega-dataflow@^5.1.0, vega-dataflow@^5.1.1, vega-dataflow@^5.4.0, vega-dataflow@^5.4.1, vega-dataflow@^5.5.0, vega-dataflow@~5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-5.5.0.tgz#9a1ecd2eb0ff02aef53cdb87a7828eae528f8d82"
-  integrity sha512-9eRe2qLpwvEegBoSaH3vdziSLMZSszY02wxVmvcFzHe57Rf/eYEr0YRuW4qc+gMmwURPYu9wtmeUTiK4XhDKXw==
-  dependencies:
-    vega-loader "^4.0.0"
-    vega-util "^1.11.0"
-
-vega-encode@~4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/vega-encode/-/vega-encode-4.5.3.tgz#a243cbe2af461313a8a2eef88400548b89cdf52c"
-  integrity sha512-N7EVoDVQOrloutGnnXZj0Pa9JReH2s7Tio/2KUiMb5eGeJQ7jRD2zyqZSG0ZxKODSlxoP3YLmbLVKHIqNJQ5Kg==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-format "^1.4.3"
-    d3-interpolate "^1.4.0"
-    vega-dataflow "^5.5.0"
-    vega-scale "^6.0.0"
-    vega-time "^1.0.0"
-    vega-util "^1.13.1"
-
-vega-event-selector@^2.0.2, vega-event-selector@~2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-2.0.2.tgz#bb64e1cfe047c6808878038319e18af6991759d9"
-  integrity sha512-Uv72vBfM0lrlI2belKHFMZuVnW2uJl2ShqWPwGSXPVe6p+PzgqoPJYC8A/i5N8B54UA4UMDzlbBeo3x7q2W9Yg==
-
-vega-expression@^2.6.1, vega-expression@^2.6.3, vega-expression@~2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-2.6.3.tgz#11110922765cc495b8aebd8e05c4ec848d9f2b3b"
-  integrity sha512-sME1+45BToTGsftb1Q6Ubs2iRYEoXkD2NRGnJuKS9YJ2ITzZwPHF/jy2kHW3iLpuNjj54meaO7HMQ/hUKrciUw==
-  dependencies:
-    vega-util "^1.11.0"
-
-vega-force@~4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/vega-force/-/vega-force-4.0.3.tgz#33e0b03c9af60146f821007d9e7a7617fe9e8ac6"
-  integrity sha512-4stItN4jD9H1CENaCz4jXRNS1Bi9cozMOUjX2824FeJENi2RZSiAZAaGbscgerZQ/jbNcOHD8PHpC2pWldEvGA==
-  dependencies:
-    d3-force "^2.0.1"
-    vega-dataflow "^5.4.0"
-    vega-util "^1.11.0"
-
-vega-functions@^5.5.1, vega-functions@~5.5.1:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.5.1.tgz#849a7c9f19c77899c26969b6070c724cd7366131"
-  integrity sha512-VTfEwf/ChSOGc4d4yUIgu2XoScky6NH06WN4vwVGY5PREhsyVPsQ+p2zqgD/N/a00EyWPHeOSHEhsPU28oIMtQ==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-color "^1.4.0"
-    d3-format "^1.4.2"
-    d3-geo "^1.11.9"
-    d3-time-format "^2.2.2"
-    vega-dataflow "^5.5.0"
-    vega-expression "^2.6.3"
-    vega-scale "^6.0.0"
-    vega-scenegraph "^4.5.0"
-    vega-selections "^5.1.0"
-    vega-statistics "^1.7.1"
-    vega-time "^1.0.0"
-    vega-util "^1.12.1"
-
-vega-geo@~4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-4.3.0.tgz#3dd5d3606f18dc839c8a430338c6a390319bf477"
-  integrity sha512-Rcz4z+TR4qy727pjBWSsbMAn8eM9bDZ5MXKqo5AWuFkoj/8ngv13vafHd1tvEMTA8L5BjAW3/eTqN4tyx9KSQg==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-color "^1.4.0"
-    d3-geo "^1.11.9"
-    vega-canvas "^1.2.1"
-    vega-dataflow "^5.1.1"
-    vega-projection "^1.4.0"
-    vega-statistics "^1.7.1"
-    vega-util "^1.12.1"
-
-vega-hierarchy@~4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/vega-hierarchy/-/vega-hierarchy-4.0.3.tgz#0d36bc29ad6f369fa844e3e2ce5faec983f8b047"
-  integrity sha512-9wNe+KyKqZW1S4++jCC38HuAhZbqNhfY7gOvwiMLjsp65tMtRETrtvYfHkULClm3UokUIX54etAXREAGW7znbw==
-  dependencies:
-    d3-hierarchy "^1.1.8"
-    vega-dataflow "^5.4.0"
-    vega-util "^1.11.0"
-
-vega-lite@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-4.1.1.tgz#f6e6cae4e0518c66afd0298fb544b6a35290437b"
-  integrity sha512-D2seO6ZbY8aZQ8+ZQfU+5NYwot3ryIDyvdQdcVoupMSgJ/oGv4QqEwL3rmu8abdSG6NhFiac0trsI+wBb0F6vQ==
-  dependencies:
-    "@types/clone" "~0.1.30"
-    "@types/fast-json-stable-stringify" "^2.0.0"
-    array-flat-polyfill "^1.0.1"
-    clone "~2.1.2"
-    fast-deep-equal "~3.1.1"
-    fast-json-stable-stringify "~2.1.0"
-    json-stringify-pretty-compact "~2.0.0"
-    tslib "~1.10.0"
-    vega-event-selector "~2.0.2"
-    vega-expression "~2.6.3"
-    vega-typings "~0.12.0"
-    vega-util "~1.12.2"
-    yargs "~15.1.0"
-
-vega-loader@^4.0.0, vega-loader@^4.2.0, vega-loader@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/vega-loader/-/vega-loader-4.2.1.tgz#556554e6e70f254dc68da15a391ba0d3ad6d1373"
-  integrity sha512-JfF/vwOWzj7MD2Je/5r0beqBApTsQ68e2H8uV1T9wZctMM7WV9+z3JWvQ95yUFiMqyjVYRpXUR25y/b7qPE03Q==
-  dependencies:
-    d3-dsv "^1.2.0"
-    d3-time-format "^2.2.3"
-    node-fetch "^2.6.0"
-    topojson-client "^3.1.0"
-    vega-util "^1.13.1"
-
-vega-parser@~5.13.1:
-  version "5.13.1"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-5.13.1.tgz#37770fe599808988a4c31e36bb632976a0119786"
-  integrity sha512-xTtfpZTgJ/UMclcSor8adpK95G5hh1YSCZom94eUnFabfsoEHAfl5K3RJd5XVjInUISsGFOyAR5LqXNth4k7BA==
-  dependencies:
-    vega-dataflow "^5.5.0"
-    vega-event-selector "^2.0.2"
-    vega-expression "^2.6.3"
-    vega-functions "^5.5.1"
-    vega-scale "^6.0.0"
-    vega-util "^1.13.1"
-
-vega-projection@^1.4.0, vega-projection@~1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/vega-projection/-/vega-projection-1.4.0.tgz#58c910b30306869132c4a26516164f8643fd1734"
-  integrity sha512-Prb/E41PqZT5b+46rHv6BZLDsXMe+NFClHxJ9NbwW7mntz8aMGAHiYolVa/M2KuTLbsXVgDAPxk/aA9tbQ0SSg==
-  dependencies:
-    d3-geo "^1.11.9"
-    d3-geo-projection "^2.7.1"
-
-vega-regression@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/vega-regression/-/vega-regression-1.0.5.tgz#dbe39dc6e3cb0c1f54f631be4edeedd3366f4b2c"
-  integrity sha512-HlKRQ0N5pQGqjmdy7Am+jtDCInI1IyAfHMbIVmpgF7H9odaUqtHynZijRtHRfbS6IXK+aXJ0WNsKW/oc+ox2fA==
-  dependencies:
-    d3-array "^2.4.0"
-    vega-dataflow "^5.4.1"
-    vega-statistics "^1.7.3"
-    vega-util "^1.12.2"
-
-vega-runtime@^5.0.2, vega-runtime@~5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/vega-runtime/-/vega-runtime-5.0.2.tgz#4d7f327e05b2d4addc8b7472d49eb54f1118ff6c"
-  integrity sha512-Cuv+RY6kprH+vtNERg6xP4dgcdYGD2ZnxPxJNEtGi7dmtQQTBa1s7jQ0VDXTolsO6lKJ3B7np2GzKJYwevgj1A==
-  dependencies:
-    vega-dataflow "^5.1.1"
-    vega-util "^1.11.0"
-
-vega-scale@^6.0.0, vega-scale@~6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-6.0.0.tgz#b227127b00841e9d507a3235af2f8be475f7de83"
-  integrity sha512-uNJ5LC+s+XLxdO2iXC36/TLen3mMNv0wzhMZMNXa8h+Ih10geJ57sHbYYA8Z8403JC9AYTaWUe7m0H9CHgV9NA==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-interpolate "^1.4.0"
-    d3-scale "^3.2.1"
-    vega-util "^1.12.1"
-
-vega-scenegraph@^4.5.0, vega-scenegraph@^4.6.0, vega-scenegraph@~4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-4.6.0.tgz#431b31c72ce528285c5808593dbb29cf8ed981e8"
-  integrity sha512-OwHr67kUyY5vG7VR1ovatVyynoHemIUxLgG6w5I4ckzCwCUWgvQRMhxT3bJnoIWvgE9AgLTiIL8mfoSLehK1IA==
-  dependencies:
-    d3-path "^1.0.9"
-    d3-shape "^1.3.7"
-    vega-canvas "^1.2.1"
-    vega-loader "^4.2.0"
-    vega-util "^1.13.1"
-
-vega-selections@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.1.0.tgz#5cbfe4d50e404129e5613bfa6470a1cb60cf6015"
-  integrity sha512-Gm+16RaCMkWbimqKh9kuIGMK91vutJsTbIDKBXxmq0c3pTvf+Djy6KfBoFsipEJ9wkwhXHSqpLqS1tExV93E9g==
-  dependencies:
-    vega-expression "^2.6.1"
-    vega-util "^1.11.0"
-
-vega-statistics@^1.7.1, vega-statistics@^1.7.3, vega-statistics@~1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/vega-statistics/-/vega-statistics-1.7.3.tgz#8ce436eccebf484f7c7aa619c884e2427a7e044b"
-  integrity sha512-PRhoozWmlQRYesly4greSIJ5yaKljzmuPYiXbhcvxW3dvgcnWexKjh3Kxk66eTgf9vX6OU/5QEnKQqjWKXqiQQ==
-  dependencies:
-    d3-array "^2.4.0"
-
-vega-time@^1.0.0, vega-time@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/vega-time/-/vega-time-1.0.0.tgz#5bc61ff311260cd212ccc8cbd73049bcd29b1440"
-  integrity sha512-r0yOFr/VklJwD3ew1+fEcB7E0LBCLChYlwh0KoO6cTIWMdlC4KhIIUN3/FuBfUZ4qx4V/xp71xH2YYYZTH6izg==
-  dependencies:
-    d3-array "^2.3.3"
-    d3-time "^1.1.0"
-    d3-time-format "^2.2.1"
-    vega-util "^1.12.0"
-
-vega-transforms@~4.7.1:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/vega-transforms/-/vega-transforms-4.7.1.tgz#6bde7a05d43df4aa12e9cefe8ae559812c52b21c"
-  integrity sha512-F8KMowHTerCl6VZonbrItqKpTTf1/2TZDCCZ+HO0Izw9RiamkXrgwu3DZQ/H/wUwDiI/WrmKNIHh6L6pYs45AQ==
-  dependencies:
-    d3-array "^2.4.0"
-    vega-dataflow "^5.5.0"
-    vega-statistics "^1.7.3"
-    vega-time "^1.0.0"
-    vega-util "^1.13.1"
-
-vega-typings@~0.12.0:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-0.12.4.tgz#e3b298723db1a484aae6ca1cf760ff20fd46fae1"
-  integrity sha512-2tnAfFMxaGul1875q6v6vZW20s+j9hYGlt/lpp3yVYYGARG7hjgwyHpOKnHzw3C/huy4JaHaMhf3psXgG/VnHw==
-  dependencies:
-    vega-util "^1.12.1"
-
-vega-typings@~0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-0.15.0.tgz#def47bff152deaaa7b796aa483a7db8beb928b9c"
-  integrity sha512-6XreJKYQEpqfsvNCMK+ULnY/Uy6F595LdRqM7lQO8g+lZUHbYDzhMI95a9SEz4e7KyRmdETytYKhHEL0hxQp9w==
-  dependencies:
-    vega-util "^1.13.1"
-
-vega-util@^1.11.0, vega-util@^1.12.0, vega-util@^1.12.1, vega-util@^1.12.2, vega-util@^1.13.1, vega-util@^1.8.0, vega-util@~1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.13.1.tgz#3eae51043184c6b873c17b148755c21b01274a0e"
-  integrity sha512-TmvZSMKqhGlS7eAXphqJUhq+NZVYbvXX2ahargTRkVckGWjEUpWhMC7T13vYihrU2Lf/OevKbrruSXKOBxke2w==
-
-vega-util@~1.12.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.12.2.tgz#4997a50e56fa4be05046966568aed72246a40e27"
-  integrity sha512-p02+oQ/XU/gzY9S/CTZinym2NKWEMIneLc+FYdUeJZZnDGa3DvcNgUDlVR90JlwLcYZNs5dBdfYLfdRHsKZKiw==
-
-vega-view-transforms@~4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/vega-view-transforms/-/vega-view-transforms-4.5.2.tgz#46b488aacc28be4c2f134be2e13f80378f399844"
-  integrity sha512-i12eEWSkCTGRyuFCn+96k2FvftZAygEkbYJOqSyoFdyAvdN37+87GdsDhgJJzGF31hjnN8OfzuVgxfueE0uhEQ==
-  dependencies:
-    vega-dataflow "^5.5.0"
-    vega-scenegraph "^4.6.0"
-    vega-util "^1.13.1"
-
-vega-view@~5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.5.0.tgz#57901e5bce075c1389a949bb761d94b32f9118d0"
-  integrity sha512-hD3J00QRkh3zC1jF81UgxnXpTKY07nVKKG1ut7rlCpVdpEec8Ix6EckOHpAzMkHeY6aG5fbhSQbRYv05tzQy/A==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-timer "^1.0.10"
-    vega-dataflow "^5.5.0"
-    vega-functions "^5.5.1"
-    vega-runtime "^5.0.2"
-    vega-scenegraph "^4.6.0"
-    vega-util "^1.13.1"
-
-vega-voronoi@~4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-4.1.1.tgz#1a09f86661cf85c75581282f19ff108603893715"
-  integrity sha512-agLmr+UGxJs5KB9D8GeZqxgeWWGoER/eVHPcFFPgVuoNBsrqf2bdoltmIkRnpiRsQnGCibGixhFEDCc9GGNAww==
-  dependencies:
-    d3-delaunay "^5.1.3"
-    vega-dataflow "^5.1.1"
-    vega-util "^1.11.0"
-
-vega-wordcloud@~4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/vega-wordcloud/-/vega-wordcloud-4.0.4.tgz#9169165c652478489e43cc56e05edbe14ce3d3c3"
-  integrity sha512-+FwgCKTj8JBMbBjNiVciLvjQnk+rC59uyecmlTsmtUGVZz5wyANooYcXt4xtiRu+G8ohdlJ6L/59+UFTaUR8og==
-  dependencies:
-    vega-canvas "^1.2.1"
-    vega-dataflow "^5.4.1"
-    vega-scale "^6.0.0"
-    vega-statistics "^1.7.1"
-    vega-util "^1.12.1"
-
-vega@^5.9.1:
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/vega/-/vega-5.10.1.tgz#4eafef108c065cefa463375350bab7db27e06836"
-  integrity sha512-DSY0G3NnOk425TYVxRlrzdi1xKk3b5yfqjIRRhg+oN+T55PWCBzDnUG3GdqOSJnfs6zTp6485rR4IL8qpbDizA==
-  dependencies:
-    vega-crossfilter "~4.0.1"
-    vega-dataflow "~5.5.0"
-    vega-encode "~4.5.3"
-    vega-event-selector "~2.0.2"
-    vega-expression "~2.6.3"
-    vega-force "~4.0.3"
-    vega-functions "~5.5.1"
-    vega-geo "~4.3.0"
-    vega-hierarchy "~4.0.3"
-    vega-loader "~4.2.1"
-    vega-parser "~5.13.1"
-    vega-projection "~1.4.0"
-    vega-regression "~1.0.5"
-    vega-runtime "~5.0.2"
-    vega-scale "~6.0.0"
-    vega-scenegraph "~4.6.0"
-    vega-statistics "~1.7.3"
-    vega-time "~1.0.0"
-    vega-transforms "~4.7.1"
-    vega-typings "~0.15.0"
-    vega-util "~1.13.1"
-    vega-view "~5.5.0"
-    vega-view-transforms "~4.5.2"
-    vega-voronoi "~4.1.1"
-    vega-wordcloud "~4.0.4"
 
 verror@1.10.0:
   version "1.10.0"
@@ -18981,14 +18633,6 @@ yargs-parser@^15.0.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
-  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^18.1.1:
   version "18.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.2.tgz#2f482bea2136dbde0861683abea7756d30b504f1"
@@ -19055,23 +18699,6 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
-
-yargs@~15.1.0:
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
-  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
-  dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^16.1.0"
 
 yeoman-assert@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
🏠 Internal

* Bump `encodable` to latest version which no longer has nested dependency to `@superset-ui/color`, `@superset-ui/number-format` and `@superset-ui/time-format`.
* By default `encodable` ships with its own color and formatter registries. This PR include shims to point to the same registries that `@superset-ui` is using, so the specified formats and colorScheme from control panel can be correctly used. Have to call this shim function in the setup.
  * There are multiple copies of the same shim in each package at the moment. It could be extracted to a new package, but seems like an overkill for this first pass.
  * I may also refactor `@superset-ui/colors,number-format,time-format` later to use the same underlying registries so the shim won't be necessary.

scatter plot working
![image](https://user-images.githubusercontent.com/1659771/90681845-ece8e580-e218-11ea-9fb3-833ee88706dd.png)

word cloud working
![image](https://user-images.githubusercontent.com/1659771/90681892-fe31f200-e218-11ea-9084-2975c1bef284.png)

map working
![image](https://user-images.githubusercontent.com/1659771/90681932-0be77780-e219-11ea-8347-998a1075c558.png)
