### PR TITLE
feat(color): add official ECharts color schemes

### DIFF
--- a/packages/superset-ui-color/src/colorSchemes/categorical/echarts.ts
+++ b/packages/superset-ui-color/src/colorSchemes/categorical/echarts.ts
@@ -3,7 +3,7 @@ import CategoricalScheme from '../../CategoricalScheme';
 const schemes = [
   {
     id: 'echarts4Colors',
-    label: 'ECharts 4 Colors',
+    label: 'ECharts v4.x Colors',
     colors: [
       '#c23531',
       '#2f4554',
@@ -20,7 +20,7 @@ const schemes = [
   },
   {
     id: 'echarts5Colors',
-    label: 'ECharts 5 Colors',
+    label: 'ECharts v5.x Colors',
     colors: [
       '#5470C6',
       '#91CC75',

--- a/packages/superset-ui-color/src/colorSchemes/categorical/echarts.ts
+++ b/packages/superset-ui-color/src/colorSchemes/categorical/echarts.ts
@@ -1,0 +1,38 @@
+import CategoricalScheme from '../../CategoricalScheme';
+
+const schemes = [
+  {
+    id: 'echarts4Colors',
+    label: 'ECharts 4 Colors',
+    colors: [
+      '#c23531',
+      '#2f4554',
+      '#61a0a8',
+      '#d48265',
+      '#91c7ae',
+      '#749f83',
+      '#ca8622',
+      '#bda29a',
+      '#6e7074',
+      '#546570',
+      '#c4ccd3',
+    ],
+  },
+  {
+    id: 'echarts5Colors',
+    label: 'ECharts 5 Colors',
+    colors: [
+      '#5470C6',
+      '#91CC75',
+      '#FAC858',
+      '#EE6666',
+      '#73C0DE',
+      '#3BA272',
+      '#FC8452',
+      '#9A60B4',
+      '#EA7CCC',
+    ],
+  },
+].map(s => new CategoricalScheme(s));
+
+export default schemes;

--- a/packages/superset-ui-color/src/colorSchemes/sequential/common.ts
+++ b/packages/superset-ui-color/src/colorSchemes/sequential/common.ts
@@ -193,6 +193,12 @@ const schemes = [
       '#3AA3B2',
     ],
   },
+  {
+    id: 'echarts_gradient',
+    label: 'ECharts gradient',
+    isDiverging: false,
+    colors: ['#f6EFA6', '#D88273', '#BF444C'],
+  },
 ].map(s => new SequentialScheme(s));
 
 export default schemes;

--- a/packages/superset-ui-color/test/colorSchemes.test.ts
+++ b/packages/superset-ui-color/test/colorSchemes.test.ts
@@ -1,4 +1,5 @@
 import categoricalAirbnb from '../src/colorSchemes/categorical/airbnb';
+import categoricalEcharts from '../src/colorSchemes/categorical/echarts';
 import categoricalSuperset from '../src/colorSchemes/categorical/superset';
 import categoricalPreset from '../src/colorSchemes/categorical/preset';
 import categoricalD3 from '../src/colorSchemes/categorical/d3';
@@ -14,6 +15,7 @@ describe('Color Schemes', () => {
     it('returns an array of CategoricalScheme', () => {
       [
         categoricalAirbnb,
+        categoricalEcharts,
         categoricalD3,
         categoricalGoogle,
         categoricalLyft,

--- a/packages/superset-ui-demo/storybook/stories/superset-ui-color/ColorPallettesStories.jsx
+++ b/packages/superset-ui-demo/storybook/stories/superset-ui-color/ColorPallettesStories.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import AirbnbPalettes from '@superset-ui/color/src/colorSchemes/categorical/airbnb';
 import D3Palettes from '@superset-ui/color/src/colorSchemes/categorical/d3';
+import EchartsPalettes from '@superset-ui/color/src/colorSchemes/categorical/echarts';
 import GooglePalettes from '@superset-ui/color/src/colorSchemes/categorical/google';
 import LyftPalettes from '@superset-ui/color/src/colorSchemes/categorical/lyft';
 import PresetPalettes from '@superset-ui/color/src/colorSchemes/categorical/preset';
@@ -21,6 +22,7 @@ export const categoricalPalettes = () =>
     { palettes: SupersetPalettes, storyName: 'Superset' },
     { palettes: AirbnbPalettes, storyName: 'Airbnb' },
     { palettes: D3Palettes, storyName: 'd3' },
+    { palettes: EchartsPalettes, storyName: 'ECharts' },
     { palettes: GooglePalettes, storyName: 'Google' },
     { palettes: LyftPalettes, storyName: 'Lyft' },
     { palettes: PresetPalettes, storyName: 'Preset' },


### PR DESCRIPTION
🏆 Enhancements

Add ECharts 4.x and 5.x official color schemes.
4.x: https://github.com/apache/incubator-echarts/blob/eb396f27137af1d74b42b1b28752f204a34dbecf/src/model/globalDefault.js#L36-L41
5.x: https://github.com/apache/incubator-echarts/blob/4c916f527f211a34c8dd5555c23870db25a78b05/src/model/globalDefault.ts#L42-L55

Categorical:
![image](https://user-images.githubusercontent.com/33317356/91257572-f3281600-e772-11ea-9ede-9bcbd82df69e.png)
Sequential:
![image](https://user-images.githubusercontent.com/33317356/91166798-97f71480-e6db-11ea-810d-7b118ddd2761.png)


Ping @Ovilia