### PR TITLE
chore: silencing console errors by making MetricOption props optional

### DIFF
--- a/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -34,9 +34,9 @@ const FlexRowContainer = styled.div`
 
 export interface MetricOptionProps {
   metric: {
-    verbose_name: string;
+    verbose_name?: string;
     metric_name: string;
-    label: string;
+    label?: string;
     description: string;
     warning_text: string;
     expression: string;
@@ -44,10 +44,10 @@ export interface MetricOptionProps {
     certified_by?: string | null;
     certification_details?: string | null;
   };
-  openInNewWindow: boolean;
-  showFormula: boolean;
-  showType: boolean;
-  url: string;
+  openInNewWindow?: boolean;
+  showFormula?: boolean;
+  showType?: boolean;
+  url?: string;
 }
 
 export function MetricOption({


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix
Explore had a bunch of console warnings going on since various implementations of <MetricOption> did not provide all the props that the TS definition had listed as mandatory. This loosens up the typing so the console is less painful to look at :)

🏠 Internal
