### PR TITLE
feat(legacy-preset-chart-nvd3): add zero imputation

### DIFF
--- a/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.js
@@ -42,6 +42,18 @@ export default {
       controlSetRows: [
         [
           {
+            name: 'zero_out',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Fill missing timestamps with zero'),
+              renderTrigger: false,
+              default: false,
+              description: t('Fill missing values with zero based on time grain'),
+            },
+          },
+        ],
+        [
+          {
             name: 'pandas_aggfunc',
             config: {
               type: 'SelectControl',

--- a/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.js
@@ -42,7 +42,7 @@ export default {
       controlSetRows: [
         [
           {
-            name: 'zero_out',
+            name: 'fill_missing_with_zero',
             config: {
               type: 'CheckboxControl',
               label: t('Fill missing timestamps with zero'),

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
@@ -342,6 +342,20 @@ export const timeSeriesSection = [
     ),
     controlSetRows: [
       // eslint-disable-next-line react/jsx-key
+      [<h1 className="section-header">{t('Data imputation')}</h1>],
+      [
+        {
+          name: 'zero_out',
+          config: {
+            type: 'CheckboxControl',
+            label: t('Fill missing timestamps with zero'),
+            renderTrigger: false,
+            default: false,
+            description: t('Fill missing values with zero based on time grain'),
+          },
+        },
+      ],
+      // eslint-disable-next-line react/jsx-key
       [<h1 className="section-header">{t('Rolling Window')}</h1>],
       [
         {

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
@@ -345,7 +345,7 @@ export const timeSeriesSection = [
       [<h1 className="section-header">{t('Data imputation')}</h1>],
       [
         {
-          name: 'zero_out',
+          name: 'fill_missing_with_zero',
           config: {
             type: 'CheckboxControl',
             label: t('Fill missing timestamps with zero'),


### PR DESCRIPTION
🏆 Enhancements

Add control for imputation of missing timestamps. Useful if missing data indicates zero observations.

### SCREENSHOTS (these changes are on a forthcoming PR on `incubator-superset`)

When imputing annual data with monthly time grains:
![image](https://user-images.githubusercontent.com/33317356/91432041-d8849880-e869-11ea-8d06-9da63f4b7a69.png)
When trying to zero out without selecting a time grain first:
![image](https://user-images.githubusercontent.com/33317356/91432596-9f005d00-e86a-11ea-8701-046c3ac292f2.png)
