### PR TITLE
fix: add Echarts tooltip confine

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -127,6 +127,7 @@ export default function transformProps(chartProps: ChartProps): EchartsTimeserie
     },
     tooltip: {
       trigger: 'axis',
+      confine: true,
       formatter: (params, ticket, callback) => {
         // @ts-ignore
         const rows = [`${smartDateVerboseFormatter(params[0].value[0])}`];


### PR DESCRIPTION
🏆 Enhancements
add `tooltip.confine = true`
https://echarts.apache.org/en/option.html#tooltip.confine

(cc @villebro @ktmud)

BEFORE:
<img width="637" alt="Screen Shot 2020-09-02 at 14 50 46" src="https://user-images.githubusercontent.com/10289162/91943187-bd64cd80-ed2e-11ea-8003-41997ff9a2e4.png">

AFTER:
<img width="637" alt="Screen Shot 2020-09-02 at 15 04 29" src="https://user-images.githubusercontent.com/10289162/91943198-c2298180-ed2e-11ea-82b8-6d9e294dc964.png">
