### PR TITLE
fix(legacy-preset-chart-nvd3): remove unnecessary control override

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/Area/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/Area/controlPanel.ts
@@ -84,11 +84,6 @@ export default {
     timeSeriesSection[1],
     sections.annotations,
   ],
-  controlOverrides: {
-    color_scheme: {
-      renderTrigger: false,
-    },
-  },
   sectionOverrides: {
     druidTimeSeries: {
       controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],


### PR DESCRIPTION
🐛 Bug Fix
For some reason the color scheme was set to `renderTrigger: false`, causing the whole "Chart Options" section to be moved to the front pane an require refetching data from the backend.

### BEFORE
![area-before](https://user-images.githubusercontent.com/33317356/92108277-c8336700-edef-11ea-8a30-b4ac8b5e78c2.gif)
### AFTER
![area-after](https://user-images.githubusercontent.com/33317356/92108288-ce294800-edef-11ea-8db3-a90625577d52.gif)

