### PR TITLE
build: enable skipLibCheck for tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,10 @@
         "declaration": true,
         "emitDeclarationOnly": true,
         "composite": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "typeRoots": [
+          "./node_modules/@types"
+        ]
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "typescript": {
       "compilerOptions": {
         "rootDir": "./src",
+        "skipLibCheck": true,
         "declaration": true,
         "emitDeclarationOnly": true,
         "composite": true,

--- a/plugins/legacy-plugin-chart-calendar/tsconfig.json
+++ b/plugins/legacy-plugin-chart-calendar/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-chord/tsconfig.json
+++ b/plugins/legacy-plugin-chart-chord/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-country-map/tsconfig.json
+++ b/plugins/legacy-plugin-chart-country-map/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-event-flow/tsconfig.json
+++ b/plugins/legacy-plugin-chart-event-flow/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-force-directed/tsconfig.json
+++ b/plugins/legacy-plugin-chart-force-directed/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-heatmap/tsconfig.json
+++ b/plugins/legacy-plugin-chart-heatmap/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-histogram/tsconfig.json
+++ b/plugins/legacy-plugin-chart-histogram/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-horizon/tsconfig.json
+++ b/plugins/legacy-plugin-chart-horizon/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-map-box/tsconfig.json
+++ b/plugins/legacy-plugin-chart-map-box/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-paired-t-test/tsconfig.json
+++ b/plugins/legacy-plugin-chart-paired-t-test/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-parallel-coordinates/tsconfig.json
+++ b/plugins/legacy-plugin-chart-parallel-coordinates/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-partition/tsconfig.json
+++ b/plugins/legacy-plugin-chart-partition/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-pivot-table/tsconfig.json
+++ b/plugins/legacy-plugin-chart-pivot-table/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-rose/tsconfig.json
+++ b/plugins/legacy-plugin-chart-rose/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-sankey-loop/tsconfig.json
+++ b/plugins/legacy-plugin-chart-sankey-loop/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-sankey/tsconfig.json
+++ b/plugins/legacy-plugin-chart-sankey/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-sunburst/tsconfig.json
+++ b/plugins/legacy-plugin-chart-sunburst/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-time-table/tsconfig.json
+++ b/plugins/legacy-plugin-chart-time-table/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-treemap/tsconfig.json
+++ b/plugins/legacy-plugin-chart-treemap/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-plugin-chart-world-map/tsconfig.json
+++ b/plugins/legacy-plugin-chart-world-map/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-preset-chart-big-number/tsconfig.json
+++ b/plugins/legacy-preset-chart-big-number/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/legacy-preset-chart-nvd3/tsconfig.json
+++ b/plugins/legacy-preset-chart-nvd3/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/plugin-chart-choropleth-map/tsconfig.json
+++ b/plugins/plugin-chart-choropleth-map/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/plugin-chart-echarts/tsconfig.json
+++ b/plugins/plugin-chart-echarts/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/plugin-chart-table/tsconfig.json
+++ b/plugins/plugin-chart-table/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/plugin-chart-word-cloud/tsconfig.json
+++ b/plugins/plugin-chart-word-cloud/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/plugins/preset-chart-xy/tsconfig.json
+++ b/plugins/preset-chart-xy/tsconfig.json
@@ -16,10 +16,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/superset-ui-core"
+      "path": "../../packages/superset-ui-chart-controls"
     },
     {
-      "path": "../../packages/superset-ui-chart-controls"
+      "path": "../../packages/superset-ui-core"
     }
   ]
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -22,7 +22,7 @@ const { argv } = require('yargs')
   .option('clean', {
     describe: 'Whether to clean cache',
     type: 'boolean',
-    default: true,
+    default: false,
   })
   .option('type', {
     describe: 'Whether to run tsc',

--- a/tsconfig.options.json
+++ b/tsconfig.options.json
@@ -25,6 +25,9 @@
     "rootDir": "./src",
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
   }
 }

--- a/tsconfig.options.json
+++ b/tsconfig.options.json
@@ -23,6 +23,7 @@
     "composite": true,
     "declarationMap": true,
     "rootDir": "./src",
+    "skipLibCheck": true,
     "emitDeclarationOnly": true,
     "resolveJsonModule": true
   }


### PR DESCRIPTION
🏆 Enhancements
🏠 Internal

From TypeScript [handbook](https://www.typescriptlang.org/docs/handbook/compiler-options.html):

```
--skipLibCheck       Skip type checking of all declaration files (*.d.ts).
```

This cuts build-time for `tsc` in half. Most TS errors can still be captured by ESLint.

Also limit `typeRoots` to `./node_modules` in the root folder so to reduce chances of type conflicts from `packages/*` and `plugins/*`.
