### PR TITLE
chore: move @types/react to peerDependencies

### DIFF
--- a/packages/superset-ui-chart-controls/package.json
+++ b/packages/superset-ui-chart-controls/package.json
@@ -25,17 +25,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "react": "^16.13.1"
-  },
-  "devDependencies": {
-    "enzyme": "^3.11.0"
-  },
   "dependencies": {
     "@superset-ui/core": "0.15.0",
-    "@types/react-bootstrap": "0.32.21",
     "lodash": "^4.17.15",
-    "prop-types": "^15.7.2",
-    "react-bootstrap": "^0.33.1"
+    "prop-types": "^15.7.2"
+  },
+  "peerDependencies": {
+    "@types/react-bootstrap": "*",
+    "@types/react": "*",
+    "react-bootstrap": "^0.33.1",
+    "react": "^16.13.1"
   }
 }

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -40,7 +40,6 @@
     "@types/d3-time": "^1.0.9",
     "@types/d3-time-format": "^2.1.0",
     "@types/lodash": "^4.14.149",
-    "@types/react": "*",
     "@types/react-bootstrap": "0.32.21",
     "@types/react-loadable": "^5.5.3",
     "@vx/responsive": "^0.0.197",
@@ -61,6 +60,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.13.1"
   }
 }

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -40,8 +40,6 @@
     "@types/d3-time": "^1.0.9",
     "@types/d3-time-format": "^2.1.0",
     "@types/lodash": "^4.14.149",
-    "@types/react-bootstrap": "0.32.21",
-    "@types/react-loadable": "^5.5.3",
     "@vx/responsive": "^0.0.197",
     "csstype": "^2.6.4",
     "d3-format": "^1.3.2",
@@ -55,12 +53,15 @@
     "lodash": "^4.17.11",
     "pretty-ms": "^7.0.0",
     "react-error-boundary": "^1.2.5",
-    "react-loadable": "^5.5.0",
     "reselect": "^4.0.0",
     "whatwg-fetch": "^3.0.0"
   },
   "peerDependencies": {
+    "@types/react-bootstrap": "*",
+    "@types/react-loadable": "*",
     "@types/react": "*",
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "react-bootstrap": "^0.33.1",
+    "react-loadable": "^5.5.0"
   }
 }

--- a/packages/superset-ui-demo/package.json
+++ b/packages/superset-ui-demo/package.json
@@ -62,6 +62,8 @@
     "@superset-ui/legacy-preset-chart-big-number": "0.15.0",
     "@superset-ui/plugin-chart-table": "0.15.0",
     "@superset-ui/plugin-chart-word-cloud": "0.15.0",
+    "@types/react-loadable": "^5.5.3",
+    "@types/react-bootstrap": "^0.32.22",
     "@types/react-resizable": "^1.7.2",
     "@types/storybook__react": "5.2.1",
     "bootstrap": "^3.4.1",
@@ -71,6 +73,8 @@
     "jquery": "^3.4.1",
     "memoize-one": "^5.1.1",
     "react": "^16.13.1",
+    "react-loadable": "^5.5.0",
+    "react-bootstrap": "^0.33.1",
     "react-resizable": "^1.10.1",
     "storybook-addon-jsx": "^7.2.3"
   },

--- a/plugins/legacy-plugin-chart-time-table/package.json
+++ b/plugins/legacy-plugin-chart-time-table/package.json
@@ -32,7 +32,6 @@
     "@superset-ui/chart-controls": "0.15.0",
     "@superset-ui/core": "0.15.0",
     "@types/d3-scale": "^2.0.2",
-    "@types/react": "*",
     "d3-scale": "^3.2.1",
     "emotion-theming": "^10.0.27",
     "moment": "^2.26.0",
@@ -41,6 +40,7 @@
     "reactable-arc": "^0.15.0"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.3.1"
   }
 }

--- a/plugins/plugin-chart-choropleth-map/package.json
+++ b/plugins/plugin-chart-choropleth-map/package.json
@@ -31,7 +31,6 @@
     "@superset-ui/core": "0.15.0",
     "@types/d3-geo": "^1.11.1",
     "@types/geojson": "^7946.0.3",
-    "@types/react": "*",
     "@types/topojson-client": "^3.0.0",
     "@types/topojson-specification": "^1.0.0",
     "@vx/clip-path": "^0.0.197",
@@ -46,6 +45,7 @@
     "topojson-client": "^3.1.0"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.13.1"
   }
 }

--- a/plugins/plugin-chart-table/package.json
+++ b/plugins/plugin-chart-table/package.json
@@ -31,7 +31,6 @@
     "@superset-ui/core": "0.15.0",
     "@types/d3-array": "^2.0.0",
     "@types/match-sorter": "^4.0.0",
-    "@types/react": "*",
     "@types/react-table": "^7.0.19",
     "d3-array": "^2.4.0",
     "match-sorter": "^4.1.0",
@@ -42,6 +41,7 @@
     "xss": "^1.0.6"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   }

--- a/plugins/plugin-chart-word-cloud/package.json
+++ b/plugins/plugin-chart-word-cloud/package.json
@@ -32,13 +32,13 @@
     "@superset-ui/core": "0.15.0",
     "@types/d3-cloud": "^1.2.1",
     "@types/d3-scale": "^2.0.2",
-    "@types/react": "*",
     "d3-cloud": "^1.2.5",
     "d3-scale": "^3.0.1",
     "emotion-theming": "^10.0.27",
     "encodable": "^0.7.6"
   },
   "peerDependencies": {
+    "@types/react": "*",
     "react": "^16.13.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4237,10 +4237,10 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-bootstrap@0.32.21":
-  version "0.32.21"
-  resolved "https://registry.yarnpkg.com/@types/react-bootstrap/-/react-bootstrap-0.32.21.tgz#ac614f8c2f42bff9d7e1e01c2c3dddb22ff86e43"
-  integrity sha512-AV/6cMUBbKArEQcjXEzpoHexHi6hJL0cH3Vcw9qI4Ob2g/XFRvyTAFdMlGlp8HZmOHXL35PdF0K75Z31Po87qg==
+"@types/react-bootstrap@^0.32.22":
+  version "0.32.22"
+  resolved "https://registry.yarnpkg.com/@types/react-bootstrap/-/react-bootstrap-0.32.22.tgz#26a1a5a95ce46759672c56168b46de9e759d89c6"
+  integrity sha512-pjUVcJzogMxns3lbvMqnnU+I8EOYxl3aI13tS2vvRm0RdAe1rs7Ds/VZA29GI6p8p3Un6NqKUpW3+dgwAjyzxg==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
🏠 Internal


move @types/react to peerDependencies otherwise `npm link` will install `@types/react` in both ``superset-frontend/node_modules/@types/react` and `superset-frontned/@node_modules/@superset-ui/xxxx/node_modules/@types/react`. TSC (`npm run dev-server`) may throw errors with duplicate `@types/react` installations.