### PR TITLE
chore: url prop for MetricOption should be optional

### DIFF
--- a/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -37,7 +37,7 @@ export interface MetricOptionProps {
   openInNewWindow?: boolean;
   showFormula?: boolean;
   showType?: boolean;
-  url: string;
+  url?: string;
 }
 
 export function MetricOption({


### PR DESCRIPTION

🏠 Internal


Make `url` optional to suppress a `propTypes` check warning.