### PR TITLE
chore: move all superset-ui/core deps out of peerDependencies

### DIFF
--- a/plugins/legacy-plugin-chart-calendar/package.json
+++ b/plugins/legacy-plugin-chart-calendar/package.json
@@ -28,14 +28,14 @@
     "access": "public"
   },
   "dependencies": {
+    "@superset-ui/chart-controls": "0.15.1",
+    "@superset-ui/core": "0.15.1",
     "d3-array": "^2.0.3",
     "d3-selection": "^1.4.0",
     "d3-tip": "^0.9.1",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "@superset-ui/chart-controls": "^0.14.22",
-    "@superset-ui/core": "^0.14.22",
     "react": "^16.13.1"
   }
 }

--- a/plugins/legacy-plugin-chart-event-flow/package.json
+++ b/plugins/legacy-plugin-chart-event-flow/package.json
@@ -28,12 +28,12 @@
     "access": "public"
   },
   "dependencies": {
+    "@superset-ui/chart-controls": "0.15.1",
+    "@superset-ui/core": "0.15.1",
     "@data-ui/event-flow": "^0.0.84",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "@superset-ui/chart-controls": "^0.14.22",
-    "@superset-ui/core": "^0.14.22",
     "react": "^15 || ^16"
   }
 }

--- a/plugins/legacy-plugin-chart-rose/package.json
+++ b/plugins/legacy-plugin-chart-rose/package.json
@@ -28,13 +28,13 @@
     "access": "public"
   },
   "dependencies": {
+    "@superset-ui/chart-controls": "0.15.1",
+    "@superset-ui/core": "0.15.1",
     "d3": "^3.5.17",
     "nvd3": "1.8.6",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "@superset-ui/chart-controls": "^0.14.22",
-    "@superset-ui/core": "^0.14.22",
     "react": "^16.13.1"
   }
 }

--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -25,17 +25,13 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "react": "^16.13.1"
-  },
-  "devDependencies": {
-    "@types/jest": "^26.0.0",
-    "jest": "^26.0.1"
-  },
   "dependencies": {
     "@superset-ui/chart-controls": "0.15.1",
     "@superset-ui/core": "0.15.1",
     "@types/echarts": "^4.6.3",
     "echarts": "^4.9.0"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1"
   }
 }


### PR DESCRIPTION
🏠 Internal

Move all superset-ui/core deps out of peerDependencies so that `lerna` can update the dep versions automatically, avoiding "unmet peerDependency" errors in `incubator-superset`.