### PR TITLE
chore: add more props to DatasourceMeta for chart-controls

### DIFF
--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -61,13 +61,18 @@ export interface ColumnMeta extends AnyDict {
 
 export interface DatasourceMeta {
   id: number;
+  type: DatasourceType;
   columns: ColumnMeta[];
   metrics: Metric[];
-  type: DatasourceType;
+  column_format: Record<string, string>;
+  verbose_map: Record<string, string>;
   main_dttm_col: string;
-  time_grain_sqla: string;
   // eg. ['["ds", true]', 'ds [asc]']
   order_by_choices?: [string, string][] | null;
+  time_grain_sqla: [string, string][];
+  granularity_sqla: [string, string][];
+  datasource_name: string | null;
+  description: string | null;
 }
 
 export interface ControlPanelState {

--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -60,6 +60,7 @@ export interface ColumnMeta extends AnyDict {
 }
 
 export interface DatasourceMeta {
+  id: number;
   columns: ColumnMeta[];
   metrics: Metric[];
   type: DatasourceType;


### PR DESCRIPTION
🏆 Enhancements

More typing optimization for DatasourceMeta in chart-controls. We needed `datasource.id` for our internal Superset. But I decided to add more fields.

Fields are verified existent by examining component using React Dev Tools.