### PR TITLE
feat(plugin-chart-echarts): remove loading from timeseries tooltip

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -129,7 +129,7 @@ export default function transformProps(chartProps: ChartProps): EchartsTimeserie
     tooltip: {
       trigger: 'axis',
       confine: true,
-      formatter: (params, ticket, callback) => {
+      formatter: params => {
         // @ts-ignore
         const rows = [`${smartDateVerboseFormatter(params[0].value[0])}`];
         // @ts-ignore
@@ -144,10 +144,7 @@ export default function transformProps(chartProps: ChartProps): EchartsTimeserie
             }),
           );
         });
-        setTimeout(() => {
-          callback(ticket, rows.join('<br />'));
-        }, 50);
-        return 'loading';
+        return rows.join('<br />');
       },
     },
     legend: {


### PR DESCRIPTION
🏆 Enhancements
Removes the 50 ms wait on the Timeseries chart tooltip.

### AFTER
![tooltip-after](https://user-images.githubusercontent.com/33317356/93428352-f0c76080-f8c7-11ea-94b1-c342d13fdb74.gif)

### BEFORE
![tooltip-before](https://user-images.githubusercontent.com/33317356/93428364-f624ab00-f8c7-11ea-97f9-7ecdb08bf7fd.gif)
