### PR TITLE
fix(plugin-chart-word-cloud): make colors schemes work

### DIFF
--- a/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
+++ b/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 import cloudLayout, { Word } from 'd3-cloud';
 import { PlainObject, createEncoderFactory, DeriveEncoding } from 'encodable';
 import { SupersetThemeProps, withTheme } from '@superset-ui/core';
-import configureEncodable from '../configureEncodable';
-
-configureEncodable();
 
 export const ROTATION = {
   flat: () => 0,

--- a/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
+++ b/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import cloudLayout, { Word } from 'd3-cloud';
 import { PlainObject, createEncoderFactory, DeriveEncoding } from 'encodable';
 import { SupersetThemeProps, withTheme } from '@superset-ui/core';
+import configureEncodable from '../configureEncodable';
+
+configureEncodable();
 
 export const ROTATION = {
   flat: () => 0,

--- a/plugins/plugin-chart-word-cloud/src/plugin/index.ts
+++ b/plugins/plugin-chart-word-cloud/src/plugin/index.ts
@@ -4,6 +4,9 @@ import buildQuery from './buildQuery';
 import { WordCloudFormData } from '../types';
 import thumbnail from '../images/thumbnail.png';
 import controlPanel from './controlPanel';
+import configureEncodable from '../configureEncodable';
+
+configureEncodable();
 
 const metadata = new ChartMetadata({
   credits: ['https://github.com/jasondavies/d3-cloud'],

--- a/plugins/preset-chart-xy/src/BoxPlot/index.ts
+++ b/plugins/preset-chart-xy/src/BoxPlot/index.ts
@@ -20,6 +20,9 @@ import { ChartPlugin } from '@superset-ui/core';
 import createMetadata from './createMetadata';
 import transformProps from './transformProps';
 import controlPanel from './controlPanel';
+import configureEncodable from '../configureEncodable';
+
+configureEncodable();
 
 export default class BoxPlotChartPlugin extends ChartPlugin {
   constructor() {


### PR DESCRIPTION
🐛 Bug Fix
Currently the selected color scheme isn't being respected. This is probably a regression from #768. 

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/93434323-ab5b6100-f8d0-11ea-908e-aa9ef5bbfe0b.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/93434261-954da080-f8d0-11ea-92f6-a6c23884b1f6.png)

