### PR TITLE
fix: echarts formdata series -> groupby

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -40,7 +40,7 @@ export default function buildQuery(formData: QueryFormData) {
     return [
       {
         ...baseQueryObject,
-        groupby: formData.series,
+        groupby: formData.groupby,
         is_timeseries: true,
         post_processing: [
           {


### PR DESCRIPTION
🐛 Bug Fix

#772 introduced a regression where the missing property `formData.series` was mapped to `groupby`, instead of `formData.groupby`.
