### PR TITLE
fix(plugin-chart-echarts): fix incorrect groupby in buildQuery

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -40,7 +40,7 @@ export default function buildQuery(formData: QueryFormData) {
     return [
       {
         ...baseQueryObject,
-        groupby: formData.series,
+        groupby: formData.groupby || [],
         is_timeseries: true,
         post_processing: [
           {

--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.ts
@@ -16,12 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  t,
-  validateNonEmpty,
-  legacyValidateInteger,
-  legacyValidateNumber,
-} from '@superset-ui/core';
+import { t, legacyValidateInteger, legacyValidateNumber } from '@superset-ui/core';
 import { ControlPanelConfig } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
@@ -295,10 +290,6 @@ const config: ControlPanelConfig = {
     },
   },
   controlOverrides: {
-    series: {
-      validators: [validateNonEmpty],
-      clearable: false,
-    },
     row_limit: {
       default: 100,
     },

--- a/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
+++ b/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
@@ -22,7 +22,7 @@ describe('Timeseries buildQuery', () => {
   const formData = {
     datasource: '5__table',
     granularity_sqla: 'ds',
-    series: ['foo'],
+    groupby: ['foo'],
     metrics: ['bar', 'baz'],
     viz_type: 'my_chart',
   };

--- a/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -26,7 +26,7 @@ describe('EchartsTimeseries tranformProps', () => {
     datasource: '3__table',
     granularity_sqla: 'ds',
     metric: 'sum__num',
-    series: ['foo', 'bar'],
+    groupby: ['foo', 'bar'],
   };
   const chartProps = new ChartProps({
     formData,


### PR DESCRIPTION
🐛 Bug Fix
Fix a regression caused by party contradictory naming in controls/buildQuery.
