### PR TITLE
fix(legacy-preset-chart-nvd3): custom yAxisFormat for contribution

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -587,8 +587,14 @@ function nvd3Vis(element, props) {
 
     let yAxisFormatter = getTimeOrNumberFormatter(yAxisFormat);
     if (chart.yAxis && chart.yAxis.tickFormat) {
-      if (contribution || comparisonType === 'percentage') {
-        // When computing a "Percentage" or "Contribution" selected, we force a percentage format
+      if (
+        (contribution || comparisonType === 'percentage') &&
+        (!yAxisFormat ||
+          yAxisFormat === NumberFormats.SMART_NUMBER ||
+          yAxisFormat === NumberFormats.SMART_NUMBER_SIGNED)
+      ) {
+        // When computing a "Percentage" or "Contribution" selected,
+        // force a percentage format if no custom formatting set
         yAxisFormatter = getNumberFormatter(NumberFormats.PERCENT_1_POINT);
       }
       chart.yAxis.tickFormat(yAxisFormatter);


### PR DESCRIPTION
🐛 Bug Fix

Currently it's not possible to change the number formatting for when "contribution" is checked or using percentage comparison in line charts.


Let's allow that.

### Test plan

1. Go to a line chart in Superset
2. Check contribution or select a percentage comparison
    <img src="https://user-images.githubusercontent.com/335541/96027941-8560a800-0e0d-11eb-9c4d-7391292d2b8f.png" width="300">
3. Change y axis format in "Customize"

The format should apply. If there is not format selected or is using the default "Adaptive Formatting", the format should be 1 decimal percentages.
