### PR TITLE
feat(core): add applied_time_extras to QueryObject

### DIFF
--- a/packages/superset-ui-core/src/query/extractExtras.ts
+++ b/packages/superset-ui-core/src/query/extractExtras.ts
@@ -6,6 +6,7 @@ export default function extractExtras(formData: QueryFormData): Partial<QueryObj
   const partialQueryObject: Partial<QueryObject> = {
     filters: formData.filters || [],
     extras: formData.extras || {},
+    applied_time_extras: {},
   };
 
   const reservedColumnsToQueryField: Record<string, keyof QueryObject> = {
@@ -20,6 +21,8 @@ export default function extractExtras(formData: QueryFormData): Partial<QueryObj
     if (filter.col in reservedColumnsToQueryField) {
       const queryField = reservedColumnsToQueryField[filter.col];
       partialQueryObject[queryField] = filter.val;
+      // @ts-ignore
+      partialQueryObject.applied_time_extras[filter.col] = filter.val;
     } else {
       // @ts-ignore
       partialQueryObject.filters.push(filter);

--- a/packages/superset-ui-core/src/query/extractExtras.ts
+++ b/packages/superset-ui-core/src/query/extractExtras.ts
@@ -1,15 +1,18 @@
 /* eslint-disable camelcase */
 import { isDruidFormData, QueryFormData } from './types/QueryFormData';
 import { QueryObject } from './types/Query';
+import { AppliedTimeExtras, TimeColumnConfigKey } from './types/Time';
 
 export default function extractExtras(formData: QueryFormData): Partial<QueryObject> {
+  const applied_time_extras: AppliedTimeExtras = {};
+  const { extras = {}, filters = [] } = formData;
   const partialQueryObject: Partial<QueryObject> = {
-    filters: formData.filters || [],
-    extras: formData.extras || {},
-    applied_time_extras: {},
+    filters,
+    extras,
+    applied_time_extras,
   };
 
-  const reservedColumnsToQueryField: Record<string, keyof QueryObject> = {
+  const reservedColumnsToQueryField: Record<TimeColumnConfigKey, keyof QueryObject> = {
     __time_range: 'time_range',
     __time_col: 'granularity_sqla',
     __time_grain: 'time_grain_sqla',
@@ -19,28 +22,22 @@ export default function extractExtras(formData: QueryFormData): Partial<QueryObj
 
   (formData.extra_filters || []).forEach(filter => {
     if (filter.col in reservedColumnsToQueryField) {
-      const queryField = reservedColumnsToQueryField[filter.col];
+      const key = filter.col as TimeColumnConfigKey;
+      const queryField = reservedColumnsToQueryField[key];
       partialQueryObject[queryField] = filter.val;
-      // @ts-ignore
-      partialQueryObject.applied_time_extras[filter.col] = filter.val;
+      applied_time_extras[key] = filter.val as string;
     } else {
-      // @ts-ignore
-      partialQueryObject.filters.push(filter);
+      filters.push(filter);
     }
   });
 
   // map to undeprecated names and remove deprecated fields
   if (isDruidFormData(formData) && !partialQueryObject.druid_time_origin) {
-    partialQueryObject.extras = {
-      druid_time_origin: formData.druid_time_origin,
-    };
+    extras.druid_time_origin = formData.druid_time_origin;
     delete partialQueryObject.druid_time_origin;
   } else {
     // SQL
-    partialQueryObject.extras = {
-      ...partialQueryObject.extras,
-      time_grain_sqla: partialQueryObject.time_grain_sqla || formData.time_grain_sqla,
-    };
+    extras.time_grain_sqla = partialQueryObject.time_grain_sqla || formData.time_grain_sqla;
     partialQueryObject.granularity =
       partialQueryObject.granularity_sqla || formData.granularity || formData.granularity_sqla;
     delete partialQueryObject.granularity_sqla;
@@ -48,8 +45,7 @@ export default function extractExtras(formData: QueryFormData): Partial<QueryObj
   }
 
   // map time range endpoints:
-  if (formData.time_range_endpoints)
-    partialQueryObject.extras.time_range_endpoints = formData.time_range_endpoints;
+  if (formData.time_range_endpoints) extras.time_range_endpoints = formData.time_range_endpoints;
 
   return partialQueryObject;
 }

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -41,11 +41,24 @@ export type QueryObjectExtras = Partial<{
   where?: string;
 }>;
 
+export type QueryObjectAppliedTimeExtraKey =
+  | '__time_col'
+  | '__time_grain'
+  | '__time_range'
+  | '__time_origin'
+  | '__granularity';
+
+export type QueryObjectAppliedTimeExtras = {
+  QueryObjectAppliedTimeExtraKey?: string;
+};
+
 export type ResidualQueryObjectData = {
   [key: string]: unknown;
 };
 
 export type QueryObject = {
+  /** Extra filters that have been applied to the query object */
+  applied_time_extras?: QueryObjectAppliedTimeExtras;
   /** Columns to group by */
   groupby?: string[];
   /** Metrics */

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -2,7 +2,7 @@
 import { DatasourceType } from './Datasource';
 import { AdhocMetric } from './Metric';
 import { BinaryOperator, SetOperator, UnaryOperator } from './Operator';
-import { TimeRange } from './Time';
+import { AppliedTimeExtras, TimeRange } from './Time';
 import { QueryFormDataMetric, QueryFormResidualDataValue } from './QueryFormData';
 
 export type QueryObjectFilterClause = {
@@ -41,24 +41,13 @@ export type QueryObjectExtras = Partial<{
   where?: string;
 }>;
 
-export type QueryObjectAppliedTimeExtraKey =
-  | '__time_col'
-  | '__time_grain'
-  | '__time_range'
-  | '__time_origin'
-  | '__granularity';
-
-export type QueryObjectAppliedTimeExtras = {
-  QueryObjectAppliedTimeExtraKey?: string;
-};
-
 export type ResidualQueryObjectData = {
   [key: string]: unknown;
 };
 
 export type QueryObject = {
-  /** Extra filters that have been applied to the query object */
-  applied_time_extras?: QueryObjectAppliedTimeExtras;
+  /** Time filters that have been applied to the query object */
+  applied_time_extras?: AppliedTimeExtras;
   /** Columns to group by */
   groupby?: string[];
   /** Metrics */

--- a/packages/superset-ui-core/src/query/types/Time.ts
+++ b/packages/superset-ui-core/src/query/types/Time.ts
@@ -1,3 +1,5 @@
+import { QueryObject } from './Query';
+
 export type TimeRange = {
   /** Time range of the query [from, to] */
   // eslint-disable-next-line camelcase
@@ -5,3 +7,12 @@ export type TimeRange = {
   since?: string;
   until?: string;
 };
+
+export type TimeColumnConfigKey =
+  | '__time_col'
+  | '__time_grain'
+  | '__time_range'
+  | '__time_origin'
+  | '__granularity';
+
+export type AppliedTimeExtras = Partial<Record<TimeColumnConfigKey, keyof QueryObject>>;

--- a/packages/superset-ui-core/test/query/extractExtras.test.ts
+++ b/packages/superset-ui-core/test/query/extractExtras.test.ts
@@ -39,6 +39,11 @@ describe('extractExtras', () => {
         ],
       }),
     ).toEqual({
+      applied_time_extras: {
+        __time_col: 'ds2',
+        __time_grain: 'PT5M',
+        __time_range: '2009-07-17T00:00:00 : 2020-07-17T00:00:00',
+      },
       extras: {
         time_grain_sqla: 'PT5M',
         time_range_endpoints: ['inclusive', 'exclusive'],
@@ -68,6 +73,7 @@ describe('extractExtras', () => {
         ],
       }),
     ).toEqual({
+      applied_time_extras: {},
       extras: {
         time_grain_sqla: 'PT1M',
       },


### PR DESCRIPTION
🏆 Enhancements
Add `applied_time_extras` to `QueryObject` to be able to identify which filters have been set/overridden by `extra_filters`. Please see https://github.com/apache/incubator-superset/pull/11325 for additional context.