### PR TITLE
fix(plugin-chart-echarts): fix default y axis bounds

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -300,7 +300,7 @@ const config: ControlPanelConfig = {
               type: 'BoundsControl',
               label: t('Y Axis Bounds'),
               renderTrigger: true,
-              default: [null, null],
+              default: [undefined, undefined],
               description: t(
                 'Bounds for the Y-axis. When left empty, the bounds are ' +
                   'dynamically defined based on the min/max of the data. Note that ' +


### PR DESCRIPTION
🐛 Bug Fix
The default `yAxisBounds` are currently set to `null`, which evaluate to zero when passed to the `Number` function: (`Number(null) === 0`). The defaults were copied from the NVD3 control panel, but apparently there evaluating to zero isn't a problem.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/96427116-d6560f00-1206-11eb-9bf2-1265a0edd508.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/96427177-e4a42b00-1206-11eb-8e95-f7670b10471c.png)
