### PR TITLE
feat(core): add support for annotations and url params

### DIFF
--- a/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -18,6 +18,7 @@ export const DTTM_ALIAS = '__timestamp';
  */
 export default function buildQueryObject<T extends QueryFormData>(formData: T): QueryObject {
   const {
+    annotation_layers = [],
     time_range,
     since,
     until,
@@ -28,6 +29,7 @@ export default function buildQueryObject<T extends QueryFormData>(formData: T): 
     timeseries_limit_metric,
     queryFields,
     granularity,
+    url_params = {},
     ...residualFormData
   } = formData;
 
@@ -49,6 +51,7 @@ export default function buildQueryObject<T extends QueryFormData>(formData: T): 
     granularity,
     ...extras,
     ...extrasAndfilters,
+    annotation_layers,
     groupby: processGroupby(Array.from(groupbySet)),
     is_timeseries: groupbySet.has(DTTM_ALIAS),
     metrics: metrics.map(convertMetric),
@@ -60,5 +63,6 @@ export default function buildQueryObject<T extends QueryFormData>(formData: T): 
     timeseries_limit_metric: timeseries_limit_metric
       ? convertMetric(timeseries_limit_metric)
       : null,
+    url_params,
   };
 }

--- a/packages/superset-ui-core/src/query/index.ts
+++ b/packages/superset-ui-core/src/query/index.ts
@@ -25,6 +25,7 @@ export { default as convertFilter } from './convertFilter';
 export { default as convertMetric } from './convertMetric';
 export { default as DatasourceKey } from './DatasourceKey';
 
+export * from './types/AnnotationLayer';
 export * from './types/QueryFormData';
 export * from './types/Column';
 export * from './types/Datasource';

--- a/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
+++ b/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
@@ -1,0 +1,72 @@
+/* eslint camelcase: 0 */
+type BaseAnnotationLayer = {
+  color?: string | null;
+  name: string;
+  opacity?: '' | 'opacityLow' | 'opacityMedium' | 'opacityHigh';
+  show: boolean;
+  sourceType?: '';
+  style: 'dashed' | 'dotted' | 'solid' | 'longDashed';
+  width?: number;
+};
+
+type AnnotationOverrides = {
+  granularity?: string | null;
+  time_grain_sqla?: string | null;
+  time_range?: string | null;
+  time_shift?: string | null;
+};
+
+type LineSourceAnnotationLayer = {
+  hideLine?: boolean;
+  overrides?: AnnotationOverrides;
+  sourceType: 'line';
+  titleColumn: string;
+  // viz id
+  value: number;
+};
+
+type NativeSourceAnnotationLayer = {
+  sourceType: 'NATIVE';
+  // annotation id
+  value: number;
+};
+
+type TableSourceAnnotationLayer = {
+  descriptionColumns?: string[];
+  timeColumn?: string;
+  intervalEndColumn?: string;
+  overrides?: AnnotationOverrides;
+  sourceType: 'table';
+  titleColumn?: string;
+  // viz id
+  value: number;
+};
+
+export type EventAnnotationLayer = BaseAnnotationLayer &
+  (TableSourceAnnotationLayer | NativeSourceAnnotationLayer) & {
+    annotationType: 'EVENT';
+  };
+
+export type IntervalAnnotationLayer = BaseAnnotationLayer &
+  (TableSourceAnnotationLayer | NativeSourceAnnotationLayer) & {
+    annotationType: 'INTERVAL';
+  };
+
+export type FormulaAnnotationLayer = BaseAnnotationLayer & {
+  annotationType: 'FORMULA';
+  // the mathjs parseable formula
+  value: string;
+};
+
+export type TimeseriesAnnotationLayer = BaseAnnotationLayer &
+  LineSourceAnnotationLayer & {
+    annotationType: 'TIME_SERIES';
+    showMarkers?: boolean;
+    value: number;
+  };
+
+export type AnnotationLayer =
+  | EventAnnotationLayer
+  | IntervalAnnotationLayer
+  | FormulaAnnotationLayer
+  | TimeseriesAnnotationLayer;

--- a/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
+++ b/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
@@ -4,7 +4,6 @@ type BaseAnnotationLayer = {
   name: string;
   opacity?: '' | 'opacityLow' | 'opacityMedium' | 'opacityHigh';
   show: boolean;
-  sourceType?: '';
   style: 'dashed' | 'dotted' | 'solid' | 'longDashed';
   width?: number;
 };
@@ -55,6 +54,7 @@ export type IntervalAnnotationLayer = BaseAnnotationLayer &
 export type FormulaAnnotationLayer = BaseAnnotationLayer & {
   annotationType: 'FORMULA';
   // the mathjs parseable formula
+  sourceType?: '';
   value: string;
 };
 
@@ -70,3 +70,23 @@ export type AnnotationLayer =
   | IntervalAnnotationLayer
   | FormulaAnnotationLayer
   | TimeseriesAnnotationLayer;
+
+export function isFormulaAnnotationLayer(layer: AnnotationLayer): layer is FormulaAnnotationLayer {
+  return layer.annotationType === 'FORMULA';
+}
+
+export function isEventAnnotationLayer(layer: EventAnnotationLayer): layer is EventAnnotationLayer {
+  return layer.annotationType === 'EVENT';
+}
+
+export function isIntervalAnnotationLayer(
+  layer: IntervalAnnotationLayer,
+): layer is IntervalAnnotationLayer {
+  return layer.annotationType === 'INTERVAL';
+}
+
+export function isTimeseriesAnnotationLayer(
+  layer: AnnotationLayer,
+): layer is TimeseriesAnnotationLayer {
+  return layer.annotationType === 'TIME_SERIES';
+}

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -3,6 +3,7 @@ import { DatasourceType } from './Datasource';
 import { AdhocMetric } from './Metric';
 import { BinaryOperator, SetOperator, UnaryOperator } from './Operator';
 import { AppliedTimeExtras, TimeRange } from './Time';
+import { AnnotationLayer } from './AnnotationLayer';
 import { QueryFormDataMetric, QueryFormResidualDataValue } from './QueryFormData';
 
 export type QueryObjectFilterClause = {
@@ -46,6 +47,7 @@ export type ResidualQueryObjectData = {
 };
 
 export type QueryObject = {
+  annotation_layers?: AnnotationLayer[];
   /** Time filters that have been applied to the query object */
   applied_time_extras?: AppliedTimeExtras;
   /** Columns to group by */
@@ -82,6 +84,7 @@ export type QueryObject = {
 
   /** If set, will group by timestamp */
   is_timeseries?: boolean;
+  url_params?: Record<string, string>;
 } & TimeRange &
   ResidualQueryObjectData;
 

--- a/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -4,6 +4,7 @@ import { AdhocMetric } from './Metric';
 import { TimeRange } from './Time';
 import { AdhocFilter } from './Filter';
 import { BinaryOperator, SetOperator } from './Operator';
+import { AnnotationLayer } from './AnnotationLayer';
 
 export type QueryFormDataMetric = string | AdhocMetric;
 export type QueryFormResidualDataValue = string | AdhocMetric;
@@ -72,6 +73,8 @@ export type BaseFormData = {
   result_type?: string;
   queryFields?: QueryFields;
   time_range_endpoints?: TimeRangeEndpoints;
+  annotation_layers?: AnnotationLayer[];
+  url_params?: Record<string, string>;
 } & TimeRange &
   QueryFormResidualData;
 

--- a/packages/superset-ui-core/test/query/buildQueryObject.test.ts
+++ b/packages/superset-ui-core/test/query/buildQueryObject.test.ts
@@ -1,4 +1,4 @@
-import { buildQueryObject, QueryObject } from '@superset-ui/core/src/query';
+import { AnnotationLayer, buildQueryObject, QueryObject } from '@superset-ui/core/src/query';
 
 describe('buildQueryObject', () => {
   let query: QueryObject;
@@ -119,5 +119,65 @@ describe('buildQueryObject', () => {
     query = buildQueryObject({ ...baseQuery, row_limit: 'two hundred', row_offset: 'twenty' });
     expect(query.row_limit).toBeUndefined();
     expect(query.row_offset).toBeUndefined();
+  });
+
+  it('should populate annotation_layers', () => {
+    const annotationLayers: AnnotationLayer[] = [
+      {
+        annotationType: 'FORMULA',
+        color: '#ff7f44',
+        name: 'My Formula',
+        opacity: 'opacityLow',
+        show: true,
+        style: 'solid',
+        value: '10*sin(x)',
+        width: 1,
+      },
+      {
+        annotationType: 'INTERVAL',
+        color: null,
+        descriptionColumns: [],
+        name: 'My Interval',
+        overrides: { time_range: null },
+        sourceType: 'NATIVE',
+        style: 'dashed',
+        value: 1,
+        width: 100,
+      },
+      {
+        annotationType: 'EVENT',
+        color: null,
+        descriptionColumns: [],
+        name: 'My Interval',
+        overrides: {
+          granularity: null,
+          time_grain_sqla: null,
+          time_range: null,
+        },
+        sourceType: 'table',
+        timeColumn: 'ds',
+        style: 'dashed',
+        value: 'asdf',
+        width: 100,
+      },
+    ];
+    query = buildQueryObject({
+      datasource: '5__table',
+      granularity_sqla: 'ds',
+      viz_type: 'table',
+      annotation_layers: annotationLayers,
+    });
+    expect(query.annotation_layers).toEqual(annotationLayers);
+  });
+
+  it('should populate url_params', () => {
+    const urlParams = { abc: '123' };
+    query = buildQueryObject({
+      datasource: '5__table',
+      granularity_sqla: 'ds',
+      viz_type: 'table',
+      url_params: urlParams,
+    });
+    expect(query.url_params).toEqual(urlParams);
   });
 });

--- a/packages/superset-ui-core/test/query/types/AnnotationFilter.test.ts
+++ b/packages/superset-ui-core/test/query/types/AnnotationFilter.test.ts
@@ -1,0 +1,108 @@
+import {
+  isEventAnnotationLayer,
+  isFormulaAnnotationLayer,
+  isIntervalAnnotationLayer,
+  isTimeseriesAnnotationLayer,
+} from '@superset-ui/core/src/query/types/AnnotationLayer';
+
+describe('AnnotationLayer type guards', () => {
+  describe('isFormulaAnnotationLayer', () => {
+    it('should return true when it is the correct type', () => {
+      expect(
+        isFormulaAnnotationLayer({
+          annotationType: 'FORMULA',
+          name: 'My Formula',
+          value: 'sin(2*x)',
+          style: 'solid',
+          show: true,
+        }),
+      ).toEqual(true);
+    });
+    it('should return false otherwise', () => {
+      expect(
+        isFormulaAnnotationLayer({
+          annotationType: 'EVENT',
+          name: 'My Event',
+          value: 1,
+          style: 'solid',
+          show: true,
+        }),
+      ).toEqual(false);
+    });
+  });
+
+  describe('isEventAnnotationLayer', () => {
+    it('should return true when it is the correct type', () => {
+      expect(
+        isEventAnnotationLayer({
+          annotationType: 'EVENT',
+          name: 'My Event',
+          value: 1,
+          style: 'solid',
+          show: true,
+        }),
+      ).toEqual(true);
+    });
+    it('should return false otherwise', () => {
+      expect(
+        isEventAnnotationLayer({
+          annotationType: 'FORMULA',
+          name: 'My Formula',
+          value: 'sin(2*x)',
+          style: 'solid',
+          show: true,
+        }),
+      ).toEqual(false);
+    });
+  });
+
+  describe('isIntervalAnnotationLayer', () => {
+    it('should return true when it is the correct type', () => {
+      expect(
+        isIntervalAnnotationLayer({
+          annotationType: 'INTERVAL',
+          name: 'My Event',
+          value: 1,
+          style: 'solid',
+          show: true,
+        }),
+      ).toEqual(true);
+    });
+    it('should return false otherwise', () => {
+      expect(
+        isEventAnnotationLayer({
+          annotationType: 'FORMULA',
+          name: 'My Formula',
+          value: 'sin(2*x)',
+          style: 'solid',
+          show: true,
+        }),
+      ).toEqual(false);
+    });
+  });
+
+  describe('isTimeseriesAnnotationLayer', () => {
+    it('should return true when it is the correct type', () => {
+      expect(
+        isTimeseriesAnnotationLayer({
+          annotationType: 'TIME_SERIES',
+          name: 'My Event',
+          value: 1,
+          style: 'solid',
+          show: true,
+        }),
+      ).toEqual(true);
+    });
+    it('should return false otherwise', () => {
+      expect(
+        isTimeseriesAnnotationLayer({
+          annotationType: 'FORMULA',
+          name: 'My Formula',
+          value: 'sin(2*x)',
+          style: 'solid',
+          show: true,
+        }),
+      ).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
Add support for `url_params` and `annotation_layers` to `QueryFormData` and `QueryObject`. The `AnnotationLayer` schema corresponds to that generated by `AnnotationLayerControl` in `superset-ui`.