### PR TITLE
fix(plugin-chart-echarts): improve yAxisBounds parsing

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -24,6 +24,7 @@ import {
 } from '@superset-ui/core';
 import { EchartsTimeseriesProps } from './types';
 import { ForecastSeriesEnum } from '../types';
+import { parseYAxisBound } from '../utils/controls';
 import { extractTimeseriesSeries } from '../utils/series';
 import {
   extractForecastSeriesContext,
@@ -113,10 +114,8 @@ export default function transformProps(chartProps: ChartProps): EchartsTimeserie
       });
   });
 
-  // yAxisBounds sometimes starts returning NaNs, which messes up the u-axis
-  let [min, max] = (yAxisBounds || [])
-    .map(Number)
-    .map((val: number) => (Number.isNaN(val) ? undefined : val));
+  // yAxisBounds need to be parsed to replace incompatible values with undefined
+  let [min, max] = (yAxisBounds || []).map(parseYAxisBound);
 
   // default to 0-100% range when doing row-level contribution chart
   if (contributionMode === 'row' && stack) {

--- a/plugins/plugin-chart-echarts/src/utils/controls.ts
+++ b/plugins/plugin-chart-echarts/src/utils/controls.ts
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function parseYAxisBound(bound?: string | number | null): number | undefined {
+  if (bound === undefined || bound === null || Number.isNaN(Number(bound))) {
+    return undefined;
+  }
+  return Number(bound);
+}

--- a/plugins/plugin-chart-echarts/test/utils/controls.test.ts
+++ b/plugins/plugin-chart-echarts/test/utils/controls.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { parseYAxisBound } from '../../src/utils/controls';
+
+describe('parseYAxisBound', () => {
+  it('should return undefined for invalid values', () => {
+    expect(parseYAxisBound(null)).toBeUndefined();
+    expect(parseYAxisBound(undefined)).toBeUndefined();
+    expect(parseYAxisBound(NaN)).toBeUndefined();
+    expect(parseYAxisBound('abc')).toBeUndefined();
+  });
+
+  it('should return numeric value for valid values', () => {
+    expect(parseYAxisBound(0)).toEqual(0);
+    expect(parseYAxisBound('0')).toEqual(0);
+    expect(parseYAxisBound(1)).toEqual(1);
+    expect(parseYAxisBound('1')).toEqual(1);
+    expect(parseYAxisBound(10.1)).toEqual(10.1);
+    expect(parseYAxisBound('10.1')).toEqual(10.1);
+  });
+});


### PR DESCRIPTION
🐛 Bug Fix
Currently the `YAxisBoundsControl` will initialize with `null` values despite being passed `undefined`, causing trouble when setting the y axis bounds. This improves the parsing of said values prior to using them so Y-axis bounds are always either undefined or valid values.

### Before
![image](https://user-images.githubusercontent.com/33317356/97408967-8c0b1700-1905-11eb-92b7-dfdbe4e9f914.png)

### After
![image](https://user-images.githubusercontent.com/33317356/97408919-7bf33780-1905-11eb-945e-e7e0871ad521.png)
