### PR TITLE
fix(plugin-chart-echarts): disable pie chart animation

### DIFF
--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -130,6 +130,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     series: [
       {
         type: 'pie',
+        animation: false,
         radius: [`${donut ? innerRadius : 0}%`, `${outerRadius}%`],
         center: ['50%', '50%'],
         avoidLabelOverlap: true,


### PR DESCRIPTION
🏆 Enhancements
Disable animation in Pie Chart.

### Before
![piebefore](https://user-images.githubusercontent.com/33317356/97407461-5ebd6980-1903-11eb-83ca-f3b49afecee0.gif)

### After
![pieafter](https://user-images.githubusercontent.com/33317356/97407491-65e47780-1903-11eb-802b-f1601b1cdcda.gif)
