### PR TITLE
fix(chart-controls): move @superset-ui/core to a peerDependency

### DIFF
--- a/packages/superset-ui-chart-controls/package.json
+++ b/packages/superset-ui-chart-controls/package.json
@@ -26,11 +26,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/core": "0.15.10",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
+    "@superset-ui/core": "0.15.10",
     "@types/react": "*",
     "@types/react-bootstrap": "*",
     "react": "^16.13.1",


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix

I _think_ this fixes the warnings we're seeing in the superset test suite, but I'm not totally sure because `npm link` hasn't been working for me

<img width="844" alt="Screen Shot 2020-10-29 at 11 44 03 PM" src="https://user-images.githubusercontent.com/1858430/97736407-dec90800-1a98-11eb-9536-ac61c0cec565.png">


🏠 Internal
