### PR TITLE
feat(legacy-plugin-chart-sankey): allow sort by metric

### DIFF
--- a/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts
@@ -17,13 +17,46 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
+import { ControlPanelConfig } from '@superset-ui/chart-controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
     {
       label: t('Query'),
       expanded: true,
-      controlSetRows: [['groupby'], ['metric'], ['adhoc_filters'], ['row_limit']],
+      controlSetRows: [
+        [
+          {
+            name: 'groupby',
+            override: {
+              label: t('Source / Target'),
+              description: t('Choose a source and a target'),
+            },
+          },
+        ],
+        ['metric'],
+        ['adhoc_filters'],
+        [
+          {
+            name: 'row_limit',
+            override: {
+              description: t(
+                'Limiting rows may result in incomplete data and misleading charts. Consider filtering or grouping source/target names instead.',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'sort_by_metric',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort by metric'),
+              description: t('Whether to sort results by the selected metric in descending order.'),
+            },
+          },
+        ],
+      ],
     },
     {
       label: t('Chart Options'),
@@ -31,10 +64,6 @@ export default {
       controlSetRows: [['color_scheme', 'label_colors']],
     },
   ],
-  controlOverrides: {
-    groupby: {
-      label: t('Source / Target'),
-      description: t('Choose a source and a target'),
-    },
-  },
 };
+
+export default config;


### PR DESCRIPTION
🏆 Enhancements

Adding a "Sort by metric" checkbox control for Sankey chart. If selected, the query results will be sorted by metric in descending order. This is useful when there are many rows of data but it's not easy to regroup source and targets via custom SQL queries (e.g. when working with a datasource that does not support arbitrary SQL queries).

<img src="https://user-images.githubusercontent.com/335541/98601024-4c441800-2293-11eb-8225-2708be52f2b4.png" width="300">

Also added a caveat warning for row limit:

<img src="https://user-images.githubusercontent.com/335541/98601030-4f3f0880-2293-11eb-903e-461cd6b7b428.png" width="300">
