### PR TITLE
feat(plugin-chart-echarts): add legend customization options

### DIFF
--- a/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Pie/Stories.tsx
+++ b/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Pie/Stories.tsx
@@ -29,15 +29,15 @@ export const WeekdayPie = ({ width, height }) => {
         numberFormat: 'SMART_NUMBER',
         donut: boolean('Donut', false),
         innerRadius: number('Inner Radius', 30),
-        outerRadius: number('Outer Radius', 50),
+        outerRadius: number('Outer Radius', 70),
         labelsOutside: boolean('Labels outside', true),
         labelLine: boolean('Label line', true),
         showLabels: boolean('Show labels', true),
         showLegend: boolean('Show legend', false),
-        pieLabelType: select(
+        labelType: select(
           'Pie label type',
           ['key', 'value', 'percent', 'key_value', 'key_percent', 'key_value_percent'],
-          'key_value_percent',
+          'key',
         ),
       }}
     />
@@ -58,15 +58,15 @@ export const PopulationPie = ({ width, height }) => {
         numberFormat: 'SMART_NUMBER',
         donut: boolean('Donut', false),
         innerRadius: number('Inner Radius', 30),
-        outerRadius: number('Outer Radius', 50),
+        outerRadius: number('Outer Radius', 70),
         labelsOutside: boolean('Labels outside', false),
-        labelLine: boolean('Label line', false),
+        labelLine: boolean('Label line', true),
         showLabels: boolean('Show labels', true),
         showLegend: boolean('Show legend', false),
-        pieLabelType: select(
+        labelType: select(
           'Pie label type',
           ['key', 'value', 'percent', 'key_value', 'key_percent', 'key_value_percent'],
-          'key_value_percent',
+          'key',
         ),
       }}
     />

--- a/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
@@ -16,8 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import React from 'react';
 import { t, validateNonEmpty } from '@superset-ui/core';
 import { ControlPanelConfig, D3_FORMAT_OPTIONS, sections } from '@superset-ui/chart-controls';
+import { DEFAULT_FORM_DATA } from './types';
+import {
+  legendMarginControl,
+  legendOrientationControl,
+  legendTypeControl,
+  showLegendControl,
+} from '../controls';
+
+const {
+  donut,
+  innerRadius,
+  labelsOutside,
+  labelType,
+  labelLine,
+  outerRadius,
+  numberFormat,
+  showLabels,
+} = DEFAULT_FORM_DATA;
 
 const noopControl = { name: 'noop', config: { type: '', renderTrigger: true } };
 
@@ -33,13 +52,21 @@ const config: ControlPanelConfig = {
       label: t('Chart Options'),
       expanded: true,
       controlSetRows: [
+        ['color_scheme', noopControl],
+        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Legend')}</h1>],
+        [showLegendControl],
+        [legendTypeControl, legendOrientationControl],
+        [legendMarginControl, noopControl],
+        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Labels')}</h1>],
         [
           {
             name: 'pie_label_type',
             config: {
               type: 'SelectControl',
               label: t('Label Type'),
-              default: 'key',
+              default: labelType,
               renderTrigger: true,
               choices: [
                 ['key', 'Category Name'],
@@ -59,33 +86,11 @@ const config: ControlPanelConfig = {
               freeForm: true,
               label: t('Number format'),
               renderTrigger: true,
-              default: 'SMART_NUMBER',
+              default: numberFormat,
               choices: D3_FORMAT_OPTIONS,
               description: `${t('D3 format syntax: https://github.com/d3/d3-format')} ${t(
                 'Only applies when "Label Type" is set to show values.',
               )}`,
-            },
-          },
-        ],
-        [
-          {
-            name: 'donut',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Donut'),
-              default: false,
-              renderTrigger: true,
-              description: t('Do you want a donut or a pie?'),
-            },
-          },
-          {
-            name: 'show_legend',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Legend'),
-              renderTrigger: true,
-              default: true,
-              description: t('Whether to display a legend for the chart'),
             },
           },
         ],
@@ -96,7 +101,7 @@ const config: ControlPanelConfig = {
               type: 'CheckboxControl',
               label: t('Show Labels'),
               renderTrigger: true,
-              default: true,
+              default: showLabels,
               description: t('Whether to display the labels.'),
             },
           },
@@ -107,7 +112,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'CheckboxControl',
               label: t('Put labels outside'),
-              default: true,
+              default: labelsOutside,
               renderTrigger: true,
               description: t('Put the labels outside of the pie?'),
             },
@@ -117,13 +122,14 @@ const config: ControlPanelConfig = {
             config: {
               type: 'CheckboxControl',
               label: t('Label Line'),
-              default: false,
+              default: labelLine,
               renderTrigger: true,
               description: t('Draw line from Pie to label when labels outside?'),
             },
           },
         ],
-        ['color_scheme', noopControl],
+        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Pie shape')}</h1>],
         [
           {
             name: 'outerRadius',
@@ -134,8 +140,21 @@ const config: ControlPanelConfig = {
               min: 10,
               max: 100,
               step: 1,
-              default: 80,
+              default: outerRadius,
               description: t('Outer edge of Pie chart'),
+            },
+          },
+          noopControl,
+        ],
+        [
+          {
+            name: 'donut',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Donut'),
+              default: donut,
+              renderTrigger: true,
+              description: t('Do you want a donut or a pie?'),
             },
           },
         ],
@@ -149,10 +168,11 @@ const config: ControlPanelConfig = {
               min: 0,
               max: 100,
               step: 1,
-              default: 30,
+              default: innerRadius,
               description: t('Inner radius of donut hole'),
             },
           },
+          noopControl,
         ],
       ],
     },

--- a/plugins/plugin-chart-echarts/src/Pie/types.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/types.ts
@@ -16,25 +16,47 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryFormData } from '@superset-ui/core';
+import {
+  DEFAULT_LEGEND_FORM_DATA,
+  EchartsLegendFormData,
+  LegendOrientation,
+  LegendType,
+} from '../types';
 
-export type PieChartFormData = QueryFormData & {
-  groupby: string[];
-  metric: string;
-  outerRadius?: number;
-  innerRadius?: number;
+export type EchartsPieFormData = EchartsLegendFormData & {
   colorScheme?: string;
-  donut?: boolean;
-  showLegend?: boolean;
-  showLabels?: boolean;
-  labelsOutside?: boolean;
-  numberFormat?: string;
+  donut: boolean;
+  groupby: string[];
+  innerRadius: number;
+  labelLine: boolean;
+  labelType: EchartsPieLabelType;
+  labelsOutside: boolean;
+  metric?: string;
+  outerRadius: number;
+  showLabels: boolean;
+  numberFormat: string;
 };
 
-export type EchartsPieLabelType =
-  | 'key'
-  | 'value'
-  | 'percent'
-  | 'key_value'
-  | 'key_percent'
-  | 'key_value_percent';
+export enum EchartsPieLabelType {
+  Key = 'key',
+  Value = 'value',
+  Percent = 'percent',
+  KeyValue = 'key_value',
+  KeyPercent = 'key_percent',
+  KeyValuePercent = 'key_value_percent',
+}
+
+export const DEFAULT_FORM_DATA: EchartsPieFormData = {
+  ...DEFAULT_LEGEND_FORM_DATA,
+  donut: false,
+  groupby: [],
+  innerRadius: 30,
+  labelLine: false,
+  labelType: EchartsPieLabelType.Key,
+  legendOrientation: LegendOrientation.Top,
+  legendType: LegendType.Scroll,
+  numberFormat: 'SMART_NUMBER',
+  outerRadius: 70,
+  showLabels: true,
+  labelsOutside: true,
+};

--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -25,6 +25,13 @@ import {
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
 } from './types';
+import {
+  legendMarginControl,
+  legendOrientationControl,
+  legendTypeControl,
+  noopControl,
+  showLegendControl,
+} from '../controls';
 
 const {
   area,
@@ -301,7 +308,10 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Legend')}</h1>],
+        [showLegendControl],
+        [legendTypeControl, legendOrientationControl],
+        [legendMarginControl, noopControl],
         [<h1 className="section-header">{t('X Axis')}</h1>],
         ['x_axis_time_format'],
         [
@@ -328,7 +338,6 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        // eslint-disable-next-line react/jsx-key
         [<h1 className="section-header">{t('Y Axis')}</h1>],
         ['y_axis_format'],
         [

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -36,7 +36,7 @@ import {
 import { DEFAULT_FORM_DATA, EchartsTimeseriesFormData } from './types';
 import { EchartsProps, ForecastSeriesEnum } from '../types';
 import { parseYAxisBound } from '../utils/controls';
-import { extractTimeseriesSeries } from '../utils/series';
+import { extractTimeseriesSeries, getChartPadding, getLegendProps } from '../utils/series';
 import { extractAnnotationLabels } from '../utils/annotation';
 import {
   extractForecastSeriesContext,
@@ -65,9 +65,13 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     annotationLayers,
     colorScheme,
     contributionMode,
+    legendMargin,
+    legendOrientation,
+    legendType,
     logAxis,
-    stack,
     minorSplitLine,
+    showLegend,
+    stack,
     truncateYAxis,
     yAxisFormat,
     xAxisShowMinLabel,
@@ -122,15 +126,16 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     if (min === undefined) min = 0;
     if (max === undefined) max = 1;
   }
-
   const echartOptions: echarts.EChartOption = {
     useUTC: true,
     grid: {
       ...defaultGrid,
-      top: 30,
-      bottom: zoomable ? 80 : 0,
-      left: 20,
-      right: 20,
+      ...getChartPadding(showLegend, legendOrientation, legendMargin, {
+        top: 20,
+        bottom: zoomable ? 80 : 20,
+        left: 20,
+        right: 20,
+      }),
     },
     xAxis: {
       type: 'time',
@@ -184,6 +189,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
       },
     },
     legend: {
+      ...getLegendProps(legendType, legendOrientation, showLegend),
       data: rawSeries
         .filter(
           entry =>
@@ -191,7 +197,6 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
         )
         .map(entry => entry.name || '')
         .concat(extractAnnotationLabels(annotationLayers, annotationData)),
-      right: zoomable ? 80 : 'auto',
     },
     series,
     toolbox: {

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { AnnotationLayer, TimeGranularity } from '@superset-ui/core';
+import { DEFAULT_LEGEND_FORM_DATA, EchartsLegendFormData } from '../types';
 
 export enum EchartsTimeseriesContributionType {
   Row = 'row',
@@ -61,9 +62,10 @@ export type EchartsTimeseriesFormData = {
   timeGrainSqla?: TimeGranularity;
   yAxisBounds: [number | undefined | null, number | undefined | null];
   zoomable: boolean;
-};
+} & EchartsLegendFormData;
 
 export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
+  ...DEFAULT_LEGEND_FORM_DATA,
   annotationLayers: [],
   area: false,
   forecastEnabled: false,
@@ -72,15 +74,15 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   forecastSeasonalityDaily: null,
   forecastSeasonalityWeekly: null,
   forecastSeasonalityYearly: null,
-  seriesType: EchartsTimeseriesSeriesType.Line,
   logAxis: false,
-  opacity: 0.2,
-  orderDesc: true,
-  stack: false,
   markerEnabled: false,
   markerSize: 6,
   minorSplitLine: false,
+  opacity: 0.2,
+  orderDesc: true,
   rowLimit: 10000,
+  seriesType: EchartsTimeseriesSeriesType.Line,
+  stack: false,
   truncateYAxis: true,
   yAxisBounds: [null, null],
   xAxisShowMinLabel: true,

--- a/plugins/plugin-chart-echarts/src/controls.ts
+++ b/plugins/plugin-chart-echarts/src/controls.ts
@@ -1,0 +1,81 @@
+import { t } from '@superset-ui/core';
+import { DEFAULT_LEGEND_FORM_DATA } from './types';
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+const { legendMargin, legendOrientation, legendType, showLegend } = DEFAULT_LEGEND_FORM_DATA;
+
+export const noopControl = { name: 'noop', config: { type: '', renderTrigger: true } };
+
+export const showLegendControl = {
+  name: 'show_legend',
+  config: {
+    type: 'CheckboxControl',
+    label: t('Legend'),
+    renderTrigger: true,
+    default: showLegend,
+    description: t('Whether to display a legend for the chart'),
+  },
+};
+
+export const legendMarginControl = {
+  name: 'legendMargin',
+  config: {
+    type: 'TextControl',
+    label: t('Margin'),
+    renderTrigger: true,
+    isInt: true,
+    default: legendMargin,
+    description: t('Additional padding for legend.'),
+  },
+};
+
+export const legendTypeControl = {
+  name: 'legendType',
+  config: {
+    type: 'SelectControl',
+    freeForm: false,
+    label: 'Type',
+    choices: [
+      ['scroll', 'Scroll'],
+      ['plain', 'Plain'],
+    ],
+    default: legendType,
+    renderTrigger: true,
+    description: t('Legend type'),
+  },
+};
+
+export const legendOrientationControl = {
+  name: 'legendOrientation',
+  config: {
+    type: 'SelectControl',
+    freeForm: false,
+    label: 'Orientation',
+    choices: [
+      ['top', 'Top'],
+      ['bottom', 'Bottom'],
+      ['left', 'Left'],
+      ['right', 'Right'],
+    ],
+    default: legendOrientation,
+    renderTrigger: true,
+    description: t('Legend type'),
+  },
+};

--- a/plugins/plugin-chart-echarts/src/defaults.ts
+++ b/plugins/plugin-chart-echarts/src/defaults.ts
@@ -1,3 +1,5 @@
+import { LegendOrientation } from './types';
+
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -26,4 +28,11 @@ export const defaultTooltip = {
 
 export const defaultYAxis = {
   scale: true,
+};
+
+export const defaultLegendPadding = {
+  [LegendOrientation.Top]: 20,
+  [LegendOrientation.Bottom]: 20,
+  [LegendOrientation.Left]: 170,
+  [LegendOrientation.Right]: 170,
 };

--- a/plugins/plugin-chart-echarts/src/types.ts
+++ b/plugins/plugin-chart-echarts/src/types.ts
@@ -39,10 +39,36 @@ export type ForecastSeriesContext = {
   type: ForecastSeriesEnum;
 };
 
+export enum LegendOrientation {
+  Top = 'top',
+  Bottom = 'bottom',
+  Left = 'left',
+  Right = 'right',
+}
+
+export enum LegendType {
+  Scroll = 'scroll',
+  Plain = 'plain',
+}
+
 export type ProphetValue = {
   marker: string;
   observation?: number;
   forecastTrend?: number;
   forecastLower?: number;
   forecastUpper?: number;
+};
+
+export type EchartsLegendFormData = {
+  legendMargin: number | null | string;
+  legendOrientation: LegendOrientation.Top;
+  legendType: LegendType;
+  showLegend: boolean;
+};
+
+export const DEFAULT_LEGEND_FORM_DATA: EchartsLegendFormData = {
+  legendMargin: null,
+  legendOrientation: LegendOrientation.Top,
+  legendType: LegendType.Scroll,
+  showLegend: false,
 };

--- a/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -25,6 +25,8 @@ import {
   TimeseriesDataRecord,
 } from '@superset-ui/core';
 import { NULL_STRING } from '../constants';
+import { LegendOrientation, LegendType } from '../types';
+import { defaultLegendPadding } from '../defaults';
 
 export function extractTimeseriesSeries(
   data: TimeseriesDataRecord[],
@@ -85,4 +87,63 @@ export function extractGroupbyLabel({
   return (groupby || [])
     .map(val => formatSeriesName(datum[val], { numberFormatter, timeFormatter }))
     .join(', ');
+}
+
+export function getLegendProps(
+  type: LegendType,
+  orientation: LegendOrientation,
+  show: boolean,
+): echarts.EChartOption.Legend {
+  const legend: echarts.EChartOption.Legend = {
+    orient: [LegendOrientation.Top, LegendOrientation.Bottom].includes(orientation)
+      ? 'horizontal'
+      : 'vertical',
+    show,
+    type,
+  };
+  switch (orientation) {
+    case LegendOrientation.Left:
+      legend.left = 0;
+      break;
+    case LegendOrientation.Right:
+      legend.right = 0;
+      break;
+    case LegendOrientation.Bottom:
+      legend.bottom = 0;
+      break;
+    case LegendOrientation.Top:
+    default:
+      legend.top = 0;
+      break;
+  }
+  return legend;
+}
+
+export function getChartPadding(
+  show: boolean,
+  orientation: LegendOrientation,
+  margin?: string | number | null,
+  padding?: { top?: number; bottom?: number; left?: number; right?: number },
+): {
+  bottom: number;
+  left: number;
+  right: number;
+  top: number;
+} {
+  let legendMargin;
+  if (!show) {
+    legendMargin = 0;
+  } else if (margin === null || margin === undefined || typeof margin === 'string') {
+    legendMargin = defaultLegendPadding[orientation];
+  } else {
+    legendMargin = margin;
+  }
+
+  const { bottom = 0, left = 0, right = 0, top = 0 } = padding || {};
+  return {
+    left: left + (orientation === LegendOrientation.Left ? legendMargin : 0),
+    right: right + (orientation === LegendOrientation.Right ? legendMargin : 0),
+    top: top + (orientation === LegendOrientation.Top ? legendMargin : 0),
+    bottom: bottom + (orientation === LegendOrientation.Bottom ? legendMargin : 0),
+  };
 }

--- a/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
+++ b/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
@@ -18,6 +18,7 @@
  */
 import { ChartProps, getNumberFormatter } from '@superset-ui/core';
 import transformProps, { formatPieLabel } from '../../src/Pie/transformProps';
+import { EchartsPieLabelType } from '../../src/Pie/types';
 
 describe('Pie tranformProps', () => {
   const formData = {
@@ -72,17 +73,23 @@ describe('formatPieLabel', () => {
   it('should generate a valid pie chart label', () => {
     const numberFormatter = getNumberFormatter();
     const params = { name: 'My Label', value: 1234, percent: 12.34 };
-    expect(formatPieLabel({ params, numberFormatter, pieLabelType: 'key' })).toEqual('My Label');
-    expect(formatPieLabel({ params, numberFormatter, pieLabelType: 'value' })).toEqual('1.23k');
-    expect(formatPieLabel({ params, numberFormatter, pieLabelType: 'percent' })).toEqual('12.34%');
-    expect(formatPieLabel({ params, numberFormatter, pieLabelType: 'key_value' })).toEqual(
-      'My Label: 1.23k',
+    expect(formatPieLabel({ params, numberFormatter, labelType: EchartsPieLabelType.Key })).toEqual(
+      'My Label',
     );
-    expect(formatPieLabel({ params, numberFormatter, pieLabelType: 'key_percent' })).toEqual(
-      'My Label: 12.34%',
-    );
-    expect(formatPieLabel({ params, numberFormatter, pieLabelType: 'key_value_percent' })).toEqual(
-      'My Label: 1.23k (12.34%)',
-    );
+    expect(
+      formatPieLabel({ params, numberFormatter, labelType: EchartsPieLabelType.Value }),
+    ).toEqual('1.23k');
+    expect(
+      formatPieLabel({ params, numberFormatter, labelType: EchartsPieLabelType.Percent }),
+    ).toEqual('12.34%');
+    expect(
+      formatPieLabel({ params, numberFormatter, labelType: EchartsPieLabelType.KeyValue }),
+    ).toEqual('My Label: 1.23k');
+    expect(
+      formatPieLabel({ params, numberFormatter, labelType: EchartsPieLabelType.KeyPercent }),
+    ).toEqual('My Label: 12.34%');
+    expect(
+      formatPieLabel({ params, numberFormatter, labelType: EchartsPieLabelType.KeyValuePercent }),
+    ).toEqual('My Label: 1.23k (12.34%)');
   });
 });

--- a/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -21,7 +21,11 @@ import {
   extractGroupbyLabel,
   extractTimeseriesSeries,
   formatSeriesName,
+  getChartPadding,
+  getLegendProps,
 } from '../../src/utils/series';
+import { LegendOrientation, LegendType } from '../../src/types';
+import { defaultLegendPadding } from '../../src/defaults';
 
 describe('extractTimeseriesSeries', () => {
   it('should generate a valid ECharts timeseries series object', () => {
@@ -128,5 +132,115 @@ describe('formatSeriesName', () => {
     expect(formatSeriesName(new Date('2020-09-11'), { timeFormatter })).toEqual(
       '2020-09-11 00:00:00',
     );
+  });
+
+  describe('getLegendProps', () => {
+    it('should return the correct props for scroll type with top orientation', () => {
+      expect(getLegendProps(LegendType.Scroll, LegendOrientation.Top, true)).toEqual({
+        show: true,
+        top: 0,
+        orient: 'horizontal',
+        type: 'scroll',
+      });
+    });
+
+    it('should return the correct props for plain type with left orientation', () => {
+      expect(getLegendProps(LegendType.Plain, LegendOrientation.Left, true)).toEqual({
+        show: true,
+        left: 0,
+        orient: 'vertical',
+        type: 'plain',
+      });
+    });
+
+    it('should return the correct props for plain type with right orientation', () => {
+      expect(getLegendProps(LegendType.Plain, LegendOrientation.Right, false)).toEqual({
+        show: false,
+        right: 0,
+        orient: 'vertical',
+        type: 'plain',
+      });
+    });
+
+    it('should return the correct props for plain type with bottom orientation', () => {
+      expect(getLegendProps(LegendType.Plain, LegendOrientation.Bottom, false)).toEqual({
+        show: false,
+        bottom: 0,
+        orient: 'horizontal',
+        type: 'plain',
+      });
+    });
+  });
+
+  describe('getChartPadding', () => {
+    it('should handle top default', () => {
+      expect(getChartPadding(true, LegendOrientation.Top)).toEqual({
+        bottom: 0,
+        left: 0,
+        right: 0,
+        top: defaultLegendPadding[LegendOrientation.Top],
+      });
+    });
+
+    it('should handle left default', () => {
+      expect(getChartPadding(true, LegendOrientation.Left)).toEqual({
+        bottom: 0,
+        left: defaultLegendPadding[LegendOrientation.Left],
+        right: 0,
+        top: 0,
+      });
+    });
+
+    it('should return the default padding when show is false', () => {
+      expect(
+        getChartPadding(false, LegendOrientation.Left, 100, {
+          top: 10,
+          bottom: 20,
+          left: 30,
+          right: 40,
+        }),
+      ).toEqual({
+        bottom: 20,
+        left: 30,
+        right: 40,
+        top: 10,
+      });
+    });
+
+    it('should return the correct padding for left orientation', () => {
+      expect(getChartPadding(true, LegendOrientation.Left, 100)).toEqual({
+        bottom: 0,
+        left: 100,
+        right: 0,
+        top: 0,
+      });
+    });
+
+    it('should return the correct padding for right orientation', () => {
+      expect(getChartPadding(true, LegendOrientation.Right, 50)).toEqual({
+        bottom: 0,
+        left: 0,
+        right: 50,
+        top: 0,
+      });
+    });
+
+    it('should return the correct padding for top orientation', () => {
+      expect(getChartPadding(true, LegendOrientation.Top, 20)).toEqual({
+        bottom: 0,
+        left: 0,
+        right: 0,
+        top: 20,
+      });
+    });
+
+    it('should return the correct padding for bottom orientation', () => {
+      expect(getChartPadding(true, LegendOrientation.Bottom, 10)).toEqual({
+        bottom: 10,
+        left: 0,
+        right: 0,
+        top: 0,
+      });
+    });
   });
 });


### PR DESCRIPTION
🏆 Enhancements
Currently ECharts has limited functionality for automatically resizing the chart area based on the legend, causing overflowing. This PR adds the possibility to
- Enable/disable legend on Timeseries chart (default: disabled)
- Change legend type (scroll, plain) (default: scroll)
- Change orientation of legend (top, bottom, left, right) on Pie and Timeseries (default: top)
- Define custom legend padding (default: 20 for top/bottom, 170 for left/right)

The custom padding option will be removed once automatic component resizing is implemented in ECharts. Also cleans up default props for ECharts Pie (should really be in a separate PR, apologies for that).

### Before
Currently there's no way of disabling the legend
![image](https://user-images.githubusercontent.com/33317356/105168372-b5ad9600-5b22-11eb-89ec-6f27142a0feb.png)

### After
Now the legend is disabled by default
![image](https://user-images.githubusercontent.com/33317356/105175093-26a57b80-5b2c-11eb-9a2f-fab6355ac36b.png)

When enabled, it defaults to scroll mode
![image](https://user-images.githubusercontent.com/33317356/105175154-36bd5b00-5b2c-11eb-9312-41d3ca39000d.png)

The legend can also be moved to top/right/bottom/left:
![image](https://user-images.githubusercontent.com/33317356/105175187-4472e080-5b2c-11eb-8332-8a43427bf099.png)
