### PR TITLE
fix(plugin-chart-echarts): default to 45 degree rotated labels

### DIFF
--- a/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
@@ -105,7 +105,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
   else if (xTicksLayout === '90°') axisLabel = { rotate: -90 };
   else if (xTicksLayout === 'flat') axisLabel = { rotate: 0 };
   else if (xTicksLayout === 'staggered') axisLabel = { rotate: -45 };
-  else axisLabel = { show: true };
+  else axisLabel = { rotate: -45 };
 
   // @ts-ignore
   const echartOptions: echarts.EChartOption<echarts.EChartOption.SeriesBoxplot> = {


### PR DESCRIPTION
🐛 Bug Fix
Default to 45 degree rotated x-axis labels

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/99004419-b84ea680-2547-11eb-9989-9487818514f8.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/99004458-c4d2ff00-2547-11eb-9b2e-b261d61312fe.png)
