### PR TITLE
fix(legacy-plugin-chart-pivot-table): remove nulls from table

### DIFF
--- a/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
@@ -112,6 +112,9 @@ function PivotTable(element, props) {
             const date = new Date(parseFloat(regexMatch[1]));
             $(this)[0].textContent = dateFormatter(date);
             $(this).attr('data-sort', date);
+          } else {
+            $(this)[0].textContent = '';
+            $(this).attr('data-sort', Number.NEGATIVE_INFINITY);
           }
         } else {
           $(this)[0].textContent = formatNumber(format, parsedValue);


### PR DESCRIPTION
🐛 Bug Fix
Currently null values are displayed as `null` in the table. This changes the label to empty, and treats the null value as `Number.NEGATIVE_INFINITY` on sort.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/100193712-fc08bf00-2efc-11eb-8016-b43ebe5202c1.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/100193674-e72c2b80-2efc-11eb-883e-713a1cd38bf9.png)
