### PR TITLE
fix(legacy-preset-chart-nvd3): time compare and stacked area tooltips

### DIFF
--- a/packages/superset-ui-demo/storybook/stories/plugins/legacy-preset-chart-nvd3/Compare/Stories.tsx
+++ b/packages/superset-ui-demo/storybook/stories/plugins/legacy-preset-chart-nvd3/Compare/Stories.tsx
@@ -7,3 +7,4 @@ export default {
 };
 
 export { basic } from './stories/basic';
+export { timeFormat } from './stories/timeFormat';

--- a/packages/superset-ui-demo/storybook/stories/plugins/legacy-preset-chart-nvd3/Compare/stories/timeFormat.tsx
+++ b/packages/superset-ui-demo/storybook/stories/plugins/legacy-preset-chart-nvd3/Compare/stories/timeFormat.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+import { SuperChart } from '@superset-ui/core';
+import dummyDatasource from '../../../../../shared/dummyDatasource';
+
+export const timeFormat = () => (
+  <SuperChart
+    chartType="compare"
+    width={400}
+    height={400}
+    datasource={dummyDatasource}
+    queryData={{
+      data: [
+        {
+          key: ['Africa and Middle East'],
+          values: [
+            {
+              x: 1606348800000,
+              y: 3985,
+            },
+            {
+              x: 1606435200000,
+              y: 5882,
+            },
+            {
+              x: 1606521600000,
+              y: 7983,
+            },
+            {
+              x: 1606608000000,
+              y: 16462,
+            },
+            {
+              x: 1606694400000,
+              y: 5542,
+            },
+            {
+              x: 1606780800000,
+              y: 2825,
+            },
+          ],
+        },
+        {
+          key: ['Asia'],
+          values: [
+            {
+              x: 1606348800000,
+              y: 34837,
+            },
+            {
+              x: 1606435200000,
+              y: 40718,
+            },
+            {
+              x: 1606521600000,
+              y: 58507,
+            },
+            {
+              x: 1606608000000,
+              y: 110120,
+            },
+            {
+              x: 1606694400000,
+              y: 43443,
+            },
+            {
+              x: 1606780800000,
+              y: 33538,
+            },
+          ],
+        },
+        {
+          key: ['Australia'],
+          values: [
+            {
+              x: 1606348800000,
+              y: 12975,
+            },
+            {
+              x: 1606435200000,
+              y: 18471,
+            },
+            {
+              x: 1606521600000,
+              y: 17880,
+            },
+            {
+              x: 1606608000000,
+              y: 52204,
+            },
+            {
+              x: 1606694400000,
+              y: 26690,
+            },
+            {
+              x: 1606780800000,
+              y: 16423,
+            },
+          ],
+        },
+        {
+          key: ['Europe'],
+          values: [
+            {
+              x: 1606348800000,
+              y: 127029,
+            },
+            {
+              x: 1606435200000,
+              y: 177637,
+            },
+            {
+              x: 1606521600000,
+              y: 172653,
+            },
+            {
+              x: 1606608000000,
+              y: 203654,
+            },
+            {
+              x: 1606694400000,
+              y: 79200,
+            },
+            {
+              x: 1606780800000,
+              y: 45238,
+            },
+          ],
+        },
+        {
+          key: ['LatAm'],
+          values: [
+            {
+              x: 1606348800000,
+              y: 22513,
+            },
+            {
+              x: 1606435200000,
+              y: 24594,
+            },
+            {
+              x: 1606521600000,
+              y: 32578,
+            },
+            {
+              x: 1606608000000,
+              y: 34733,
+            },
+            {
+              x: 1606694400000,
+              y: 71696,
+            },
+            {
+              x: 1606780800000,
+              y: 166611,
+            },
+          ],
+        },
+        {
+          key: ['North America'],
+          values: [
+            {
+              x: 1606348800000,
+              y: 104596,
+            },
+            {
+              x: 1606435200000,
+              y: 109850,
+            },
+            {
+              x: 1606521600000,
+              y: 136873,
+            },
+            {
+              x: 1606608000000,
+              y: 133243,
+            },
+            {
+              x: 1606694400000,
+              y: 327739,
+            },
+            {
+              x: 1606780800000,
+              y: 162711,
+            },
+          ],
+        },
+      ],
+    }}
+    formData={{
+      queryFields: {
+        metrics: 'metrics',
+        groupby: 'groupby',
+      },
+      datasource: '24771__table',
+      vizType: 'compare',
+      urlParams: {},
+      timeRangeEndpoints: ['inclusive', 'exclusive'],
+      granularitySqla: '__time',
+      timeGrainSqla: 'P1D',
+      timeRange: 'Last week',
+      metrics: ['random_metric'],
+      adhocFilters: [],
+      groupby: ['dim_origin_region'],
+      timeseriesLimitMetric: null,
+      orderDesc: true,
+      contribution: false,
+      rowLimit: 10000,
+      colorScheme: 'd3Category10',
+      labelColors: {},
+      xAxisLabel: '',
+      bottomMargin: 'auto',
+      xTicksLayout: 'auto',
+      xAxisFormat: 'smart_date',
+      xAxisShowminmax: false,
+      yAxisLabel: '',
+      leftMargin: 'auto',
+      yAxisShowminmax: false,
+      yLogScale: false,
+      yAxisFormat: 'SMART_NUMBER',
+      yAxisBounds: [null, null],
+      rollingType: 'None',
+      comparisonType: 'values',
+      resampleRule: null,
+      resampleMethod: null,
+      annotationLayers: [],
+      appliedTimeExtras: {},
+      where: '',
+      having: '',
+      havingFilters: [],
+      filters: [],
+    }}
+  />
+);

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -652,7 +652,7 @@ function nvd3Vis(element, props) {
 
     if (isVizTypes(['compare'])) {
       chart.interactiveLayer.tooltip.contentGenerator(d =>
-        generateCompareTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter),
+        generateCompareTooltipContent(d, yAxisFormatter),
       );
     }
 

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -45,6 +45,7 @@ import {
   computeStackedYDomain,
   drawBarValues,
   generateBubbleTooltipContent,
+  generateCompareTooltipContent,
   generateMultiLineTooltipContent,
   generateRichLineTooltipContent,
   generateTimePivotTooltip,
@@ -651,7 +652,7 @@ function nvd3Vis(element, props) {
 
     if (isVizTypes(['compare'])) {
       chart.interactiveLayer.tooltip.contentGenerator(d =>
-        generateRichLineTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter),
+        generateCompareTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter),
       );
     }
 

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -649,6 +649,12 @@ function nvd3Vis(element, props) {
       }
     }
 
+    if (isVizTypes(['compare'])) {
+      chart.interactiveLayer.tooltip.contentGenerator(d =>
+        generateRichLineTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter),
+      );
+    }
+
     if (isVizTypes(['dual_line', 'line_multi'])) {
       const yAxisFormatter1 = getNumberFormatter(yAxisFormat);
       const yAxisFormatter2 = getNumberFormatter(yAxis2Format);

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -642,10 +642,10 @@ function nvd3Vis(element, props) {
         chart.interactiveLayer.tooltip.contentGenerator(d =>
           generateRichLineTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter),
         );
-      } else if (areaStackedStyle !== 'expand') {
+      } else {
         // area chart
         chart.interactiveLayer.tooltip.contentGenerator(d =>
-          generateAreaChartTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter),
+          generateAreaChartTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter, chart),
         );
       }
     }

--- a/plugins/legacy-preset-chart-nvd3/src/utils.js
+++ b/plugins/legacy-preset-chart-nvd3/src/utils.js
@@ -106,12 +106,37 @@ function getFormattedKey(seriesKey, shouldDompurify) {
 // Custom sorted tooltip
 // use a verbose formatter for times
 export function generateRichLineTooltipContent(d, timeFormatter, valueFormatter) {
-  const time = timeFormatter(d.value);
-
   let tooltip = '';
   tooltip +=
     "<table><thead><tr><td colspan='3'>" +
-    `<strong class='x-value'>${time === '0NaN' ? d.value : time}</strong>` +
+    `<strong class='x-value'>${timeFormatter(d.value)}</strong>` +
+    '</td></tr></thead><tbody>';
+  d.series.sort((a, b) => (a.value >= b.value ? -1 : 1));
+  d.series.forEach(series => {
+    const key = getFormattedKey(series.key, true);
+    tooltip +=
+      `<tr class="${series.highlight ? 'emph' : ''}">` +
+      `<td class='legend-color-guide' style="opacity: ${series.highlight ? '1' : '0.75'};"">` +
+      '<div ' +
+      `style="border: 2px solid ${series.highlight ? 'black' : 'transparent'}; background-color: ${
+        series.color
+      };"` +
+      '></div>' +
+      '</td>' +
+      `<td>${key}</td>` +
+      `<td>${valueFormatter(series.value)}</td>` +
+      '</tr>';
+  });
+  tooltip += '</tbody></table>';
+
+  return dompurify.sanitize(tooltip);
+}
+
+export function generateCompareTooltipContent(d, timeFormatter, valueFormatter) {
+  let tooltip = '';
+  tooltip +=
+    "<table><thead><tr><td colspan='3'>" +
+    `<strong class='x-value'>${d.value}</strong>` +
     '</td></tr></thead><tbody>';
   d.series.sort((a, b) => (a.value >= b.value ? -1 : 1));
   d.series.forEach(series => {

--- a/plugins/legacy-preset-chart-nvd3/src/utils.js
+++ b/plugins/legacy-preset-chart-nvd3/src/utils.js
@@ -132,7 +132,7 @@ export function generateRichLineTooltipContent(d, timeFormatter, valueFormatter)
   return dompurify.sanitize(tooltip);
 }
 
-export function generateCompareTooltipContent(d, timeFormatter, valueFormatter) {
+export function generateCompareTooltipContent(d, valueFormatter) {
   let tooltip = '';
   tooltip +=
     "<table><thead><tr><td colspan='3'>" +

--- a/plugins/legacy-preset-chart-nvd3/src/utils.js
+++ b/plugins/legacy-preset-chart-nvd3/src/utils.js
@@ -159,8 +159,13 @@ export function generateCompareTooltipContent(d, valueFormatter) {
   return dompurify.sanitize(tooltip);
 }
 
-export function generateAreaChartTooltipContent(d, timeFormatter, valueFormatter) {
-  const total = d.series[d.series.length - 1].value;
+export function generateAreaChartTooltipContent(d, timeFormatter, valueFormatter, chart) {
+  const total =
+    chart.style() === 'expand'
+      ? // expand mode does not include total row
+        d3.sum(d.series, s => s.value)
+      : // other modes include total row at the end
+        d.series[d.series.length - 1].value;
   let tooltip = '';
   tooltip +=
     "<table><thead><tr><td colspan='4'>" +

--- a/plugins/legacy-preset-chart-nvd3/src/utils.js
+++ b/plugins/legacy-preset-chart-nvd3/src/utils.js
@@ -106,10 +106,12 @@ function getFormattedKey(seriesKey, shouldDompurify) {
 // Custom sorted tooltip
 // use a verbose formatter for times
 export function generateRichLineTooltipContent(d, timeFormatter, valueFormatter) {
+  const time = timeFormatter(d.value);
+
   let tooltip = '';
   tooltip +=
     "<table><thead><tr><td colspan='3'>" +
-    `<strong class='x-value'>${timeFormatter(d.value)}</strong>` +
+    `<strong class='x-value'>${time === '0NaN' ? d.value : time}</strong>` +
     '</td></tr></thead><tbody>';
   d.series.sort((a, b) => (a.value >= b.value ? -1 : 1));
   d.series.forEach(series => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,12 +113,12 @@
   dependencies:
     tinycolor2 "^1.4.1"
 
-"@ant-design/colors@^4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-4.0.5.tgz#d7d100d7545cca8f624954604a6892fc48ba5aae"
-  integrity sha512-3mnuX2prnWOWvpFTS2WH2LoouWlOgtnIpc6IarWN6GOzzLF8dW/U8UctuvIPhoboETehZfJ61XP+CGakBEPJ3Q==
+"@ant-design/colors@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-5.0.0.tgz#46b73b4cc6935b35fc8b84555e8e42c8cfc190e6"
+  integrity sha512-Pe1rYorgVC1v4f+InDXvIlQH715pO1g7BsOhy/ehX/U6ebPKqojmkYJKU3lF+84Zmvyar7ngZ28hesAa1nWjLg==
   dependencies:
-    tinycolor2 "^1.4.1"
+    "@ctrl/tinycolor" "^3.1.6"
 
 "@ant-design/css-animation@^1.7.2":
   version "1.7.3"
@@ -130,7 +130,7 @@
   resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz#480b025f4b20ef7fe8f47d4a4846e4fee84ea06c"
   integrity sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ==
 
-"@ant-design/icons@^4.2.1", "@ant-design/icons@^4.2.2":
+"@ant-design/icons@^4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.2.2.tgz#6533c5a02aec49238ec4748074845ad7d85a4f5e"
   integrity sha512-DrVV+wcupnHS7PehJ6KiTcJtAR5c25UMgjGECCc6pUT9rsvw0AuYG+a4HDjfxEQuDqKTHwW+oX/nIvCymyLE8Q==
@@ -138,6 +138,18 @@
     "@ant-design/colors" "^3.1.0"
     "@ant-design/icons-svg" "^4.0.0"
     "@babel/runtime" "^7.10.4"
+    classnames "^2.2.6"
+    insert-css "^2.0.0"
+    rc-util "^5.0.1"
+
+"@ant-design/icons@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.3.0.tgz#420e0cd527486c0fe57f81310d681950fc4cfacf"
+  integrity sha512-UoIbw4oz/L/msbkgqs2nls2KP7XNKScOxVR54wRrWwnXOzJaGNwwSdYjHQz+5ETf8C53YPpzMOnRX99LFCdeIQ==
+  dependencies:
+    "@ant-design/colors" "^5.0.0"
+    "@ant-design/icons-svg" "^4.0.0"
+    "@babel/runtime" "^7.11.2"
     classnames "^2.2.6"
     insert-css "^2.0.0"
     rc-util "^5.0.1"
@@ -1557,6 +1569,11 @@
   integrity sha512-R2RzJZDuT2TU2dZMrRd7olax5IDVcUB/O8k76d1LW13CQ9/2ArJi3TCFXSZIaGpCUnyAYA5KiCZ+c1opnyQuog==
   dependencies:
     find-up "^2.1.0"
+
+"@ctrl/tinycolor@^3.1.6":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.2.0.tgz#77a8a33edb2fdc02318c828be78f6fb3d6c65eb2"
+  integrity sha512-cP1tbXA1qJp/er2CJaO+Pbe38p7RlhV9WytUxUe79xj++Q6s/jKVvzJ9U2dF9f1/lZAdG+j94A38CsNR+uW4gw==
 
 "@data-ui/event-flow@^0.0.84":
   version "0.0.84"
@@ -4399,6 +4416,11 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/rison@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@types/rison/-/rison-0.0.6.tgz#405605f63d4fe0ec0d66b2dd7eaf51a99a51144e"
+  integrity sha512-mE3eRK0fpTN/GnNBOIg2tGq2cFhchQXF6fCbrLxus75TgnoOECbdHikr948FGO/UAml7/ZhLMa5FbGkF5PKvmw==
+
 "@types/shortid@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
@@ -5382,13 +5404,6 @@ acorn@^7.1.0, acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
-add-dom-event-listener@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/add-dom-event-listener/-/add-dom-event-listener-1.1.0.tgz#6a92db3a0dd0abc254e095c0f1dc14acbbaae310"
-  integrity sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==
-  dependencies:
-    object-assign "4.x"
-
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
@@ -5568,14 +5583,14 @@ ansicolors@~0.2.1:
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
   integrity sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=
 
-antd@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/antd/-/antd-4.8.2.tgz#8cad882ddb5b18bafacd009cb0096f5b20c8a2f3"
-  integrity sha512-qxagKsiPVO+2rcAdX8WA3TPqiv5TS4FDGoaETVgCCln3x7ap1nqHkBC+Fr3CSNg8MxwQ+6m5BSBLcs5uDQg0Qw==
+antd@^4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/antd/-/antd-4.9.1.tgz#486c6e143e04fbd6e110a9ed9f9333bcba54b0f3"
+  integrity sha512-q+Uf8xWeUB+O+xELq3tvprj2cEot/JnCAjS24scIadHSFzCkUr1nVcHU7dTtZommx7zQgC2ajWBOCVMmJD/lrw==
   dependencies:
-    "@ant-design/colors" "^4.0.5"
+    "@ant-design/colors" "^5.0.0"
     "@ant-design/css-animation" "^1.7.2"
-    "@ant-design/icons" "^4.2.1"
+    "@ant-design/icons" "^4.3.0"
     "@ant-design/react-slick" "~0.27.0"
     "@babel/runtime" "^7.11.2"
     array-tree-filter "^2.1.0"
@@ -5584,27 +5599,25 @@ antd@^4.8.2:
     lodash "^4.17.20"
     moment "^2.25.3"
     omit.js "^2.0.2"
-    raf "^3.4.1"
-    rc-animate "~3.1.0"
     rc-cascader "~1.4.0"
     rc-checkbox "~2.3.0"
-    rc-collapse "~2.0.0"
+    rc-collapse "~3.1.0"
     rc-dialog "~8.4.0"
     rc-drawer "~4.1.0"
     rc-dropdown "~3.2.0"
-    rc-field-form "~1.13.0"
-    rc-image "~4.0.0"
+    rc-field-form "~1.17.0"
+    rc-image "~4.2.0"
     rc-input-number "~6.1.0"
     rc-mentions "~1.5.0"
-    rc-menu "~8.8.2"
-    rc-motion "^2.2.0"
+    rc-menu "~8.10.0"
+    rc-motion "^2.4.0"
     rc-notification "~4.5.2"
-    rc-pagination "~3.1.0"
-    rc-picker "~2.3.0"
+    rc-pagination "~3.1.2"
+    rc-picker "~2.4.1"
     rc-progress "~3.1.0"
     rc-rate "~2.9.0"
     rc-resize-observer "^0.2.3"
-    rc-select "~11.4.0"
+    rc-select "~11.5.3"
     rc-slider "~9.6.1"
     rc-steps "~4.1.0"
     rc-switch "~3.2.0"
@@ -5612,9 +5625,8 @@ antd@^4.8.2:
     rc-tabs "~11.7.0"
     rc-textarea "~0.3.0"
     rc-tooltip "~5.0.0"
-    rc-tree "~3.11.0"
-    rc-tree-select "~4.1.1"
-    rc-trigger "~5.0.3"
+    rc-tree "~4.0.0"
+    rc-tree-select "~4.2.0"
     rc-upload "~3.3.1"
     rc-util "^5.1.0"
     scroll-into-view-if-needed "^2.2.25"
@@ -14801,7 +14813,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@4.x, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -16022,7 +16034,7 @@ r-json@^1.2.5:
   resolved "https://registry.yarnpkg.com/r-json/-/r-json-1.2.9.tgz#0637da3485b0b4492e9ffae85796f8b2f373f600"
   integrity sha512-E5u25XBE7PpZmH5XwtthAmNvSLMTygDQMpcPtCTUBdvwPaqgIYJrxlRQJhG55Sgz7uC0Tuyh5nqNrsDT3uiefA==
 
-raf@^3.4.0, raf@^3.4.1:
+raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -16096,16 +16108,6 @@ rc-align@^4.0.0:
     rc-util "^5.3.0"
     resize-observer-polyfill "^1.5.1"
 
-rc-animate@3.x, rc-animate@~3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-3.1.1.tgz#defdd863f56816c222534e4dc68feddecd081386"
-  integrity sha512-8wg2Zg3EETy0k/9kYuis30NJNQg1D6/WSQwnCiz6SvyxQXNet/rVraRz3bPngwY6rcU2nlRvoShiYOorXyF7Sg==
-  dependencies:
-    "@ant-design/css-animation" "^1.7.2"
-    classnames "^2.2.6"
-    raf "^3.4.0"
-    rc-util "^4.15.3"
-
 rc-cascader@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/rc-cascader/-/rc-cascader-1.4.0.tgz#d731ea8e07433558627941036091a2820e895474"
@@ -16124,14 +16126,14 @@ rc-checkbox@~2.3.0:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.1"
 
-rc-collapse@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-2.0.1.tgz#99e7655acd9c237b72369a39dcb5c713451e1e92"
-  integrity sha512-sRNqwQovzQoptTh7dCwj3kfxrdor2oNXrGSBz+QJxSFS7N3Ujgf8X/KlN2ElCkwBKf7nNv36t9dwH0HEku4wJg==
+rc-collapse@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-3.1.0.tgz#4ce5e612568c5fbeaf368cc39214471c1461a1a1"
+  integrity sha512-EwpNPJcLe7b+5JfyaxM9ZNnkCgqArt3QQO0Cr5p5plwz/C9h8liAmjYY5I4+hl9lAjBqb7ZwLu94+z+rt5g1WQ==
   dependencies:
-    "@ant-design/css-animation" "^1.7.2"
+    "@babel/runtime" "^7.10.1"
     classnames "2.x"
-    rc-animate "3.x"
+    rc-motion "^2.3.4"
     rc-util "^5.2.1"
     shallowequal "^1.1.0"
 
@@ -16163,19 +16165,19 @@ rc-dropdown@^3.1.3, rc-dropdown@~3.2.0:
     classnames "^2.2.6"
     rc-trigger "^5.0.4"
 
-rc-field-form@~1.13.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/rc-field-form/-/rc-field-form-1.13.2.tgz#c33a0372fd9c5ae2c2a1ce0d1ce5a9f26a0b8fea"
-  integrity sha512-sskFsJkEmK6wUXNVxVaXRq4jYhKFKQyVrKxHQkvCI0l2ENg8ujjT8oOV2X4aa7+tLV0FNJLKdD+LuHlnTxEeSg==
+rc-field-form@~1.17.0:
+  version "1.17.2"
+  resolved "https://registry.yarnpkg.com/rc-field-form/-/rc-field-form-1.17.2.tgz#81b09d320f9b455673867bf3a1f5b2aac0fd0a15"
+  integrity sha512-+pufRy5x4G5yHxQ3k1nhgQqyqerPVJQ2jaLGojHjNpmZ2Si20o1KniMLsZxe6X8dfq4ePmH6M3IngfDnS+CrMA==
   dependencies:
     "@babel/runtime" "^7.8.4"
     async-validator "^3.0.3"
     rc-util "^5.0.0"
 
-rc-image@~4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/rc-image/-/rc-image-4.0.1.tgz#b54534684a01dcf8cb477f5ac6dda72545a9541f"
-  integrity sha512-1GxjwgtONtJjlvd7sM9VSLTAlDQhkqHI0wl72YSDpdm24w5zmDsTYLgTNh/vToFa9qAml10Gaidy03qpkTAQ+A==
+rc-image@~4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/rc-image/-/rc-image-4.2.0.tgz#3b7a977f9ecfbac046296c2908d99cb1f8795c65"
+  integrity sha512-yGqq6wPrIn86hMfC1Hl7M3NNS6zqnl9dvFWJg/StuI86jZBU0rm9rePTfKs+4uiwU3HXxpfsXlaG2p8GWRDLiw==
   dependencies:
     "@ant-design/icons" "^4.2.2"
     "@babel/runtime" "^7.11.2"
@@ -16219,18 +16221,18 @@ rc-menu@^8.0.1, rc-menu@^8.6.1:
     resize-observer-polyfill "^1.5.0"
     shallowequal "^1.1.0"
 
-rc-menu@~8.8.2:
-  version "8.8.3"
-  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-8.8.3.tgz#feb8ba0371dd342fbf1052d4fcca7b669b0bf66a"
-  integrity sha512-C9sT0SBXmUbVWRUseXASousacRVPnOm5aXdyJR569WIvZwbs2IncpGNmAcft1R5ZuFE3Y+SZZ5FYvtGtbCzkIQ==
+rc-menu@~8.10.0:
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-8.10.1.tgz#5637d85760ea6bd6ead49f44ae29686c5cc59798"
+  integrity sha512-HmTOLPkSrz5RcdDopD4+nI95YXR2DzdSq9ek3NX2EVgD1UHknlp1QAEJ5MompYdAqdtOspJUqgM/zNt0iQALOw==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
     mini-store "^3.0.1"
     omit.js "^2.0.0"
     rc-motion "^2.0.1"
-    rc-trigger "^5.0.4"
-    rc-util "^5.0.1"
+    rc-trigger "^5.1.2"
+    rc-util "^5.5.0"
     resize-observer-polyfill "^1.5.0"
     shallowequal "^1.1.0"
 
@@ -16238,6 +16240,15 @@ rc-motion@^2.0.0, rc-motion@^2.0.1, rc-motion@^2.2.0, rc-motion@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.3.4.tgz#69fe1313754ee1e746e42ec971e361cbc755456e"
   integrity sha512-La9JjfM58Vrwds1wM9OAkRTWsGeVqNnftI1YFti2WtaA2Ernk2vjbVio9hGbzhF0EvGrEvrzS96Mx/6lGT6Z0w==
+  dependencies:
+    "@babel/runtime" "^7.11.1"
+    classnames "^2.2.1"
+    rc-util "^5.2.1"
+
+rc-motion@^2.3.4, rc-motion@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.4.1.tgz#323f47c8635e6b2bc0cba2dfad25fc415b58e1dc"
+  integrity sha512-TWLvymfMu8SngPx5MDH8dQ0D2RYbluNTfam4hY/dNNx9RQ3WtGuZ/GXHi2ymLMzH+UNd6EEFYkOuR5JTTtm8Xg==
   dependencies:
     "@babel/runtime" "^7.11.1"
     classnames "^2.2.1"
@@ -16253,7 +16264,7 @@ rc-notification@~4.5.2:
     rc-motion "^2.2.0"
     rc-util "^5.0.1"
 
-rc-pagination@~3.1.0:
+rc-pagination@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rc-pagination/-/rc-pagination-3.1.2.tgz#ab5eacd9c51f869e350d2245064babe91bc1f046"
   integrity sha512-KbJvkTvRiD51vTIAi0oTARPUHNb0iV6njbDBe8yLkc3PWYDJaszASfuss6YJ98EIxEeGzuEk6xsUAEKWRJgz2g==
@@ -16261,10 +16272,10 @@ rc-pagination@~3.1.0:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.1"
 
-rc-picker@~2.3.0:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/rc-picker/-/rc-picker-2.3.4.tgz#3c42f54b6389e205b0ce0b8257e380864429192d"
-  integrity sha512-UdeqTzR9E5KHOGMjWfsMpE3VU+3VR3J5/wMrwuIRmL8orv9Tm+Gew3NPfs7djcuTrfnu+hL+lwCWp7VftZcSng==
+rc-picker@~2.4.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/rc-picker/-/rc-picker-2.4.3.tgz#ad15ee1d85e4b3e213ec66215ecd39e6a09be995"
+  integrity sha512-tOIHslTQKpoGNmbpp6YOBwS39dQSvtAuhOm3bWCkkc4jCqUqeR/velCwqefZX1BX4+t1gUMc1dIia9XvOKrEkg==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.1"
@@ -16315,10 +16326,10 @@ rc-select@^11.1.1:
     rc-virtual-list "^3.2.0"
     warning "^4.0.3"
 
-rc-select@~11.4.0:
-  version "11.4.2"
-  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-11.4.2.tgz#5b431ee7b2cc6e439886ca855774fc116e6fe6fb"
-  integrity sha512-DQHYwMcvAajnnlahKkYIW47AVTXgxpGj9CWbe+juXgvxawQRFUdd8T8L2Q05aOkMy02UTG0Qrs7EZfHmn5QHbA==
+rc-select@~11.5.3:
+  version "11.5.3"
+  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-11.5.3.tgz#682913f3669596fb794e2b4a5c619974c5ab45d1"
+  integrity sha512-ASSO4J/ayfbQQ+KOEounIMGhySDHpQtrIuH1WEABOBy8HgKec8kOLmyLH+YIXSUDnTf/gtxmflgFtl7sQ9pkSw==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
@@ -16399,21 +16410,21 @@ rc-tooltip@^5.0.1, rc-tooltip@~5.0.0:
     "@babel/runtime" "^7.11.2"
     rc-trigger "^5.0.0"
 
-rc-tree-select@~4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-4.1.2.tgz#bf012c3c32cf2e82fc7ffbdd60cb596163a290a0"
-  integrity sha512-2tRwZ4ChY+BarVKHoPR65kSZtopgwKCig6ngJiiTVgYfRdAhfdQp2j2+L8YW9TkosYGmwgTOhmlphlG3QNy7Pg==
+rc-tree-select@~4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-4.2.0.tgz#ca19163b2ccfe0772fd7b8148266dddd197d0fe1"
+  integrity sha512-VrrvBiOov6WR44RTGMqSw1Dmodg6Y++EH6a6R0ew43qsV4Ob0FGYRgoX811kImtt2Z+oAPJ6zZXN4WKtsQd3Gw==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
     rc-select "^11.1.1"
-    rc-tree "^3.8.0"
+    rc-tree "^4.0.0"
     rc-util "^5.0.5"
 
-rc-tree@^3.8.0, rc-tree@~3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-3.11.0.tgz#87edf01842bd88a05519e30dd7312bee3f7e2618"
-  integrity sha512-3RxA6fckbzX7WOk7g4gvO6AOad0znc8QW2nsv1IXSiljQaIMiyx1AK0zhzIEtABgWKbIs9QkhnBvIAHS4Rn9LA==
+rc-tree@^4.0.0, rc-tree@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-4.0.0.tgz#2f972b4a5e23ea17df05ec9f7ec43de350bea3bf"
+  integrity sha512-C2xlkA+/IypkHBPzbpAJGVWJh2HjeRbYCusA/m5k09WT6hQT0nC7LtLVmnb7QZecdBQPhoOgQh8gPwBR+xEMjQ==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
@@ -16432,17 +16443,6 @@ rc-trigger@^5.0.0, rc-trigger@^5.0.4, rc-trigger@^5.1.2:
     rc-motion "^2.0.0"
     rc-util "^5.5.0"
 
-rc-trigger@~5.0.3:
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-5.0.9.tgz#6956c31ab1a2def65f0630957ea75bdaa4b2cc4c"
-  integrity sha512-N+q/ur2dpJSPDWbZQ34ztpGorms1QIphtmFpxKE5z+wMJw2BIASkMDEfwHJ/ssvZQxScjQza0/eQ0CWUI0e+EQ==
-  dependencies:
-    "@babel/runtime" "^7.11.2"
-    classnames "^2.2.6"
-    rc-align "^4.0.0"
-    rc-motion "^2.0.0"
-    rc-util "^5.3.4"
-
 rc-upload@~3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/rc-upload/-/rc-upload-3.3.1.tgz#ad8658b2a796031930b35d2b07ab312b7cd4c9ed"
@@ -16452,18 +16452,7 @@ rc-upload@~3.3.1:
     classnames "^2.2.5"
     rc-util "^5.2.0"
 
-rc-util@^4.15.3:
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.21.1.tgz#88602d0c3185020aa1053d9a1e70eac161becb05"
-  integrity sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==
-  dependencies:
-    add-dom-event-listener "^1.1.0"
-    prop-types "^15.5.10"
-    react-is "^16.12.0"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.1.0"
-
-rc-util@^5.0.0, rc-util@^5.0.1, rc-util@^5.0.5, rc-util@^5.0.6, rc-util@^5.0.7, rc-util@^5.1.0, rc-util@^5.2.0, rc-util@^5.2.1, rc-util@^5.3.0, rc-util@^5.3.4, rc-util@^5.4.0, rc-util@^5.5.0:
+rc-util@^5.0.0, rc-util@^5.0.1, rc-util@^5.0.5, rc-util@^5.0.6, rc-util@^5.0.7, rc-util@^5.1.0, rc-util@^5.2.0, rc-util@^5.2.1, rc-util@^5.3.0, rc-util@^5.4.0, rc-util@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.5.0.tgz#76321bcb5c12f01f42bff9b971f170ff19506e5a"
   integrity sha512-YJB+zZGvCll/bhxXRVLAekr7lOvTgqMlRIhgINoINfUek7wQvi5sft46NOi3yYUYhocpuW4k8+5okW46sBsZAQ==
@@ -17547,6 +17536,11 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rison@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/rison/-/rison-0.1.1.tgz#4dcc0557b241aff60e76178e7792135713f33120"
+  integrity sha1-TcwFV7JBr/YOdheOd5ITVxPzMSA=
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
🐛 Bug Fix

Fix #795 and #799 

# Fix 795

For the `compare` chart in Superset or the `cumulativeLineChart` (from nvd3), the time is passed to the tooltip as a formatted time string. There is no way to customize the format unlike other chart types. Trying to apply a time format function on a string resulting in `0NaN`. 

This fix will at least make the tooltip has same format with the x-axis, better than `0NaN`.

![Pasted_Image_12_2_20__6_01_PM](https://user-images.githubusercontent.com/1659771/100953954-75d61500-34c8-11eb-83c2-ba6b2832417e.png)


Also add storybook example for verification

# Fix 799

The stacked area chart has 3 stacked style, the `expand` style pass data to tooltip slightly differently from the other two. It does not include a total row. This PR fix the total number calculation for `expand` case.

![Pasted_Image_12_2_20__6_00_PM](https://user-images.githubusercontent.com/1659771/100953874-4b845780-34c8-11eb-9ccb-48c2c7de8346.png)
