### PR TITLE
feat(plugin-chart-echarts): bump to version 5.0

### DIFF
--- a/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Pie/Stories.tsx
+++ b/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Pie/Stories.tsx
@@ -31,9 +31,8 @@ export const WeekdayPie = ({ width, height }) => {
         innerRadius: number('Inner Radius', 30),
         outerRadius: number('Outer Radius', 50),
         labelsOutside: boolean('Labels outside', true),
-        labelLine: boolean('Label line', false),
+        labelLine: boolean('Label line', true),
         showLabels: boolean('Show labels', true),
-        showLabelsThreshold: number('Percentage threshold', 0),
         showLegend: boolean('Show legend', false),
         pieLabelType: select(
           'Pie label type',
@@ -63,7 +62,6 @@ export const PopulationPie = ({ width, height }) => {
         labelsOutside: boolean('Labels outside', false),
         labelLine: boolean('Label line', false),
         showLabels: boolean('Show labels', true),
-        showLabelsThreshold: number('Percentage threshold', 5),
         showLegend: boolean('Show legend', false),
         pieLabelType: select(
           'Pie label type',

--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -30,7 +30,7 @@
     "@superset-ui/core": "0.15.15",
     "@types/echarts": "^4.6.3",
     "@types/mathjs": "^6.0.7",
-    "echarts": "^4.9.0",
+    "echarts": "^5.0.0",
     "mathjs": "^8.0.1"
   },
   "peerDependencies": {

--- a/plugins/plugin-chart-echarts/src/Pie/controlPanel.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/controlPanel.ts
@@ -122,20 +122,6 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [
-          {
-            name: 'show_labels_threshold',
-            config: {
-              type: 'TextControl',
-              label: t('Percentage threshold'),
-              renderTrigger: true,
-              isFloat: true,
-              default: 5,
-              description: t('Minimum threshold in percentage points for showing labels.'),
-            },
-          },
-          noopControl,
-        ],
         ['color_scheme', noopControl],
         [
           {
@@ -147,7 +133,7 @@ const config: ControlPanelConfig = {
               min: 10,
               max: 100,
               step: 1,
-              default: 50,
+              default: 80,
               description: t('Outer edge of Pie chart'),
             },
           },

--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -67,10 +67,9 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     labelLine = false,
     metric,
     numberFormat,
-    outerRadius = 50,
+    outerRadius = 80,
     pieLabelType = 'value',
     showLabels = true,
-    showLabelsThreshold = 5,
     showLegend = false,
   } = formData as PieChartFormData;
   const { label: metricLabel } = convertMetric(metric);
@@ -91,7 +90,6 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
   });
 
   const formatter = (params: { name: string; value: number; percent: number }) => {
-    if (params.percent < showLabelsThreshold) return '';
     return formatPieLabel({ params, numberFormatter, pieLabelType });
   };
 
@@ -134,7 +132,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
         radius: [`${donut ? innerRadius : 0}%`, `${outerRadius}%`],
         center: ['50%', '50%'],
         avoidLabelOverlap: true,
-        labelLine: labelLine ? { show: true } : { show: false },
+        labelLine: labelsOutside && labelLine ? { show: true } : { show: false },
         label: labelsOutside
           ? {
               ...defaultLabel,

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -93,11 +93,10 @@ export function transformSeries(
     areaStyle: {
       opacity: forecastSeries.type === ForecastSeriesEnum.ForecastUpper || area ? opacity : 0,
     },
-    symbolSize:
+    showSymbol:
       !isConfidenceBand &&
-      (plotType === 'scatter' || (forecastEnabled && isObservation) || markerEnabled)
-        ? markerSize
-        : 0,
+      (plotType === 'scatter' || (forecastEnabled && isObservation) || markerEnabled),
+    symbolSize: markerSize,
   };
 }
 

--- a/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useRef, useEffect } from 'react';
 import { styled } from '@superset-ui/core';
-import echarts from 'echarts';
+import { init } from 'echarts';
 import { EchartsProps, EchartsStylesProps } from '../types';
 
 const Styles = styled.div<EchartsStylesProps>`
@@ -33,7 +33,7 @@ export default function Echart({ width, height, echartOptions }: EchartsProps) {
   useEffect(() => {
     if (!divRef.current) return;
     if (!chartRef.current) {
-      chartRef.current = echarts.init(divRef.current);
+      chartRef.current = init(divRef.current);
     }
     chartRef.current.setOption(echartOptions, true);
   }, [echartOptions]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8953,12 +8953,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-4.9.0.tgz#a9b9baa03f03a2a731e6340c55befb57a9e1347d"
-  integrity sha512-+ugizgtJ+KmsJyyDPxaw2Br5FqzuBnyOWwcxPKO6y0gc5caYcfnEUIlNStx02necw8jmKmTafmpHhGo4XDtEIA==
+echarts@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.0.0.tgz#66ec0ea47e3c93b2aadfbb2d719869932ad13ce0"
+  integrity sha512-6SDcJbLVOcfQyjPg+spNU1+JVrkU1B9fzUa5tpbP/mMNUPyigCOJwcEIQAJSbp9jt5UP3EXvQR0vtYXIo9AjyA==
   dependencies:
-    zrender "4.3.2"
+    tslib "1.10.0"
+    zrender "5.0.1"
 
 edit-json-file@^1.4.0:
   version "1.4.0"
@@ -19201,6 +19202,11 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+tslib@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
@@ -20331,7 +20337,9 @@ yosay@^2.0.2:
     taketalk "^1.0.0"
     wrap-ansi "^2.0.0"
 
-zrender@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-4.3.2.tgz#ec7432f9415c82c73584b6b7b8c47e1b016209c6"
-  integrity sha512-bIusJLS8c4DkIcdiK+s13HiQ/zjQQVgpNohtd8d94Y2DnJqgM1yjh/jpDb8DoL6hd7r8Awagw8e3qK/oLaWr3g==
+zrender@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.0.1.tgz#cc377136a9d00d0a177ca7f65c32aed2901928da"
+  integrity sha512-i8FNCKAKfF0EfZFJ6w2p30umBrCyy481/PePFQqPdtNgCl5Hp5z7/dovqb7soEoFkhNvhjJ/J4W9zFALeae6yA==
+  dependencies:
+    tslib "1.10.0"


### PR DESCRIPTION
🏆 Enhancements
Bump ECharts to 5.0.0. Changes:
- Pie: Increase default outer radius from 50 % to 80 %, as it handles resizing much better.
- Pie: Remove show label threshold prop, as labels that don't fit are automatically dropped.
- Pie: activate label line by default and only render lines if labels are set to be outside.
- Timeseries: Minor refactor to marker props.

Pie:
![piesize2](https://user-images.githubusercontent.com/33317356/101167610-dbe6a780-3642-11eb-9dd7-dd775c668919.gif)

Boxplot:
![image](https://user-images.githubusercontent.com/33317356/101165545-8230ae00-363f-11eb-8ef0-1959680985f1.png)

Timeseries:
![image](https://user-images.githubusercontent.com/33317356/101165469-62998580-363f-11eb-96cb-c576463469dc.png)
