### PR TITLE
ci: remove `pull_request` trigger

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,7 +6,6 @@ on:
       - '*'
     tags-ignore:
       - 'trigger-patch-test.*'
-  pull_request:
   pull_request_target:
 
 jobs:


### PR DESCRIPTION
🏆 Enhancements
now that https://github.com/apache-superset/superset-ui/pull/849 has merged and the actions code is in master, we can rely on `pull_request_target` for any changes. `pull_request` will fail for any PR that comes from a fork as it will not have access to secrets needed to upload the chromatic output. 


more info on `pull_request_target` here https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks