### PR TITLE
fix(legacy-preset-chart-nvd3): make deep copy of queryData

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
+++ b/plugins/legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
@@ -20,7 +20,7 @@
 import d3 from 'd3';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isEqual } from 'lodash';
+import { isEqual, cloneDeep } from 'lodash';
 import { getExploreLongUrl } from '../vendor/superset/exploreUtils';
 import ReactNVD3 from '../ReactNVD3';
 import transformProps from '../transformProps';
@@ -61,7 +61,7 @@ function getJson(url) {
 class LineMulti extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { queryData: false };
+    this.state = { queryData: {} };
   }
 
   componentDidMount() {
@@ -153,7 +153,7 @@ class LineMulti extends React.Component {
       <ReactNVD3
         {...transformProps({
           ...this.props,
-          queryData,
+          queryData: cloneDeep(queryData),
         })}
       />
     );


### PR DESCRIPTION
🐛 Bug Fix
Fixes https://github.com/apache/incubator-superset/issues/11889. State of `LineMulti` was passed through props to another component and modified there, which caused an infinite loop if re-renders. Now we pass a deep copy of state instead of the original object.

Before: see gif in https://github.com/apache/incubator-superset/issues/11889
After: the chart is stable after rendering
![image](https://user-images.githubusercontent.com/15073128/101633704-ebd9ff00-3a27-11eb-849f-2e93ddea0b60.png)

@rusackas Can you please take a look?