### PR TITLE
fix: add fetchRetryOptions in SupersetClientClass.request method

### DIFF
--- a/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -126,6 +126,7 @@ export default class SupersetClientClass {
     url,
     headers,
     timeout,
+    fetchRetryOptions,
     ...rest
   }: RequestConfig & { parseMethod?: T }) {
     await this.ensureAuth();
@@ -136,6 +137,7 @@ export default class SupersetClientClass {
       url: this.getUrl({ endpoint, host, url }),
       headers: { ...this.headers, ...headers },
       timeout: timeout ?? this.timeout,
+      fetchRetryOptions: fetchRetryOptions ?? this.fetchRetryOptions,
     });
   }
 


### PR DESCRIPTION
🐛 Bug Fix

Following the thread 
https://github.com/apache-superset/superset-ui/issues/866#issuecomment-745503482
I propose this PR to use the default fetchRetryOptions in the SupersetClientClass.

Thanks
Mario