### PR TITLE
chore(chart-controls): remove dedicated time section

### DIFF
--- a/packages/superset-ui-chart-controls/src/sections.tsx
+++ b/packages/superset-ui-chart-controls/src/sections.tsx
@@ -17,18 +17,34 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
+import { ControlPanelSectionConfig } from './types';
 
 // A few standard controls sections that are used internally.
 // Not recommended for use in third-party plugins.
 
-export const druidTimeSeries = {
+const baseTimeSection = {
   label: t('Time'),
   expanded: true,
   description: t('Time related form attributes'),
-  controlSetRows: [['time_range']],
 };
 
-export const datasourceAndVizType = {
+export const legacyTimeseriesTime: ControlPanelSectionConfig = {
+  ...baseTimeSection,
+  controlSetRows: [
+    ['granularity'],
+    ['druid_time_origin'],
+    ['granularity_sqla'],
+    ['time_grain_sqla'],
+    ['time_range'],
+  ],
+};
+
+export const legacyRegularTime: ControlPanelSectionConfig = {
+  ...baseTimeSection,
+  controlSetRows: [['granularity_sqla'], ['time_range']],
+};
+
+export const datasourceAndVizType: ControlPanelSectionConfig = {
   label: t('Datasource & Chart Type'),
   expanded: true,
   controlSetRows: [
@@ -75,19 +91,12 @@ export const datasourceAndVizType = {
   ],
 };
 
-export const colorScheme = {
+export const colorScheme: ControlPanelSectionConfig = {
   label: t('Color Scheme'),
   controlSetRows: [['color_scheme', 'label_colors']],
 };
 
-export const sqlaTimeSeries = {
-  label: t('Time'),
-  description: t('Time related form attributes'),
-  expanded: true,
-  controlSetRows: [['granularity_sqla'], ['time_range']],
-};
-
-export const annotations = {
+export const annotations: ControlPanelSectionConfig = {
   label: t('Annotations and Layers'),
   tabOverride: 'data',
   expanded: true,

--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -69,8 +69,8 @@ export interface DatasourceMeta {
   main_dttm_col: string;
   // eg. ['["ds", true]', 'ds [asc]']
   order_by_choices?: [string, string][] | null;
-  time_grain_sqla: [string, string][];
-  granularity_sqla: [string, string][];
+  time_grain_sqla?: string;
+  granularity_sqla?: string;
   datasource_name: string | null;
   description: string | null;
 }

--- a/packages/superset-ui-chart-controls/src/utils/columnChoices.ts
+++ b/packages/superset-ui-chart-controls/src/utils/columnChoices.ts
@@ -21,10 +21,10 @@ import { DatasourceMeta } from '../types';
 /**
  * Convert Dataource columns to column choices
  */
-export default function columnChoices(datasource?: DatasourceMeta | null) {
+export default function columnChoices(datasource?: DatasourceMeta | null): [string, string][] {
   return (
     datasource?.columns
-      .map(col => [col.column_name, col.verbose_name || col.column_name])
+      .map((col): [string, string] => [col.column_name, col.verbose_name || col.column_name])
       .sort((opt1, opt2) => (opt1[1].toLowerCase() > opt2[1].toLowerCase() ? 1 : -1)) || []
   );
 }

--- a/packages/superset-ui-chart-controls/test/utils/columnChoices.test.tsx
+++ b/packages/superset-ui-chart-controls/test/utils/columnChoices.test.tsx
@@ -23,6 +23,7 @@ describe('columnChoices()', () => {
   it('should convert columns to choices', () => {
     expect(
       columnChoices({
+        id: 1,
         metrics: [],
         type: DatasourceType.Table,
         main_dttm_col: 'test',
@@ -40,6 +41,10 @@ describe('columnChoices()', () => {
             verbose_name: 'bar',
           },
         ],
+        verbose_map: {},
+        column_format: { fiz: 'NUMERIC', about: 'STRING', foo: 'DATE' },
+        datasource_name: 'my_datasource',
+        description: 'this is my datasource',
       }),
     ).toEqual([
       ['foo', 'bar'],

--- a/plugins/legacy-plugin-chart-calendar/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-calendar/src/controlPanel.js
@@ -22,10 +22,11 @@ import {
   D3_TIME_FORMAT_OPTIONS,
   D3_FORMAT_DOCS,
 } from '@superset-ui/core';
-import { formatSelectOptions } from '@superset-ui/chart-controls';
+import { formatSelectOptions, sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-chord/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-chord/src/controlPanel.js
@@ -17,9 +17,11 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
+import { sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-country-map/src/controlPanel.ts
@@ -17,10 +17,16 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { D3_FORMAT_OPTIONS, D3_FORMAT_DOCS } from '@superset-ui/chart-controls';
+import {
+  ControlPanelConfig,
+  D3_FORMAT_OPTIONS,
+  D3_FORMAT_DOCS,
+  sections,
+} from '@superset-ui/chart-controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
@@ -103,3 +109,5 @@ export default {
     },
   },
 };
+
+export default config;

--- a/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx
+++ b/plugins/legacy-plugin-chart-event-flow/src/controlPanel.tsx
@@ -23,12 +23,14 @@ import {
   ColumnOption,
   columnChoices,
   ControlPanelConfig,
+  sections,
   SelectControlConfig,
   ColumnMeta,
 } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Event definition'),
       controlSetRows: [

--- a/plugins/legacy-plugin-chart-force-directed/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-force-directed/src/controlPanel.js
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { formatSelectOptions } from '@superset-ui/chart-controls';
+import { formatSelectOptions, sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-heatmap/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-heatmap/src/controlPanel.js
@@ -21,6 +21,7 @@ import {
   formatSelectOptions,
   columnChoices,
   formatSelectOptionsForRange,
+  sections,
 } from '@superset-ui/chart-controls';
 
 const sortAxisChoices = [
@@ -32,6 +33,7 @@ const sortAxisChoices = [
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-histogram/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-histogram/src/controlPanel.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
-import { formatSelectOptions, columnChoices } from '@superset-ui/chart-controls';
+import { formatSelectOptions, columnChoices, sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
@@ -25,6 +25,7 @@ export default {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
+        sections.legacyRegularTime,
         [
           {
             name: 'all_columns_x',

--- a/plugins/legacy-plugin-chart-horizon/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-horizon/src/controlPanel.js
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { formatSelectOptions } from '@superset-ui/chart-controls';
+import { formatSelectOptions, sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-map-box/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-map-box/src/controlPanel.js
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { formatSelectOptions, columnChoices } from '@superset-ui/chart-controls';
+import { formatSelectOptions, columnChoices, sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts
@@ -17,9 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
@@ -92,3 +94,5 @@ export default {
     },
   ],
 };
+
+export default config;

--- a/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts
@@ -17,9 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
@@ -62,3 +64,5 @@ export default {
     },
   ],
 };
+
+export default config;

--- a/plugins/legacy-plugin-chart-partition/src/controlPanel.jsx
+++ b/plugins/legacy-plugin-chart-partition/src/controlPanel.jsx
@@ -23,11 +23,13 @@ import {
   D3_TIME_FORMAT_OPTIONS,
   D3_FORMAT_DOCS,
   D3_FORMAT_OPTIONS,
+  sections,
 } from '@superset-ui/chart-controls';
 import OptionDescription from './OptionDescription';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.js
@@ -22,10 +22,12 @@ import {
   D3_FORMAT_DOCS,
   formatSelectOptions,
   D3_TIME_FORMAT_OPTIONS,
+  sections,
 } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Query'),
       expanded: true,
@@ -131,13 +133,5 @@ export default {
   controlOverrides: {
     groupby: { includeTime: true },
     columns: { includeTime: true },
-  },
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
   },
 };

--- a/plugins/legacy-plugin-chart-rose/src/controlPanel.jsx
+++ b/plugins/legacy-plugin-chart-rose/src/controlPanel.jsx
@@ -23,10 +23,12 @@ import {
   D3_TIME_FORMAT_OPTIONS,
   D3_FORMAT_DOCS,
   D3_FORMAT_OPTIONS,
+  sections,
 } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Query'),
       expanded: true,
@@ -248,12 +250,4 @@ export default {
       ],
     },
   ],
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
 };

--- a/plugins/legacy-plugin-chart-sankey-loop/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-sankey-loop/src/controlPanel.js
@@ -17,9 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
+import { sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-sankey/src/controlPanel.ts
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { ControlPanelConfig } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
@@ -17,9 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
@@ -63,3 +65,5 @@ export default {
     },
   },
 };
+
+export default config;

--- a/plugins/legacy-plugin-chart-time-table/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-time-table/src/controlPanel.ts
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
-import { ControlPanelConfig } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Query'),
       expanded: true,
@@ -60,14 +61,6 @@ const config: ControlPanelConfig = {
   controlOverrides: {
     groupby: {
       multiple: false,
-    },
-  },
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
     },
   },
 };

--- a/plugins/legacy-plugin-chart-treemap/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-treemap/src/controlPanel.js
@@ -17,9 +17,11 @@
  * under the License.
  */
 import { t, D3_FORMAT_OPTIONS, D3_FORMAT_DOCS } from '@superset-ui/core';
+import { sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-plugin-chart-world-map/src/controlPanel.js
+++ b/plugins/legacy-plugin-chart-world-map/src/controlPanel.js
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { formatSelectOptions } from '@superset-ui/chart-controls';
+import { formatSelectOptions, sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx
+++ b/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx
@@ -17,12 +17,13 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { formatSelectOptions, ControlPanelConfig } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, formatSelectOptions, sections } from '@superset-ui/chart-controls';
 import React from 'react';
 import { headerFontSize, subheaderFontSize } from '../sharedControls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Query'),
       expanded: true,
@@ -156,14 +157,6 @@ const config: ControlPanelConfig = {
   controlOverrides: {
     y_axis_format: {
       label: t('Number format'),
-    },
-  },
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
     },
   },
 };

--- a/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts
+++ b/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/controlPanel.ts
@@ -17,10 +17,12 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import { headerFontSize, subheaderFontSize } from '../sharedControls';
 
 export default {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
@@ -54,4 +56,4 @@ export default {
       label: t('Number format'),
     },
   },
-};
+} as ControlPanelConfig;

--- a/plugins/legacy-preset-chart-nvd3/src/Area/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/Area/controlPanel.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { sections } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import {
   lineInterpolation,
   showBrush,
@@ -34,7 +34,7 @@ import {
   timeSeriesSection,
 } from '../NVD3Controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
     timeSeriesSection[0],
     {
@@ -86,12 +86,6 @@ export default {
     timeSeriesSection[1],
     sections.annotations,
   ],
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/Bar/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/Bar/controlPanel.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { sections } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import {
   lineInterpolation,
   showBrush,
@@ -40,7 +40,7 @@ import {
   timeSeriesSection,
 } from '../NVD3Controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
     timeSeriesSection[0],
     {
@@ -75,12 +75,6 @@ export default {
     timeSeriesSection[1],
     sections.annotations,
   ],
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/Bubble/controlPanel.ts
@@ -17,7 +17,12 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { formatSelectOptions, D3_FORMAT_OPTIONS } from '@superset-ui/chart-controls';
+import {
+  ControlPanelConfig,
+  formatSelectOptions,
+  D3_FORMAT_OPTIONS,
+  sections,
+} from '@superset-ui/chart-controls';
 import {
   showLegend,
   xAxisLabel,
@@ -31,13 +36,14 @@ import {
   leftMargin,
 } from '../NVD3Controls';
 
-export default {
-  label: t('Bubble Chart'),
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
+        [],
         ['series', 'entity'],
         ['x'],
         ['y'],
@@ -116,3 +122,5 @@ export default {
     },
   },
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/Bullet/controlPanel.ts
@@ -17,9 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
@@ -93,3 +95,5 @@ export default {
     },
   ],
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/Compare/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/Compare/controlPanel.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { sections } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import {
   xAxisLabel,
   yAxisLabel,
@@ -32,7 +32,7 @@ import {
   timeSeriesSection,
 } from '../NVD3Controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
     timeSeriesSection[0],
     {
@@ -61,12 +61,6 @@ export default {
     timeSeriesSection[1],
     sections.annotations,
   ],
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import {
   showLegend,
   showControls,
@@ -29,8 +30,9 @@ import {
   yAxisLabel,
 } from '../NVD3Controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
@@ -96,3 +98,5 @@ export default {
     },
   },
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts
@@ -17,11 +17,12 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { sections } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import { xAxisFormat, yAxis2Format } from '../NVD3Controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Chart Options'),
       expanded: true,
@@ -53,12 +54,6 @@ export default {
       label: t('Left Axis Format'),
     },
   },
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/Line/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/Line/controlPanel.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { sections } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import {
   lineInterpolation,
   showBrush,
@@ -37,7 +37,7 @@ import {
   timeSeriesSection,
 } from '../NVD3Controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
     timeSeriesSection[0],
     {
@@ -89,12 +89,6 @@ export default {
       default: 50000,
     },
   },
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/LineMulti/controlPanel.ts
@@ -18,7 +18,7 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
-import { sections } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import {
   lineInterpolation,
   showLegend,
@@ -40,8 +40,12 @@ export type Data = {
   result?: Result[];
 };
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    {
+      ...sections.legacyRegularTime,
+      controlSetRows: [['time_range']],
+    },
     {
       label: t('Chart Options'),
       tabOverride: 'customize',
@@ -149,12 +153,6 @@ export default {
       label: t('Left Axis Format'),
     },
   },
-  sectionOverrides: {
-    sqlaTimeSeries: {
-      controlSetRows: [['time_range']],
-    },
-    druidTimeSeries: {
-      controlSetRows: [['time_range']],
-    },
-  },
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
@@ -16,14 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+/* eslint-disable react/jsx-key */
 
 import React from 'react';
 import { t } from '@superset-ui/core';
 import {
+  ControlPanelSectionConfig,
+  CustomControlItem,
   formatSelectOptions,
   D3_TIME_FORMAT_OPTIONS,
   D3_FORMAT_DOCS,
   D3_FORMAT_OPTIONS,
+  sections,
 } from '@superset-ui/chart-controls';
 
 /*
@@ -42,7 +46,7 @@ import {
   TimePivotChartPlugin,
 */
 
-export const yAxis2Format = {
+export const yAxis2Format: CustomControlItem = {
   name: 'y_axis_2_format',
   config: {
     type: 'SelectControl',
@@ -54,7 +58,7 @@ export const yAxis2Format = {
   },
 };
 
-export const showMarkers = {
+export const showMarkers: CustomControlItem = {
   name: 'show_markers',
   config: {
     type: 'CheckboxControl',
@@ -65,7 +69,7 @@ export const showMarkers = {
   },
 };
 
-export const leftMargin = {
+export const leftMargin: CustomControlItem = {
   name: 'left_margin',
   config: {
     type: 'SelectControl',
@@ -79,7 +83,7 @@ export const leftMargin = {
   },
 };
 
-export const yAxisShowMinmax = {
+export const yAxisShowMinmax: CustomControlItem = {
   name: 'y_axis_showminmax',
   config: {
     type: 'CheckboxControl',
@@ -90,7 +94,7 @@ export const yAxisShowMinmax = {
   },
 };
 
-export const lineInterpolation = {
+export const lineInterpolation: CustomControlItem = {
   name: 'line_interpolation',
   config: {
     type: 'SelectControl',
@@ -109,7 +113,7 @@ export const lineInterpolation = {
   },
 };
 
-export const showBrush = {
+export const showBrush: CustomControlItem = {
   name: 'show_brush',
   config: {
     type: 'SelectControl',
@@ -126,7 +130,7 @@ export const showBrush = {
   },
 };
 
-export const showLegend = {
+export const showLegend: CustomControlItem = {
   name: 'show_legend',
   config: {
     type: 'CheckboxControl',
@@ -137,7 +141,7 @@ export const showLegend = {
   },
 };
 
-export const showControls = {
+export const showControls: CustomControlItem = {
   name: 'show_controls',
   config: {
     type: 'CheckboxControl',
@@ -152,7 +156,7 @@ export const showControls = {
   },
 };
 
-export const xAxisLabel = {
+export const xAxisLabel: CustomControlItem = {
   name: 'x_axis_label',
   config: {
     type: 'TextControl',
@@ -162,7 +166,7 @@ export const xAxisLabel = {
   },
 };
 
-export const bottomMargin = {
+export const bottomMargin: CustomControlItem = {
   name: 'bottom_margin',
   config: {
     type: 'SelectControl',
@@ -176,7 +180,7 @@ export const bottomMargin = {
   },
 };
 
-export const xTicksLayout = {
+export const xTicksLayout: CustomControlItem = {
   name: 'x_ticks_layout',
   config: {
     type: 'SelectControl',
@@ -189,7 +193,7 @@ export const xTicksLayout = {
   },
 };
 
-export const xAxisFormat = {
+export const xAxisFormat: CustomControlItem = {
   name: 'x_axis_format',
   config: {
     type: 'SelectControl',
@@ -202,7 +206,7 @@ export const xAxisFormat = {
   },
 };
 
-export const yLogScale = {
+export const yLogScale: CustomControlItem = {
   name: 'y_log_scale',
   config: {
     type: 'CheckboxControl',
@@ -213,7 +217,7 @@ export const yLogScale = {
   },
 };
 
-export const yAxisBounds = {
+export const yAxisBounds: CustomControlItem = {
   name: 'y_axis_bounds',
   config: {
     type: 'BoundsControl',
@@ -229,7 +233,7 @@ export const yAxisBounds = {
   },
 };
 
-export const xAxisShowMinmax = {
+export const xAxisShowMinmax: CustomControlItem = {
   name: 'x_axis_showminmax',
   config: {
     type: 'CheckboxControl',
@@ -240,7 +244,7 @@ export const xAxisShowMinmax = {
   },
 };
 
-export const richTooltip = {
+export const richTooltip: CustomControlItem = {
   name: 'rich_tooltip',
   config: {
     type: 'CheckboxControl',
@@ -251,7 +255,7 @@ export const richTooltip = {
   },
 };
 
-export const showBarValue = {
+export const showBarValue: CustomControlItem = {
   name: 'show_bar_value',
   config: {
     type: 'CheckboxControl',
@@ -262,7 +266,7 @@ export const showBarValue = {
   },
 };
 
-export const barStacked = {
+export const barStacked: CustomControlItem = {
   name: 'bar_stacked',
   config: {
     type: 'CheckboxControl',
@@ -273,7 +277,7 @@ export const barStacked = {
   },
 };
 
-export const reduceXTicks = {
+export const reduceXTicks: CustomControlItem = {
   name: 'reduce_x_ticks',
   config: {
     type: 'CheckboxControl',
@@ -290,7 +294,7 @@ export const reduceXTicks = {
   },
 };
 
-export const yAxisLabel = {
+export const yAxisLabel: CustomControlItem = {
   name: 'y_axis_label',
   config: {
     type: 'TextControl',
@@ -300,7 +304,8 @@ export const yAxisLabel = {
   },
 };
 
-export const timeSeriesSection = [
+export const timeSeriesSection: ControlPanelSectionConfig[] = [
+  sections.legacyTimeseriesTime,
   {
     label: t('Query'),
     expanded: true,
@@ -341,7 +346,6 @@ export const timeSeriesSection = [
         'of query results',
     ),
     controlSetRows: [
-      // eslint-disable-next-line react/jsx-key
       [<h1 className="section-header">{t('Rolling Window')}</h1>],
       [
         {
@@ -385,7 +389,6 @@ export const timeSeriesSection = [
           },
         },
       ],
-      // eslint-disable-next-line react/jsx-key
       [<h1 className="section-header">{t('Time Comparison')}</h1>],
       [
         {
@@ -433,9 +436,7 @@ export const timeSeriesSection = [
           },
         },
       ],
-      // eslint-disable-next-line react/jsx-key
       [<h1 className="section-header">{t('Python Functions')}</h1>],
-      // eslint-disable-next-line react/jsx-key
       [<h2 className="section-header">pandas.resample</h2>],
       [
         {

--- a/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { D3_FORMAT_OPTIONS } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, D3_FORMAT_OPTIONS } from '@superset-ui/chart-controls';
 import { showLegend } from '../NVD3Controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
     {
       label: t('Query'),
@@ -113,3 +113,5 @@ export default {
     },
   },
 };
+
+export default config;

--- a/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/TimePivot/controlPanel.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { D3_FORMAT_OPTIONS } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, D3_FORMAT_OPTIONS, sections } from '@superset-ui/chart-controls';
 import {
   lineInterpolation,
   showLegend,
@@ -32,8 +32,9 @@ import {
   leftMargin,
 } from '../NVD3Controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Query'),
       expanded: true,
@@ -113,12 +114,6 @@ export default {
       clearable: false,
     },
   },
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
 };
+
+export default config;

--- a/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { D3_FORMAT_OPTIONS, formatSelectOptions } from '@superset-ui/chart-controls';
+import { D3_FORMAT_OPTIONS, formatSelectOptions, sections } from '@superset-ui/chart-controls';
 
 export default {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Query'),
       expanded: true,
@@ -88,14 +89,6 @@ export default {
       ],
     },
   ],
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
   controlOverrides: {
     groupby: {
       label: t('Series'),

--- a/plugins/plugin-chart-echarts/src/Pie/controlPanel.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/controlPanel.ts
@@ -17,16 +17,17 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
-import { ControlPanelConfig, D3_FORMAT_OPTIONS } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, D3_FORMAT_OPTIONS, sections } from '@superset-ui/chart-controls';
 
 const noopControl = { name: 'noop', config: { type: '', renderTrigger: true } };
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
-      controlSetRows: [['groupby'], ['metric'], ['adhoc_filters'], ['row_limit', null]],
+      controlSetRows: [['groupby'], ['metric'], ['adhoc_filters'], ['row_limit']],
     },
     {
       label: t('Chart Options'),
@@ -156,7 +157,6 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
-
   controlOverrides: {
     series: {
       validators: [validateNonEmpty],

--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import { legacyValidateInteger, legacyValidateNumber, t } from '@superset-ui/core';
-import { ControlPanelConfig } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import {
   DEFAULT_FORM_DATA,
   EchartsTimeseriesContributionType,
@@ -50,6 +50,7 @@ const {
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Query'),
       expanded: true,
@@ -358,16 +359,6 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
-  // Time series charts need to override the `druidTimeSeries` and `sqlaTimeSeries`
-  // sections to add the time grain dropdown.
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
   controlOverrides: {
     row_limit: {
       default: rowLimit,

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -28,6 +28,7 @@ import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
   sharedControls,
+  sections,
 } from '@superset-ui/chart-controls';
 
 import i18n from './i18n';
@@ -133,6 +134,7 @@ const percent_metrics: typeof sharedControls.metrics = {
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyTimeseriesTime,
     {
       label: t('Query'),
       expanded: true,
@@ -315,14 +317,6 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
-  sectionOverrides: {
-    druidTimeSeries: {
-      controlSetRows: [['granularity', 'druid_time_origin'], ['time_range']],
-    },
-    sqlaTimeSeries: {
-      controlSetRows: [['granularity_sqla', 'time_grain_sqla'], ['time_range']],
-    },
-  },
 };
 
 export default config;

--- a/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts
@@ -17,13 +17,15 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
-      controlSetRows: [['series'], ['metric'], ['adhoc_filters'], ['row_limit', null]],
+      controlSetRows: [['series'], ['metric'], ['adhoc_filters'], ['row_limit']],
     },
     {
       label: t('Options'),
@@ -85,3 +87,5 @@ export default {
     },
   },
 };
+
+export default config;

--- a/plugins/plugin-filter-antd/src/Range/controlPanel.ts
+++ b/plugins/plugin-filter-antd/src/Range/controlPanel.ts
@@ -17,11 +17,12 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
-import { ControlPanelConfig } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   // For control input types, see: superset-frontend/src/explore/components/controls/index.js
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/plugin-filter-antd/src/Select/controlPanel.ts
+++ b/plugins/plugin-filter-antd/src/Select/controlPanel.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
-import { ControlPanelConfig } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import { DEFAULT_FORM_DATA } from './types';
 
 const {
@@ -30,6 +30,7 @@ const {
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,

--- a/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts
+++ b/plugins/preset-chart-xy/src/BoxPlot/controlPanel.ts
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { formatSelectOptions } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, formatSelectOptions, sections } from '@superset-ui/chart-controls';
 
-export default {
+const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,
@@ -65,3 +66,5 @@ export default {
     },
   ],
 };
+
+export default config;


### PR DESCRIPTION
💔 Breaking Changes
This PR paves the way for breaking up the dedicated Time section as defined by SIP-34. As a first step we are removing the `druidTimeSection` and `sqlaTimeSection`, and expect control panels to explicitly specify where any SQL or Druid temporal controls are placed. It is then the responsibility of the frontend to not render any controls that are not applicable. For instance, when editing a chart with a SQL dataset, Druid controls should not be visible and vice versa.

To ensure existing charts don't break, we're introducing two new predefined sections: `legacyRegularTime` (only contains time range and time column) and `legacyTimeseriesTime` which also includes the time grain and Druid time origin. These are implemented in all predefined viz plugins featured in the `plugins` directory.

In addition, some missing types are added that were picked up during this refactoring process and bugs fixed.

### Screenshots
Regular (=non timeseries) chart. No visible changes (see the "Time" section):
![image](https://user-images.githubusercontent.com/33317356/102588625-6e447c00-4116-11eb-992c-0a5d958514de.png)

Timeseries chart. Notice that "Time Column" and "Time Grain" are now on separate rows, otherwise no changes:
![image](https://user-images.githubusercontent.com/33317356/102588825-b8c5f880-4116-11eb-852a-cf1246898beb.png)

The only visible change is that time controls are now one per row (traditionally)