### PR TITLE
feat: remove single queryData from api

### DIFF
--- a/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -111,14 +111,12 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
       FallbackComponent,
       onErrorBoundary,
       Wrapper,
-      queryData,
       queriesData,
       ...rest
     } = this.props as PropsWithDefault;
 
     const chartProps = this.createChartProps({
       ...rest,
-      queryData,
       queriesData,
       height,
       width,
@@ -126,14 +124,10 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
 
     let chart;
     // Render the no results component if the query data is null or empty
-    const noResultQuery =
-      !queryData ||
-      !queryData.data ||
-      (Array.isArray(queryData.data) && queryData.data.length === 0);
     const noResultQueries =
       !queriesData ||
       queriesData.every(({ data }) => !data || (Array.isArray(data) && data.length === 0));
-    if (noResultQuery && noResultQueries) {
+    if (noResultQueries) {
       chart = <NoResultsComponent id={id} className={className} height={height} width={width} />;
     } else {
       const chartWithoutWrapper = (

--- a/packages/superset-ui-core/src/chart/models/ChartProps.ts
+++ b/packages/superset-ui-core/src/chart/models/ChartProps.ts
@@ -47,9 +47,6 @@ export interface ChartPropsConfig {
   height?: number;
   /** Programmatic overrides such as event handlers, renderers */
   hooks?: Hooks;
-  /** Formerly called "payload". This property going to be deprecated because
-   * contains only first item in response data array (use `queriesData` instead) */
-  queryData?: QueryData;
   /** Formerly called "payload" */
   queriesData?: QueryData[];
   /** Chart width */
@@ -78,8 +75,6 @@ export default class ChartProps {
 
   hooks: Hooks;
 
-  queryData: QueryData;
-
   queriesData: QueryData[];
 
   width: number;
@@ -91,7 +86,6 @@ export default class ChartProps {
       formData = {},
       hooks = {},
       initialValues = {},
-      queryData = {},
       queriesData = [],
       width = DEFAULT_WIDTH,
       height = DEFAULT_HEIGHT,
@@ -105,7 +99,6 @@ export default class ChartProps {
     this.rawFormData = formData;
     this.hooks = hooks;
     this.initialValues = initialValues;
-    this.queryData = queryData;
     this.queriesData = queriesData;
   }
 }
@@ -119,20 +112,9 @@ ChartProps.createSelector = function create(): ChartPropsSelector {
     input => input.height,
     input => input.hooks,
     input => input.initialValues,
-    input => input.queryData,
     input => input.queriesData,
     input => input.width,
-    (
-      annotationData,
-      datasource,
-      formData,
-      height,
-      hooks,
-      initialValues,
-      queryData,
-      queriesData,
-      width,
-    ) =>
+    (annotationData, datasource, formData, height, hooks, initialValues, queriesData, width) =>
       new ChartProps({
         annotationData,
         datasource,
@@ -140,7 +122,6 @@ ChartProps.createSelector = function create(): ChartPropsSelector {
         height,
         hooks,
         initialValues,
-        queryData,
         queriesData,
         width,
       }),


### PR DESCRIPTION
💔 Breaking Changes
Removes from Charts api deprecated `queryData` param and replace it with `queriesData`

🏆 Enhancements

📜 Documentation
`queriesData` - was implemented in previous PRs and supported by `incubator-superset`, here we just remove deprecated property from api

🐛 Bug Fix

🏠 Internal
