### PR TITLE
fix(legacy-preset-chart-nvd3): add Time section to Pie control panel

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/Pie/controlPanel.ts
@@ -17,11 +17,12 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
-import { ControlPanelConfig, D3_FORMAT_OPTIONS } from '@superset-ui/chart-controls';
+import { ControlPanelConfig, D3_FORMAT_OPTIONS, sections } from '@superset-ui/chart-controls';
 import { showLegend } from '../NVD3Controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,


### PR DESCRIPTION
🐛 Bug Fix
Fix yet another regression from #869 . This should be the last one, and I did my best to check all control panel implementations to make sure they are correctly referencing either `legacyRegularTime` or `legacyTimeseriesTime`.