### PR TITLE
fix(plugin-chart-echarts): remove columns from formData

### DIFF
--- a/plugins/plugin-chart-echarts/src/BoxPlot/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/buildQuery.ts
@@ -45,6 +45,7 @@ export default function buildQuery(formData: BoxPlotQueryFormData) {
         ...baseQueryObject,
         is_timeseries: distributionColumns.length === 0,
         groupby: (groupby || []).concat(distributionColumns),
+        columns: [],
         post_processing: [
           {
             operation: 'boxplot',

--- a/plugins/plugin-chart-echarts/test/BoxPlot/buildQuery.test.ts
+++ b/plugins/plugin-chart-echarts/test/BoxPlot/buildQuery.test.ts
@@ -38,6 +38,7 @@ describe('BoxPlot buildQuery', () => {
     expect(query.is_timeseries).toEqual(true);
     expect(query.metrics).toEqual(['foo']);
     expect(query.groupby).toEqual(['bar']);
+    expect(query.columns).toEqual([]);
   });
 
   it('should build non-timeseries query object when columns is defined', () => {
@@ -46,5 +47,6 @@ describe('BoxPlot buildQuery', () => {
     expect(query.is_timeseries).toEqual(false);
     expect(query.metrics).toEqual(['foo']);
     expect(query.groupby).toEqual(['bar', 'qwerty']);
+    expect(query.columns).toEqual([]);
   });
 });


### PR DESCRIPTION
🐛 Bug Fix
Make sure `columns` property isn't defined in `formData`, as it is a reserved parameter with a specific meaning in `QueryObject`.
