### PR TITLE
feat(legacy-preset-chart-nvd3): subject Add legend option to dual line chart

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts
@@ -18,7 +18,7 @@
  */
 import { t } from '@superset-ui/core';
 import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
-import { xAxisFormat, yAxis2Format } from '../NVD3Controls';
+import { xAxisFormat, yAxis2Format, showLegend } from '../NVD3Controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -26,7 +26,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Chart Options'),
       expanded: true,
-      controlSetRows: [['color_scheme', 'label_colors'], [xAxisFormat]],
+      controlSetRows: [['color_scheme', 'label_colors'], [showLegend], [xAxisFormat]],
     },
     {
       label: t('Y Axis 1'),

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
@@ -135,7 +135,7 @@ export const showLegend: CustomControlItem = {
     type: 'CheckboxControl',
     label: t('Legend'),
     renderTrigger: true,
-    default: true,
+    default: false,
     description: t('Whether to display the legend (toggles)'),
   },
 };

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -668,11 +668,6 @@ function nvd3Vis(element, props) {
       chart.interactiveLayer.tooltip.contentGenerator(d =>
         generateMultiLineTooltipContent(d, xAxisFormatter, yAxisFormatters),
       );
-      if (vizType === 'dual_line') {
-        chart.showLegend(width > BREAKPOINTS.small);
-      } else {
-        chart.showLegend(showLegend);
-      }
     }
     // This is needed for correct chart dimensions if a chart is rendered in a hidden container
     chart.width(width);


### PR DESCRIPTION
Add legend options for nvd3 with default false, The only chart that misses the legend option is Dual Line

related to: https://github.com/apache-superset/superset-roadmap/issues/92

## BEFORE DUAL LINE
![image](https://user-images.githubusercontent.com/8277264/105172850-e395d900-5b28-11eb-8ef0-e6f064bf9c84.png)

## AFTER DUAL LINE
![after-dual](https://user-images.githubusercontent.com/8277264/105173083-353e6380-5b29-11eb-9709-4082ca2eb38f.gif)

