### PR TITLE
fix: remove max-width from tooltip div

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -1153,7 +1153,7 @@ function nvd3Vis(element, props) {
       }
     }
 
-    wrapTooltip(chart, maxWidth);
+    wrapTooltip(chart);
 
     return chart;
   };

--- a/plugins/legacy-preset-chart-nvd3/src/utils.js
+++ b/plugins/legacy-preset-chart-nvd3/src/utils.js
@@ -307,7 +307,7 @@ export function removeTooltip(uuid) {
   }
 }
 
-export function wrapTooltip(chart, maxWidth) {
+export function wrapTooltip(chart) {
   const tooltipLayer =
     chart.useInteractiveGuideline && chart.useInteractiveGuideline()
       ? chart.interactiveLayer

--- a/plugins/legacy-preset-chart-nvd3/src/utils.js
+++ b/plugins/legacy-preset-chart-nvd3/src/utils.js
@@ -314,7 +314,7 @@ export function wrapTooltip(chart, maxWidth) {
       : chart;
   const tooltipGeneratorFunc = tooltipLayer.tooltip.contentGenerator();
   tooltipLayer.tooltip.contentGenerator(d => {
-    let tooltip = `<div style="max-width: ${maxWidth * 0.5}px">`;
+    let tooltip = `<div>`;
     tooltip += tooltipGeneratorFunc(d);
     tooltip += '</div>';
 


### PR DESCRIPTION
🐛 Bug Fix

This fixes an issue where the rich tooltip text will overflow outside of the tooltip box in Superset.

Before:
![105507084-a09a4980-5c7f-11eb-95fe-9eda8b2d56b3](https://user-images.githubusercontent.com/5475421/105546420-38189000-5cb2-11eb-96ed-852dea4ad308.png)

After:
![Screen Shot 2021-01-22 at 1 05 29 PM](https://user-images.githubusercontent.com/5475421/105546733-95144600-5cb2-11eb-89a8-5af5b424eaaf.png)


This fixes Superset issue 12688 https://github.com/apache/superset/issues/12688
