### PR TITLE
fix(chart-controls): add a tooltip to span in ColumnOption, refactor RB Tooltips to Antd

### DIFF
--- a/packages/superset-ui-chart-controls/package.json
+++ b/packages/superset-ui-chart-controls/package.json
@@ -33,6 +33,7 @@
   "peerDependencies": {
     "@types/react": "*",
     "@types/react-bootstrap": "*",
+    "antd": "^4.9.1",
     "react": "^16.13.1",
     "react-bootstrap": "^0.33.1"
   }

--- a/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -54,6 +54,7 @@ export function ColumnOption({ column, showType = false }: ColumnOptionProps) {
           icon="info"
           tooltip={column.description}
           label={`descr-${column.column_name}`}
+          placement="top"
         />
       )}
       {hasExpression && (
@@ -62,6 +63,7 @@ export function ColumnOption({ column, showType = false }: ColumnOptionProps) {
           icon="question-circle-o"
           tooltip={column.expression}
           label={`expr-${column.column_name}`}
+          placement="top"
         />
       )}
     </span>

--- a/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-
+import { Tooltip } from './Tooltip';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import { ColumnMeta } from '../types';
@@ -40,7 +40,14 @@ export function ColumnOption({ column, showType = false }: ColumnOptionProps) {
   return (
     <span>
       {showType && columnType && <ColumnTypeLabel type={columnType} />}
-      <span className="m-r-5 option-label">{column.verbose_name || column.column_name}</span>
+      <Tooltip
+        id="metric-name-tooltip"
+        title={column.verbose_name || column.column_name}
+        trigger={['hover']}
+        placement="top"
+      >
+        <span className="m-r-5 option-label">{column.verbose_name || column.column_name}</span>
+      </Tooltip>
       {column.description && (
         <InfoTooltipWithTrigger
           className="m-r-5 text-muted"

--- a/packages/superset-ui-chart-controls/src/components/InfoTooltipWithTrigger.tsx
+++ b/packages/superset-ui-chart-controls/src/components/InfoTooltipWithTrigger.tsx
@@ -16,19 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { CSSProperties } from 'react';
+import React from 'react';
 import { kebabCase } from 'lodash';
-import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 import { t } from '@superset-ui/core';
-
-const tooltipStyle: CSSProperties = { wordWrap: 'break-word' };
+import { Tooltip } from './Tooltip';
 
 export interface InfoTooltipWithTriggerProps {
   label?: string;
   tooltip?: string;
   icon?: string;
   onClick?: () => void;
-  placement?: string;
+  placement?:
+    | 'right'
+    | 'top'
+    | 'left'
+    | 'bottom'
+    | 'topLeft'
+    | 'topRight'
+    | 'bottomLeft'
+    | 'bottomRight'
+    | 'leftTop'
+    | 'leftBottom'
+    | 'rightTop'
+    | 'rightBottom';
   bsStyle?: string;
   className?: string;
 }
@@ -65,16 +75,9 @@ export function InfoTooltipWithTrigger({
     return iconEl;
   }
   return (
-    <OverlayTrigger
-      placement={placement}
-      overlay={
-        <Tooltip id={`${kebabCase(label)}-tooltip`} style={tooltipStyle}>
-          {tooltip}
-        </Tooltip>
-      }
-    >
+    <Tooltip id={`${kebabCase(label)}-tooltip`} title={tooltip} placement={placement}>
       {iconEl}
-    </OverlayTrigger>
+    </Tooltip>
   );
 }
 

--- a/packages/superset-ui-chart-controls/src/components/InfoTooltipWithTrigger.tsx
+++ b/packages/superset-ui-chart-controls/src/components/InfoTooltipWithTrigger.tsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import { kebabCase } from 'lodash';
+import { TooltipPlacement } from 'antd/lib/tooltip';
 import { t } from '@superset-ui/core';
 import { Tooltip } from './Tooltip';
 
@@ -26,19 +27,7 @@ export interface InfoTooltipWithTriggerProps {
   tooltip?: string;
   icon?: string;
   onClick?: () => void;
-  placement?:
-    | 'right'
-    | 'top'
-    | 'left'
-    | 'bottom'
-    | 'topLeft'
-    | 'topRight'
-    | 'bottomLeft'
-    | 'bottomRight'
-    | 'leftTop'
-    | 'leftBottom'
-    | 'rightTop'
-    | 'rightBottom';
+  placement?: TooltipPlacement;
   bsStyle?: string;
   className?: string;
 }

--- a/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
+++ b/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
@@ -3,12 +3,13 @@ import { useTheme } from '@superset-ui/core';
 import { Tooltip as BaseTooltip } from 'antd';
 import { TooltipProps } from 'antd/lib/tooltip';
 
-export const Tooltip = (props: TooltipProps) => {
+export const Tooltip = ({ overlayStyle, color, ...props }: TooltipProps) => {
   const theme = useTheme();
+  const defaultColor = `${theme.colors.grayscale.dark2}e6`;
   return (
     <BaseTooltip
-      overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6' }}
-      color={`${theme.colors.grayscale.dark2}e6`}
+      overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6', ...overlayStyle }}
+      color={defaultColor || color}
       {...props}
     />
   );

--- a/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
+++ b/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useTheme } from '@superset-ui/core';
+import { Tooltip as BaseTooltip } from 'antd';
+import { TooltipProps } from 'antd/lib/tooltip';
+
+export const Tooltip = (props: TooltipProps) => {
+  const theme = useTheme();
+  return (
+    <BaseTooltip
+      overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6' }}
+      color={`${theme.colors.grayscale.dark2}e6`}
+      {...props}
+    />
+  );
+};

--- a/packages/superset-ui-chart-controls/test/components/InfoTooltipWithTrigger.test.tsx
+++ b/packages/superset-ui-chart-controls/test/components/InfoTooltipWithTrigger.test.tsx
@@ -18,13 +18,13 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { OverlayTrigger } from 'react-bootstrap';
+import { Tooltip } from '../../src/components/Tooltip';
 import { InfoTooltipWithTrigger } from '../../src';
 
 describe('InfoTooltipWithTrigger', () => {
   it('renders a tooltip', () => {
     const wrapper = shallow(<InfoTooltipWithTrigger label="test" tooltip="this is a test" />);
-    expect(wrapper.find(OverlayTrigger)).toHaveLength(1);
+    expect(wrapper.find(Tooltip)).toHaveLength(1);
   });
 
   it('renders an info icon', () => {


### PR DESCRIPTION
Replace RB Tooltips with Antd in `InfoTooltipWithTrigger` to unify UI, wrap metric name in a tooltip.
Change in `InfoTooltipWithTrigger` may affect multiple components in Explore
CC: @villebro

![image](https://user-images.githubusercontent.com/15073128/105725783-a5822600-5f29-11eb-9d79-d7d61c48dea3.png)

