### PR TITLE
feat(core): add orderby to extractQueryFields

### DIFF
--- a/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -25,9 +25,9 @@ export default function buildQueryObject<T extends QueryFormData>(
     time_range,
     since,
     until,
-    order_desc,
     row_limit,
     row_offset,
+    order_desc,
     limit,
     timeseries_limit_metric,
     granularity,
@@ -38,7 +38,7 @@ export default function buildQueryObject<T extends QueryFormData>(
 
   const numericRowLimit = Number(row_limit);
   const numericRowOffset = Number(row_offset);
-  const { metrics, columns } = extractQueryFields(residualFormData, queryFields);
+  const { metrics, columns, orderby } = extractQueryFields(residualFormData, queryFields);
 
   const extras = extractExtras(formData);
   const extrasAndfilters = processFilters({
@@ -56,12 +56,12 @@ export default function buildQueryObject<T extends QueryFormData>(
     annotation_layers,
     columns,
     metrics,
-    order_desc: typeof order_desc === 'undefined' ? true : order_desc,
-    orderby: [],
+    orderby,
     row_limit: row_limit == null || Number.isNaN(numericRowLimit) ? undefined : numericRowLimit,
     row_offset: row_offset == null || Number.isNaN(numericRowOffset) ? undefined : numericRowOffset,
     timeseries_limit: limit ? Number(limit) : 0,
     timeseries_limit_metric,
+    order_desc: typeof order_desc === 'undefined' ? true : order_desc,
     url_params,
   };
   // append and override extra form data used by native filters

--- a/packages/superset-ui-core/src/query/extractQueryFields.ts
+++ b/packages/superset-ui-core/src/query/extractQueryFields.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { t } from '../translation';
 import { DTTM_ALIAS } from './buildQueryObject';
 import { QueryFields, QueryFieldAliases, FormDataResidual, QueryMode } from './types/QueryFormData';
 
@@ -41,11 +42,13 @@ export default function extractQueryFields(
     size: 'metrics',
     all_columns: 'columns',
     series: 'groupby',
+    order_by_cols: 'orderby',
     ...aliases,
   };
   const finalQueryFields: QueryFields = {
     columns: [],
     metrics: [],
+    orderby: [],
   };
   const { query_mode: queryMode, include_time: includeTime, ...restFormData } = formData;
 
@@ -64,14 +67,21 @@ export default function extractQueryFields(
     ) {
       return;
     }
+
     // ignore columns when (specifically) in aggregate mode.
+    // For charts that support both aggregate and raw records mode,
+    // we store both `groupby` and `columns` in `formData`, so users can
+    // switch between modes while retaining the selected options for each.
     if (queryMode === QueryMode.aggregate && normalizedKey === 'columns') {
       return;
     }
-    // groupby has been deprecated: https://github.com/apache/superset/pull/9366
+
+    // groupby has been deprecated in QueryObject: https://github.com/apache/superset/pull/9366
+    // We translate all `groupby` to `columns`.
     if (normalizedKey === 'groupby') {
       normalizedKey = 'columns';
     }
+
     if (normalizedKey === 'metrics') {
       finalQueryFields[normalizedKey] = finalQueryFields[normalizedKey].concat(value);
     } else if (normalizedKey === 'columns') {
@@ -79,6 +89,19 @@ export default function extractQueryFields(
       finalQueryFields[normalizedKey] = finalQueryFields[normalizedKey]
         .concat(value)
         .filter(x => typeof x === 'string' && x);
+    } else if (normalizedKey === 'orderby') {
+      finalQueryFields[normalizedKey] = finalQueryFields[normalizedKey].concat(value).map(item => {
+        // value can be in the format of `['["col1", true]', '["col2", false]'],
+        // where the option strings come directly from `order_by_choices`.
+        if (typeof item === 'string') {
+          try {
+            return JSON.parse(item);
+          } catch (error) {
+            throw new Error(t('Found invalid orderby options'));
+          }
+        }
+        return item;
+      });
     }
   });
 

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -97,12 +97,6 @@ export interface QueryObject extends QueryFields, TimeRange, ResidualQueryObject
   /** SIMPLE having filters */
   having_filters?: QueryObjectFilterClause[];
 
-  /**
-   * A list of metrics to query the datasource for. Could be the name of a predefined
-   * metric or an adhoc metric.
-   */
-  metrics: QueryFormMetric[];
-
   post_processing?: (PostProcessingRule | undefined)[];
 
   /** Maximum numbers of rows to return */
@@ -116,8 +110,6 @@ export interface QueryObject extends QueryFields, TimeRange, ResidualQueryObject
 
   /** The metric used to sort the returned result. */
   timeseries_limit_metric?: Maybe<QueryFormMetric>;
-
-  orderby?: Array<[QueryFormMetric, boolean]>;
 
   /** Direction to ordered by */
   order_desc?: boolean;

--- a/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -29,11 +29,22 @@ import { QueryObject } from './Query';
 import { TimeRange, TimeRangeEndpoints } from './Time';
 import { TimeGranularity } from '../../time-format';
 
+/**
+ * Metric definition/reference in query object.
+ */
 export type QueryFormMetric = SavedMetric | AdhocMetric;
 
-// Column selects (used as dimensions in groupby and raw query mode) only
-// support existing columns for now.
+/**
+ * Column selects in query object (used as dimensions in both groupby or raw
+ * query mode). Only support referring existing columns.
+ */
 export type QueryFormColumn = string;
+
+/**
+ * Order query results by columns.
+ * Format: [metric/column, is_ascending].
+ */
+export type QueryFormOrderBy = [QueryFormColumn | QueryFormMetric, boolean];
 
 export interface FormDataResidual {
   [key: string]: any;
@@ -50,6 +61,7 @@ export enum QueryMode {
 export interface QueryFields {
   columns: QueryFormColumn[];
   metrics: QueryFormMetric[];
+  orderby: QueryFormOrderBy[];
 }
 
 /**

--- a/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/plugins/plugin-chart-table/src/buildQuery.ts
@@ -1,12 +1,23 @@
-import { buildQueryContext, getMetricLabel, removeDuplicates } from '@superset-ui/core';
+import { buildQueryContext, getMetricLabel, QueryMode, removeDuplicates } from '@superset-ui/core';
 import { PostProcessingRule } from '@superset-ui/core/src/query/types/PostProcessing';
 import { TableChartFormData } from './types';
 
 export default function buildQuery(formData: TableChartFormData) {
-  const { percent_metrics: percentMetrics } = formData;
+  const {
+    percent_metrics: percentMetrics,
+    timeseries_limit_metric: timeseriesLimitMetric,
+    query_mode: queryMode,
+    order_desc: orderDesc,
+  } = formData;
   return buildQueryContext(formData, baseQueryObject => {
-    let { metrics } = baseQueryObject;
+    let { metrics, orderby } = baseQueryObject;
     let postProcessing: PostProcessingRule[] = [];
+
+    // orverride orderby with timeseries metric when in aggregation mode
+    if (queryMode === QueryMode.aggregate && timeseriesLimitMetric && orderDesc != null) {
+      orderby = [[timeseriesLimitMetric, !orderDesc]];
+    }
+
     if (percentMetrics) {
       const percentMetricLabels = percentMetrics.map(getMetricLabel);
       metrics = removeDuplicates(metrics.concat(percentMetrics), getMetricLabel);
@@ -23,6 +34,7 @@ export default function buildQuery(formData: TableChartFormData) {
     return [
       {
         ...baseQueryObject,
+        orderby,
         metrics,
         post_processing: postProcessing,
       },

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -181,7 +181,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'SelectControl',
               label: t('Ordering'),
-              description: t('One or many metrics to display'),
+              description: t('Order results by selected columns'),
               multi: true,
               default: [],
               mapStateToProps: ({ datasource }) => ({


### PR DESCRIPTION
🏆 Enhancements
🐛 Bug Fix


Add `orderby` to `extractQueryFields`, which consolidates query options related to generating actual SQL queries. 

This should also fix sorting options in table chart. Previously each plugin has to do the `order_by_choices` parsing themselves (e.g. in [the now deprecated old new table chart](https://github.com/apache-superset/superset-ui/blob/master/temporary-plugins/hold-potentially-deprecate/superset-ui-plugin-chart-table/src/buildQuery.ts#L12-L22)), I figure it'd be useful to make this global, in case we want to support query mode switch for other viz types.

Related: #889 https://github.com/apache/superset/pull/10270