### PR TITLE
fix(plugin-chart-table): unnecessary post_processing in raw records mode

### DIFF
--- a/plugins/plugin-chart-table/test/buildQuery.test.ts
+++ b/plugins/plugin-chart-table/test/buildQuery.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryMode } from '@superset-ui/core';
+import buildQuery from '../src/buildQuery';
+import { TableChartFormData } from '../src/types';
+
+const basicFormData: TableChartFormData = {
+  viz_type: 'table',
+  datasource: '11__table',
+};
+
+describe('plugin-chart-table', () => {
+  describe('buildQuery', () => {
+    it('should add post-processing in aggregate mode', () => {
+      const query = buildQuery({
+        ...basicFormData,
+        query_mode: QueryMode.aggregate,
+        metrics: ['aaa'],
+        percent_metrics: ['pct_abc'],
+      }).queries[0];
+      expect(query.metrics).toEqual(['aaa', 'pct_abc']);
+      expect(query.post_processing).toEqual([
+        {
+          operation: 'contribution',
+          options: {
+            columns: ['pct_abc'],
+            rename_columns: ['%pct_abc'],
+          },
+        },
+      ]);
+    });
+
+    it('should not add post-processing when there is not percent metric', () => {
+      const query = buildQuery({
+        ...basicFormData,
+        query_mode: QueryMode.aggregate,
+        metrics: ['aaa'],
+        percent_metrics: [],
+      }).queries[0];
+      expect(query.metrics).toEqual(['aaa']);
+      expect(query.post_processing).toEqual([]);
+    });
+
+    it('should not add post-processing in raw records mode', () => {
+      const query = buildQuery({
+        ...basicFormData,
+        query_mode: QueryMode.raw,
+        metrics: ['aaa'],
+        columns: ['rawcol'],
+        percent_metrics: ['ccc'],
+      }).queries[0];
+      expect(query.metrics).toEqual([]);
+      expect(query.columns).toEqual(['rawcol']);
+      expect(query.post_processing).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
🐛 Bug Fix

Table chart should not send `post_processing` when in raw records mode.

Closes https://github.com/apache/superset/issues/12853

### Test Plan

Added new unit tests

To test in Superset, go to the "Games" sample chart:

<img width="939" alt="global_sales" src="https://user-images.githubusercontent.com/335541/106424606-4f285200-6417-11eb-862a-c6bc8ac3e555.png">

Which has a Raw Records query, the `global_sales` should display the same value as in the data samples.
