### PR TITLE
fix(plugin-chart-table): refine ordering logic

### DIFF
--- a/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/plugins/plugin-chart-table/src/buildQuery.ts
@@ -1,22 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import { buildQueryContext, getMetricLabel, QueryMode, removeDuplicates } from '@superset-ui/core';
 import { PostProcessingRule } from '@superset-ui/core/src/query/types/PostProcessing';
 import { TableChartFormData } from './types';
+import { extractTimeseriesLimitMetric } from './utils/extractOrderby';
 
 export default function buildQuery(formData: TableChartFormData) {
-  const {
-    percent_metrics: percentMetrics,
-    timeseries_limit_metric: timeseriesLimitMetric,
-    query_mode: queryMode,
-    order_desc: orderDesc,
-  } = formData;
+  const { percent_metrics: percentMetrics, order_desc: orderDesc = null } = formData;
+  let { query_mode: queryMode } = formData;
+  const timeseriesLimitMetric = extractTimeseriesLimitMetric(formData.timeseries_limit_metric);
   return buildQueryContext(formData, baseQueryObject => {
     let { metrics, orderby } = baseQueryObject;
+    if (queryMode === undefined && metrics.length > 0) {
+      queryMode = QueryMode.aggregate;
+    }
     let postProcessing: PostProcessingRule[] = [];
 
     if (queryMode === QueryMode.aggregate) {
       // orverride orderby with timeseries metric when in aggregation mode
-      if (timeseriesLimitMetric && orderDesc != null) {
-        orderby = [[timeseriesLimitMetric, !orderDesc]];
+      if (timeseriesLimitMetric.length > 0 && orderDesc != null) {
+        orderby = [[timeseriesLimitMetric[0], !orderDesc]];
+      } else if (timeseriesLimitMetric.length === 0 && metrics?.length > 0 && orderDesc != null) {
+        // default to ordering by first metric when no sort order has been specified
+        orderby = [[metrics[0], !orderDesc]];
       }
       // add postprocessing for percent metrics only when in aggregation mode
       if (percentMetrics && percentMetrics.length > 0) {

--- a/plugins/plugin-chart-table/src/types.ts
+++ b/plugins/plugin-chart-table/src/types.ts
@@ -55,7 +55,7 @@ export type TableChartFormData = QueryFormData & {
   page_length?: string | number | null; // null means auto-paginate
   metrics?: QueryFormMetric[] | null;
   percent_metrics?: QueryFormMetric[] | null;
-  timeseries_limit_metric?: QueryFormMetric | null;
+  timeseries_limit_metric?: QueryFormMetric[] | QueryFormMetric | null;
   groupby?: QueryFormMetric[] | null;
   all_columns?: QueryFormMetric[] | null;
   order_desc?: boolean;

--- a/plugins/plugin-chart-table/src/utils/extractOrderby.ts
+++ b/plugins/plugin-chart-table/src/utils/extractOrderby.ts
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryFormMetric } from '@superset-ui/core';
+
+export function extractTimeseriesLimitMetric(
+  timeSeriesLimitMetric?: QueryFormMetric[] | QueryFormMetric | null,
+): QueryFormMetric[] {
+  if (timeSeriesLimitMetric === undefined || timeSeriesLimitMetric === null) {
+    return [];
+  }
+  if (Array.isArray(timeSeriesLimitMetric)) {
+    return timeSeriesLimitMetric;
+  }
+  return [timeSeriesLimitMetric];
+}

--- a/plugins/plugin-chart-table/test/utils.test.ts
+++ b/plugins/plugin-chart-table/test/utils.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { extractTimeseriesLimitMetric } from '../src/utils/extractOrderby';
+
+describe('utils', () => {
+  it('should add post-processing in aggregate mode', () => {
+    expect(extractTimeseriesLimitMetric(undefined)).toEqual([]);
+    expect(extractTimeseriesLimitMetric(null)).toEqual([]);
+    expect(extractTimeseriesLimitMetric([])).toEqual([]);
+    expect(extractTimeseriesLimitMetric('my_metric')).toEqual(['my_metric']);
+    expect(extractTimeseriesLimitMetric(['my_metric'])).toEqual(['my_metric']);
+    expect(extractTimeseriesLimitMetric(['my_metric_1', 'my_metric_2'])).toEqual([
+      'my_metric_1',
+      'my_metric_2',
+    ]);
+  });
+});


### PR DESCRIPTION
🐛 Bug Fix
Previously table chart would by default order by the first metric if no sort order was specified. This replicates the logic from the old `viz.py` implementation and also fixes a few minor issues in the current code:
- Infer `queryMode` from `formData` contents; if it's undefined and `metrics` is not empty, assume `QueryMode.aggregate`. This is the case in some old metadata, e.g. the World Bank example dashboard.
- `timeseries_limit_metric` is `[]` when the control is unset, and `QueryFormMetric` when set. The type is updated and a util is added for normalizing to `QueryFormMetric[]` + relevant tests.
- Added a missing license header.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/106765713-c5a89800-6641-11eb-8d71-b3335073a7fa.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/106765775-d5c07780-6641-11eb-9b13-81ab800d71b4.png)
