### PR TITLE
fix(plugin-chart-table): always sort descending by first metric

### DIFF
--- a/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -47,22 +47,24 @@ export default function buildQueryObject<T extends QueryFormData>(
   });
 
   let queryObject: QueryObject = {
-    time_range,
-    since,
-    until,
-    granularity,
+    // fallback `null` to `undefined` so they won't be sent to the backend
+    // (JSON.strinify will ignore `undefined`.)
+    time_range: time_range || undefined,
+    since: since || undefined,
+    until: until || undefined,
+    granularity: granularity || undefined,
     ...extras,
     ...extrasAndfilters,
-    annotation_layers,
     columns,
     metrics,
     orderby,
+    annotation_layers,
     row_limit: row_limit == null || Number.isNaN(numericRowLimit) ? undefined : numericRowLimit,
     row_offset: row_offset == null || Number.isNaN(numericRowOffset) ? undefined : numericRowOffset,
     timeseries_limit: limit ? Number(limit) : 0,
-    timeseries_limit_metric,
+    timeseries_limit_metric: timeseries_limit_metric || undefined,
     order_desc: typeof order_desc === 'undefined' ? true : order_desc,
-    url_params,
+    url_params: url_params || undefined,
   };
   // append and override extra form data used by native filters
   queryObject = appendExtraFormData(queryObject, append_form_data);

--- a/packages/superset-ui-core/src/utils/ensureIsArray.ts
+++ b/packages/superset-ui-core/src/utils/ensureIsArray.ts
@@ -16,16 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryFormMetric } from '@superset-ui/core';
 
-export function extractTimeseriesLimitMetric(
-  timeSeriesLimitMetric?: QueryFormMetric[] | QueryFormMetric | null,
-): QueryFormMetric[] {
-  if (timeSeriesLimitMetric === undefined || timeSeriesLimitMetric === null) {
+/**
+ * Ensure a nullable value input is an array. Useful when consolidating
+ * input format from a select control.
+ */
+export default function ensureIsArray<T>(value?: T[] | T | null): T[] {
+  if (value === undefined || value === null) {
     return [];
   }
-  if (Array.isArray(timeSeriesLimitMetric)) {
-    return timeSeriesLimitMetric;
-  }
-  return [timeSeriesLimitMetric];
+  return Array.isArray(value) ? value : [value];
 }

--- a/packages/superset-ui-core/src/utils/index.ts
+++ b/packages/superset-ui-core/src/utils/index.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 export { default as convertKeysToCamelCase } from './convertKeysToCamelCase';
+export { default as ensureIsArray } from './ensureIsArray';
 export { default as isDefined } from './isDefined';
 export { default as isRequired } from './isRequired';
 export { default as makeSingleton } from './makeSingleton';

--- a/packages/superset-ui-core/test/query/buildQueryObject.test.ts
+++ b/packages/superset-ui-core/test/query/buildQueryObject.test.ts
@@ -201,13 +201,21 @@ describe('buildQueryObject', () => {
   });
 
   it('should populate url_params', () => {
-    const urlParams = { abc: '123' };
-    query = buildQueryObject({
-      datasource: '5__table',
-      granularity_sqla: 'ds',
-      viz_type: 'table',
-      url_params: urlParams,
-    });
-    expect(query.url_params).toEqual(urlParams);
+    expect(
+      buildQueryObject({
+        datasource: '5__table',
+        granularity_sqla: 'ds',
+        viz_type: 'table',
+        url_params: { abc: '123' },
+      }).url_params,
+    ).toEqual({ abc: '123' });
+    expect(
+      buildQueryObject({
+        datasource: '5__table',
+        granularity_sqla: 'ds',
+        viz_type: 'table',
+        url_params: (null as unknown) as undefined,
+      }).url_params,
+    ).toBeUndefined();
   });
 });

--- a/packages/superset-ui-core/test/utils/ensureIsArray.test.ts
+++ b/packages/superset-ui-core/test/utils/ensureIsArray.test.ts
@@ -16,18 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { extractTimeseriesLimitMetric } from '../src/utils/extractOrderby';
+import { ensureIsArray } from '../../src';
 
-describe('utils', () => {
-  it('should add post-processing in aggregate mode', () => {
-    expect(extractTimeseriesLimitMetric(undefined)).toEqual([]);
-    expect(extractTimeseriesLimitMetric(null)).toEqual([]);
-    expect(extractTimeseriesLimitMetric([])).toEqual([]);
-    expect(extractTimeseriesLimitMetric('my_metric')).toEqual(['my_metric']);
-    expect(extractTimeseriesLimitMetric(['my_metric'])).toEqual(['my_metric']);
-    expect(extractTimeseriesLimitMetric(['my_metric_1', 'my_metric_2'])).toEqual([
-      'my_metric_1',
-      'my_metric_2',
-    ]);
+describe('ensureIsArray', () => {
+  it('handle inputs correctly', () => {
+    expect(ensureIsArray(undefined)).toEqual([]);
+    expect(ensureIsArray(null)).toEqual([]);
+    expect(ensureIsArray([])).toEqual([]);
+    expect(ensureIsArray('my_metric')).toEqual(['my_metric']);
+    expect(ensureIsArray(['my_metric'])).toEqual(['my_metric']);
+    expect(ensureIsArray(['my_metric_1', 'my_metric_2'])).toEqual(['my_metric_1', 'my_metric_2']);
   });
 });

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -24,6 +24,7 @@ import {
   addLocaleData,
   smartDateFormatter,
   QueryMode,
+  QueryFormColumn,
 } from '@superset-ui/core';
 import {
   formatSelectOptions,
@@ -60,8 +61,8 @@ function getQueryMode(controls: ControlStateMapping): QueryMode {
   if (mode === QueryMode.aggregate || mode === QueryMode.raw) {
     return mode as QueryMode;
   }
-  const rawColumns = controls?.all_columns?.value;
-  const hasRawColumns = rawColumns && (rawColumns as string[])?.length > 0;
+  const rawColumns: QueryFormColumn[] | undefined = controls?.all_columns?.value;
+  const hasRawColumns = rawColumns && rawColumns.length > 0;
   return hasRawColumns ? QueryMode.raw : QueryMode.aggregate;
 }
 


### PR DESCRIPTION
🐛 Bug Fix

Follow up for #930 . When there is not "Sort by" metric specified, [the original logic](https://github.com/apache/superset/blob/32f2c45f93693156f1cf88c2c5223684c31d3f20/superset/viz.py#L746) pre [the API migration](https://github.com/apache-superset/superset-ui/pull/889) is to always sort by the first metric in descending order, regardless if "Sort descending" is set.

Did some refactoring on table chart's `buildQuery`:

- Introduce a more general `ensureIsArray` utils, as replacement for `extractTimeseriesLimitMetric`
- Change `queryMode` inference logic to be the same as in the control panel configs.


I'm also slipping a small refactor on `buildQueryObject` where `null` values are fell back to `undefined` so that `null`s are not sent to the backend. Even thought the backend has now taken care of `null`s as well: https://github.com/apache/superset/pull/12905