### PR TITLE
fix(plugin-chart-table): better rendering for temporal columns

### DIFF
--- a/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/plugins/plugin-chart-table/src/buildQuery.ts
@@ -46,7 +46,17 @@ export default function buildQuery(formData: TableChartFormData) {
   const { percent_metrics: percentMetrics, order_desc: orderDesc = false } = formData;
   const queryMode = getQueryMode(formData);
   const sortByMetric = ensureIsArray(formData.timeseries_limit_metric)[0];
-  return buildQueryContext(formData, baseQueryObject => {
+  let formDataCopy = formData;
+
+  // never include time in raw records mode
+  if (queryMode === QueryMode.raw) {
+    formDataCopy = {
+      ...formData,
+      include_time: false,
+    };
+  }
+
+  return buildQueryContext(formDataCopy, baseQueryObject => {
     let { metrics, orderby } = baseQueryObject;
     let postProcessing: PostProcessingRule[] = [];
 

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -25,6 +25,7 @@ import {
   smartDateFormatter,
   getTimeFormatterForGranularity,
   TimeFormatter,
+  TimeFormats,
   GenericDataType,
   getMetricLabel,
 } from '@superset-ui/core';
@@ -34,6 +35,7 @@ import DateWithFormatter from './utils/DateWithFormatter';
 import { TableChartProps, TableChartTransformedProps, DataColumnMeta } from './types';
 
 const { PERCENT_3_POINT } = NumberFormats;
+const { DATABASE_DATETIME } = TimeFormats;
 const TIME_COLUMN = '__timestamp';
 
 function isTimeColumn(key: string) {
@@ -114,9 +116,12 @@ const processColumns = memoizeOne(function processColumns(props: TableChartProps
           } else if (format) {
             // other columns respect the column-specific format
             formatter = getTimeFormatter(format);
+          } else if (isNumeric(key, records)) {
+            // if column is numeric values, it is considered a timestamp64
+            formatter = getTimeFormatter(DATABASE_DATETIME);
           } else {
-            // if no column-specific format, use smart_date
-            formatter = smartDateFormatter;
+            // if no column-specific format, print cell as is
+            formatter = String;
           }
         } else if (timeFormat) {
           formatter = getTimeFormatter(timeFormat);

--- a/plugins/plugin-chart-table/src/types.ts
+++ b/plugins/plugin-chart-table/src/types.ts
@@ -50,6 +50,7 @@ export interface TableChartData {
 export type TableChartFormData = QueryFormData & {
   align_pn?: boolean;
   color_pn?: boolean;
+  include_time?: boolean;
   include_search?: boolean;
   query_mode?: QueryMode;
   page_length?: string | number | null; // null means auto-paginate


### PR DESCRIPTION
🐛 Bug Fix

Display temporal columns more smartly. I.e. when in "Adaptive formatting":

1. if the backend returns them as string, display as is
2. if they are numbers, then assume they are timestamps and display as full UTC timestamps

Also fixes a bug where wrong query is generated when "Include time" is selected then switch to run raw records queries.

### Test Plan

Tested with this virtual dataset in PostgreSQL:

```
SELECT TIMESTAMP '2021-01-01T11:12:33.113' as ts, '2021-01-01T11:12:33' AS ts_str, 'aa' as text, 10000000 as num
UNION
SELECT TIMESTAMP '2021-01-01T00:00:00', '2021-01-09T10:11:22', 'ccc', 11.114491
UNION
SELECT TIMESTAMP '2021-01-09T11:10:33', '2021-01-09T10:11:22', 'ccc', 11.114491
UNION
SELECT TIMESTAMP '2021-01-09T11:10:00', '2021-01-09T10:11:22', 'abc', 11.114491
UNION
SELECT TIMESTAMP '2021-01-09T11:00:00', '2021-01-09T10:11:22', 'ama', 11.114491
UNION
SELECT TIMESTAMP '2021-01-09T00:00:00', '2021-01-09T10:11:22', 'abc', 11.114491
UNION
SELECT TIMESTAMP '2021-02-07T00:00:00', '2021-01-09T10:11:22', 'abc', 11.114491
UNION
SELECT TIMESTAMP '2021-02-08T00:00:00', '2021-01-09T10:11:22', 'abc', 11.114491
```

### Before

<img width="509" alt="before-format" src="https://user-images.githubusercontent.com/335541/106873595-7ab27300-6689-11eb-9695-a97a28633e35.png">

<img width="562" alt="before-format-aggregate" src="https://user-images.githubusercontent.com/335541/106874105-0c21e500-668a-11eb-99ce-d1aa488f682b.png">


### After

<img width="551" alt="after-format" src="https://user-images.githubusercontent.com/335541/106877604-c9faa280-668d-11eb-8821-3e480b5136a9.png">

<img width="558" alt="after-format-aggregate" src="https://user-images.githubusercontent.com/335541/106877621-cf57ed00-668d-11eb-8129-fce182a2e779.png">
