### PR TITLE
fix(plugin-chart-echarts): label type and hover bugs

### DIFF
--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -29,7 +29,7 @@
     "@superset-ui/chart-controls": "0.17.5",
     "@superset-ui/core": "0.17.5",
     "@types/mathjs": "^6.0.7",
-    "echarts": "^5.0.1",
+    "echarts": "^5.0.2",
     "mathjs": "^8.0.1"
   },
   "peerDependencies": {

--- a/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
@@ -38,8 +38,6 @@ const {
   showLabels,
 } = DEFAULT_FORM_DATA;
 
-const noopControl = { name: 'noop', config: { type: '', renderTrigger: true } };
-
 const config: ControlPanelConfig = {
   controlPanelSections: [
     sections.legacyRegularTime,
@@ -52,17 +50,18 @@ const config: ControlPanelConfig = {
       label: t('Chart Options'),
       expanded: true,
       controlSetRows: [
-        ['color_scheme', noopControl],
+        ['color_scheme'],
         // eslint-disable-next-line react/jsx-key
         [<h1 className="section-header">{t('Legend')}</h1>],
         [showLegendControl],
-        [legendTypeControl, legendOrientationControl],
-        [legendMarginControl, noopControl],
+        [legendTypeControl],
+        [legendOrientationControl],
+        [legendMarginControl],
         // eslint-disable-next-line react/jsx-key
         [<h1 className="section-header">{t('Labels')}</h1>],
         [
           {
-            name: 'pie_label_type',
+            name: 'label_type',
             config: {
               type: 'SelectControl',
               label: t('Label Type'),
@@ -79,6 +78,8 @@ const config: ControlPanelConfig = {
               description: t('What should be shown on the label?'),
             },
           },
+        ],
+        [
           {
             name: 'number_format',
             config: {
@@ -117,6 +118,8 @@ const config: ControlPanelConfig = {
               description: t('Put the labels outside of the pie?'),
             },
           },
+        ],
+        [
           {
             name: 'label_line',
             config: {
@@ -144,7 +147,6 @@ const config: ControlPanelConfig = {
               description: t('Outer edge of Pie chart'),
             },
           },
-          noopControl,
         ],
         [
           {
@@ -172,7 +174,6 @@ const config: ControlPanelConfig = {
               description: t('Inner radius of donut hole'),
             },
           },
-          noopControl,
         ],
       ],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4644,13 +4644,6 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
-"@types/echarts@^4.9.3":
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/@types/echarts/-/echarts-4.9.3.tgz#8a143cf315f6ae88d0778d75a133b378974d37d5"
-  integrity sha512-CbgZUYdLy1G2BhCI6maBwVXmrqIx/D8KwUccMXQ9W2uyXNMjBvpIRXSs+UaBtvUihPV2f0g7LGj/yua1iY0VbQ==
-  dependencies:
-    "@types/zrender" "*"
-
 "@types/enzyme@^3.10.3":
   version "3.10.5"
   resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.5.tgz#fe7eeba3550369eed20e7fb565bfb74eec44f1f0"
@@ -5107,11 +5100,6 @@
   integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
   dependencies:
     "@types/yargs-parser" "*"
-
-"@types/zrender@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/zrender/-/zrender-4.0.0.tgz#a6806f12ec4eccaaebd9b0d816f049aca6188fbd"
-  integrity sha512-s89GOIeKFiod2KSqHkfd2rzx+T2DVu7ihZCBEBnhFrzvQPUmzvDSBot9Fi1DfMQm9Odg+rTqoMGC38RvrwJK2w==
 
 "@typescript-eslint/eslint-plugin@^4.1.0":
   version "4.9.0"
@@ -10080,13 +10068,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.0.0.tgz#66ec0ea47e3c93b2aadfbb2d719869932ad13ce0"
-  integrity sha512-6SDcJbLVOcfQyjPg+spNU1+JVrkU1B9fzUa5tpbP/mMNUPyigCOJwcEIQAJSbp9jt5UP3EXvQR0vtYXIo9AjyA==
+echarts@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.0.2.tgz#1726d17a57cf05d62cd0567b4325e1201a56baf6"
+  integrity sha512-En0VYpc96nw2/2AZoBWPHsGi471zMublttj50kfFpYAeR4geup0Tj9iVgEXh7QYZFPnRiruDJEjcB5PXZ+BYzQ==
   dependencies:
-    tslib "1.10.0"
-    zrender "5.0.1"
+    tslib "2.0.3"
+    zrender "5.0.4"
 
 editions@^2.2.0:
   version "2.3.0"
@@ -21759,10 +21747,10 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+tslib@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
@@ -23206,9 +23194,9 @@ yosay@^2.0.2:
     taketalk "^1.0.0"
     wrap-ansi "^2.0.0"
 
-zrender@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.0.1.tgz#cc377136a9d00d0a177ca7f65c32aed2901928da"
-  integrity sha512-i8FNCKAKfF0EfZFJ6w2p30umBrCyy481/PePFQqPdtNgCl5Hp5z7/dovqb7soEoFkhNvhjJ/J4W9zFALeae6yA==
+zrender@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.0.4.tgz#89c355af908b9f64a301b38f751b7951f2c8a95a"
+  integrity sha512-DJpy0yrHYY5CuH6vhb9IINWbjvBUe/56J8aH86Jb7O8rRPAYZ3M2E469Qf5B3EOIfM3o3aUrO5edRQfLJ+l1Qw==
   dependencies:
-    tslib "1.10.0"
+    tslib "2.0.3"


### PR DESCRIPTION
🐛 Bug Fix

Bump ECharts to 5.0.2 to fix hover bug (https://github.com/apache/echarts/pull/14108) and label type bug. Also clean up control panel so that all customization fields are on a single row.

### After
![image](https://user-images.githubusercontent.com/33317356/107146013-1ecc4080-694e-11eb-80e0-59b957d21299.png)

### Before
![image](https://user-images.githubusercontent.com/33317356/107146016-2b509900-694e-11eb-8fb6-f0cd2d38617b.png)

