### PR TITLE
feat(legacy-plugin-chart-sunburst): subject Add sort by metric

### DIFF
--- a/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
@@ -31,6 +31,16 @@ const config: ControlPanelConfig = {
         ['secondary_metric'],
         ['adhoc_filters'],
         ['row_limit'],
+        [
+          {
+            name: 'sort_by_metric',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort by metric'),
+              description: t('Whether to sort results by the selected metric in descending order.'),
+            },
+          },
+        ],
       ],
     },
     {


### PR DESCRIPTION
### SUMMARY
Add sort by by metric for sunburst chart

Associated with: https://github.com/apache/superset/pull/13053

### After
![sunburst](https://user-images.githubusercontent.com/8277264/107503853-1de01c80-6ba3-11eb-9408-ab66c066dc7e.gif)
