### PR TITLE
feat: add sort by metric for charts with multiple metrics

### DIFF
--- a/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-parallel-coordinates/src/controlPanel.ts
@@ -31,6 +31,18 @@ const config: ControlPanelConfig = {
         ['secondary_metric'],
         ['adhoc_filters'],
         ['limit', 'row_limit'],
+        ['timeseries_limit_metric'],
+        [
+          {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort Descending'),
+              default: true,
+              description: t('Whether to sort descending or ascending'),
+            },
+          },
+        ],
       ],
     },
     {

--- a/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-pivot-table/src/controlPanel.ts
@@ -38,6 +38,18 @@ const config: ControlPanelConfig = {
         ['groupby'],
         ['columns'],
         ['row_limit', null],
+        ['timeseries_limit_metric'],
+        [
+          {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort Descending'),
+              default: true,
+              description: t('Whether to sort descending or ascending'),
+            },
+          },
+        ],
       ],
     },
     {

--- a/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-treemap/src/controlPanel.ts
@@ -30,7 +30,24 @@ const config: ControlPanelConfig = {
     {
       label: t('Query'),
       expanded: true,
-      controlSetRows: [['metrics'], ['adhoc_filters'], ['groupby'], ['row_limit']],
+      controlSetRows: [
+        ['metrics'],
+        ['adhoc_filters'],
+        ['groupby'],
+        ['row_limit'],
+        ['timeseries_limit_metric'],
+        [
+          {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort Descending'),
+              default: true,
+              description: t('Whether to sort descending or ascending'),
+            },
+          },
+        ],
+      ],
     },
     {
       label: t('Chart Options'),


### PR DESCRIPTION
### SUMMARY
Add sort by metric charts with multiple metrics

Associated with: https://github.com/apache/superset/pull/13057

### pivot-table
![pivot](https://user-images.githubusercontent.com/8277264/107524456-77097980-6bbe-11eb-915b-51f35bd4944c.gif)

### parallel-coordinates
![parallel-coordinates](https://user-images.githubusercontent.com/8277264/107627609-38c89480-6c68-11eb-967d-e922c9e3bbe8.gif)

### treemap
![treemap](https://user-images.githubusercontent.com/8277264/107635199-6c5cec00-6c73-11eb-95aa-26b7cb15050f.gif)
