### PR TITLE
feat: Single metric sort

### DIFF
--- a/plugins/legacy-plugin-chart-chord/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-chord/src/controlPanel.ts
@@ -25,7 +25,23 @@ const config: ControlPanelConfig = {
     {
       label: t('Query'),
       expanded: true,
-      controlSetRows: [['groupby'], ['columns'], ['metric'], ['adhoc_filters'], ['row_limit']],
+      controlSetRows: [
+        ['groupby'],
+        ['columns'],
+        ['metric'],
+        ['adhoc_filters'],
+        ['row_limit'],
+        [
+          {
+            name: 'sort_by_metric',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort by metric'),
+              description: t('Whether to sort results by the selected metric in descending order.'),
+            },
+          },
+        ],
+      ],
     },
     {
       label: t('Chart Options'),

--- a/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-force-directed/src/controlPanel.ts
@@ -25,7 +25,22 @@ export default {
     {
       label: t('Query'),
       expanded: true,
-      controlSetRows: [['groupby'], ['metric'], ['adhoc_filters'], ['row_limit']],
+      controlSetRows: [
+        ['groupby'],
+        ['metric'],
+        ['adhoc_filters'],
+        ['row_limit'],
+        [
+          {
+            name: 'sort_by_metric',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort by metric'),
+              description: t('Whether to sort results by the selected metric in descending order.'),
+            },
+          },
+        ],
+      ],
     },
     {
       label: t('Chart Options'),

--- a/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-heatmap/src/controlPanel.ts
@@ -70,6 +70,16 @@ const config: ControlPanelConfig = {
         ['metric'],
         ['adhoc_filters'],
         ['row_limit'],
+        [
+          {
+            name: 'sort_by_metric',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort by metric'),
+              description: t('Whether to sort results by the selected metric in descending order.'),
+            },
+          },
+        ],
       ],
     },
     {

--- a/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
@@ -31,6 +31,16 @@ const config: ControlPanelConfig = {
         ['secondary_metric'],
         ['adhoc_filters'],
         ['row_limit'],
+        [
+          {
+            name: 'sort_by_metric',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort by metric'),
+              description: t('Whether to sort results by the selected metric in descending order.'),
+            },
+          },
+        ],
       ],
     },
     {

--- a/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-world-map/src/controlPanel.ts
@@ -50,6 +50,16 @@ const config: ControlPanelConfig = {
         ['metric'],
         ['adhoc_filters'],
         ['row_limit'],
+        [
+          {
+            name: 'sort_by_metric',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort by metric'),
+              description: t('Whether to sort results by the selected metric in descending order.'),
+            },
+          },
+        ],
       ],
     },
     {


### PR DESCRIPTION
Add single metric sort for charts: 


## legacy-plugin-chart-heatmap
![heatmap](https://user-images.githubusercontent.com/8277264/107526327-6823c680-6bc0-11eb-8b99-7e49a2c5ebcb.gif)

## legacy-plugin-chart-sunburst
![sunburst](https://user-images.githubusercontent.com/8277264/107525290-5e4d9380-6bbf-11eb-943f-c7b8ad5e153b.gif)

## legacy-plugin-chart-force-directed
![force-directed](https://user-images.githubusercontent.com/8277264/107525310-660d3800-6bbf-11eb-981d-dca8db2465ce.gif)

## legacy-plugin-chart-chord
![chod](https://user-images.githubusercontent.com/8277264/107525344-70c7cd00-6bbf-11eb-81be-6ccee37ecbe2.gif)

## legacy-plugin-world-map
![country-map](https://user-images.githubusercontent.com/8277264/107621730-61985c00-6c5f-11eb-83dd-0f7f0a7dd569.gif)
