### PR TITLE
fix(plugin-chart-table): hide cell bar for group by fields

### DIFF
--- a/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/plugins/plugin-chart-table/src/TableChart.tsx
@@ -146,6 +146,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     height,
     width,
     data,
+    isRawRecords,
     columns: columnsMeta,
     alignPositiveNegative = false,
     colorPositiveNegative = false,
@@ -205,14 +206,14 @@ export default function TableChart<D extends DataRecord = DataRecord>(
 
   const getColumnConfigs = useCallback(
     (column: DataColumnMeta, i: number): ColumnWithLooseAccessor<D> => {
-      const { key, label, dataType } = column;
+      const { key, label, dataType, isMetric } = column;
       let className = '';
       if (dataType === GenericDataType.NUMERIC) {
         className += ' dt-metric';
       } else if (emitFilter) {
         className += ' dt-is-filter';
       }
-      const valueRange = showCellBars && getValueRange(key);
+      const valueRange = showCellBars && (isMetric || isRawRecords) && getValueRange(key);
       return {
         id: String(i), // to allow duplicate column keys
         // must use custom accessor to allow `.` in column names

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -28,6 +28,7 @@ import {
   TimeFormats,
   GenericDataType,
   getMetricLabel,
+  QueryMode,
 } from '@superset-ui/core';
 
 import isEqualColumns from './utils/isEqualColumns';
@@ -136,6 +137,8 @@ const processColumns = memoizeOne(function processColumns(props: TableChartProps
         key,
         label,
         dataType,
+        isMetric,
+        isPercentMetric,
         formatter,
       };
     });
@@ -183,6 +186,7 @@ export default function transformProps(chartProps: TableChartProps): TableChartT
     page_length: pageSize,
     table_filter: tableFilter,
     order_desc: sortDesc = false,
+    query_mode: queryMode,
   } = formData;
 
   const [metrics, percentMetrics, columns] = processColumns(chartProps);
@@ -191,6 +195,7 @@ export default function transformProps(chartProps: TableChartProps): TableChartT
   return {
     height,
     width,
+    isRawRecords: queryMode === QueryMode.raw,
     data,
     columns,
     metrics,

--- a/plugins/plugin-chart-table/src/types.ts
+++ b/plugins/plugin-chart-table/src/types.ts
@@ -40,6 +40,8 @@ export interface DataColumnMeta {
   label: string;
   dataType: GenericDataType;
   formatter?: TimeFormatter | NumberFormatter | CustomFormatter;
+  isMetric?: boolean;
+  isPercentMetric?: boolean;
 }
 
 export interface TableChartData {
@@ -74,6 +76,7 @@ export interface TableChartProps extends ChartProps {
 export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   height: number;
   width: number;
+  isRawRecords?: boolean;
   data: D[];
   columns: DataColumnMeta[];
   metrics?: (keyof D)[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4740,14 +4740,6 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/jest@^26.0.0":
-  version "26.0.15"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.15.tgz#12e02c0372ad0548e07b9f4e19132b834cb1effe"
-  integrity sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==
-  dependencies:
-    jest-diff "^26.0.0"
-    pretty-format "^26.0.0"
-
 "@types/jest@^26.0.4":
   version "26.0.13"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.13.tgz#5a7b9d5312f5dd521a38329c38ee9d3802a0b85e"
@@ -14667,7 +14659,7 @@ jest@^25.5.4:
     import-local "^3.0.2"
     jest-cli "^25.5.4"
 
-jest@^26.0.1, jest@^26.6.3:
+jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
   integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==


### PR DESCRIPTION
🏆 Enhancements

Hide table chart cell bars for group by fields, as normally they could be considered categorical and not numeric metrics.

For raw records, we could theoretically use the "IS DIMENSION" flag, but it seems to be set to True by default, even for numeric columns:

![image](https://user-images.githubusercontent.com/335541/107859374-f6c95b00-6ded-11eb-94bc-18784f0c24d0.png)

So I'm not changing the behavior for raw records mode.

### Before

<img width="960" alt="with-cell-bar" src="https://user-images.githubusercontent.com/335541/107859303-87ec0200-6ded-11eb-9daf-f00bef80a073.png">

### After

<img src="https://user-images.githubusercontent.com/335541/107859306-89b5c580-6ded-11eb-8f54-c3687f84346e.png" width="960">
