### PR TITLE
feat(legacy-plugin-chart-map-box): show all points in mapbox chart

### DIFF
--- a/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
+++ b/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
@@ -108,7 +108,14 @@ class MapBox extends React.Component {
     // Compute the clusters based on the original bounds and current zoom level. Note when zoom/pan
     // to an area outside of the original bounds, no additional queries are made to the backend to
     // retrieve additional data.
-    const bbox = [bounds[0][0], bounds[0][1], bounds[1][0], bounds[1][1]];
+    // add this variable to widen the visible area
+    const offset = 0.05;
+    const bbox = [
+      bounds[0][0] - offset,
+      bounds[0][1] - offset,
+      bounds[1][0] + offset,
+      bounds[1][1] + offset,
+    ];
     const clusters = clusterer.getClusters(bbox, Math.round(viewport.zoom));
 
     return (

--- a/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
+++ b/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
@@ -109,12 +109,13 @@ class MapBox extends React.Component {
     // to an area outside of the original bounds, no additional queries are made to the backend to
     // retrieve additional data.
     // add this variable to widen the visible area
-    const offset = 0.05;
+    const offsetHorizontal = (width * 0.5) / 100;
+    const offsetVertical = (height * 0.5) / 100;
     const bbox = [
-      bounds[0][0] - offset,
-      bounds[0][1] - offset,
-      bounds[1][0] + offset,
-      bounds[1][1] + offset,
+      bounds[0][0] - offsetHorizontal,
+      bounds[0][1] - offsetVertical,
+      bounds[1][0] + offsetHorizontal,
+      bounds[1][1] + offsetVertical,
     ];
     const clusters = clusterer.getClusters(bbox, Math.round(viewport.zoom));
 


### PR DESCRIPTION
Closes: https://github.com/apache/superset/issues/10843

Increase area with 0.05 to include all points.

## BEFORE
![mapbox-before](https://user-images.githubusercontent.com/8277264/108057460-55dfd780-705b-11eb-8473-9e8ba6d8f42e.gif)
## AFTER
![mapbox-after](https://user-images.githubusercontent.com/8277264/108057464-57a99b00-705b-11eb-9238-ca1656ceec1b.gif)
