### PR TITLE
fix(legacy-plugin-chart-paired-t-test): fix paired t-test table chart

### DIFF
--- a/plugins/legacy-plugin-chart-paired-t-test/package.json
+++ b/plugins/legacy-plugin-chart-paired-t-test/package.json
@@ -32,7 +32,7 @@
     "@superset-ui/core": "0.17.9",
     "distributions": "^1.0.0",
     "prop-types": "^15.6.2",
-    "reactable-arc": "0.15.0"
+    "reactable": "^1.1.0"
   },
   "peerDependencies": {
     "react": "^15 || ^16"

--- a/plugins/legacy-plugin-chart-paired-t-test/src/PairedTTest.jsx
+++ b/plugins/legacy-plugin-chart-paired-t-test/src/PairedTTest.jsx
@@ -45,7 +45,7 @@ class PairedTTest extends React.PureComponent {
 
     return (
       <div className={`superset-legacy-chart-paired-t-test ${className}`}>
-        <div className="paired-ttest-table scrollbar-container">
+        <div className="paired-ttest-table">
           <div className="scrollbar-content">
             {metrics.map((metric, i) => (
               <TTestTable

--- a/plugins/legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
+++ b/plugins/legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
@@ -19,7 +19,7 @@
 /* eslint-disable react/no-array-index-key, react/jsx-no-bind */
 import dist from 'distributions';
 import React from 'react';
-import { Table, Tr, Td, Thead, Th } from 'reactable-arc';
+import { Table, Tr, Td, Thead, Th } from 'reactable';
 import PropTypes from 'prop-types';
 
 export const dataPropType = PropTypes.arrayOf(

--- a/plugins/legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
+++ b/plugins/legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
@@ -166,6 +166,11 @@ class TTestTable extends React.Component {
   render() {
     const { data, metric, groups } = this.props;
     const { control, liftValues, pValues } = this.state;
+
+    if (!Array.isArray(groups) || groups.length === 0) {
+      throw Error('Group by param is required');
+    }
+
     // Render column header for each group
     const columns = groups.map((group, i) => (
       <Th key={i} column={group}>

--- a/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t } from '@superset-ui/core';
+import { t, validateNonEmpty } from '@superset-ui/core';
 import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
@@ -47,6 +47,13 @@ const config: ControlPanelConfig = {
               label: t('Contribution'),
               default: false,
               description: t('Compute the contribution to the total'),
+            },
+          },
+
+          {
+            name: 'groupby',
+            override: {
+              validators: [validateNonEmpty],
             },
           },
         ],

--- a/plugins/legacy-plugin-chart-paired-t-test/src/transformProps.js
+++ b/plugins/legacy-plugin-chart-paired-t-test/src/transformProps.js
@@ -25,7 +25,7 @@ export default function transformProps(chartProps) {
     data: queriesData[0].data,
     groups: groupby,
     liftValPrec: parseInt(liftvaluePrecision, 10),
-    metrics,
+    metrics: metrics.map(metric => (typeof metric === 'string' ? metric : metric.label)),
     pValPrec: parseInt(pvaluePrecision, 10),
   };
 }


### PR DESCRIPTION
This PR fixes several bugs that were breaking Paired t-test table chart.
1. Chart was using a metric name as a to transform data, which worked only with saved metrics, since backend returns a saved metric as a string. If an adhoc metric was used, chart was still trying to use it as a key, even though it's an object, which led to an 'undefined' error.
2. `reactable-arc` was not rendering table body. I replaced it with the latest version of `reactable`.
3. CSS for scrollable table content was buggy, caused chart to have 0px height. 

What is left to decide is how to handle a case when no group by column was specified. The chart does render when group by is not specified, but it doesn't make much sense. What we can do is either display an error message (see video) or leave it as it is (see screenshot). If we go for the first option, we need to figure out a proper, descriptive error message - the one in the video is just an example.

https://user-images.githubusercontent.com/15073128/108093700-4aea6e80-707e-11eb-8cda-a83ef14df964.mov
![image](https://user-images.githubusercontent.com/15073128/108093717-52117c80-707e-11eb-9caa-cb952ee2185b.png)

UPDATE:
After adding a validator for groupby, user cannot run query without specifying at least 1 group by column.
![image](https://user-images.githubusercontent.com/15073128/108172575-49ac5680-70fd-11eb-828d-80c88e553fde.png)

CC: @villebro @ktmud @rusackas @junlincc

