### PR TITLE
refactor(chart-controls): improve typing and file organization

### DIFF
--- a/packages/superset-ui-chart-controls/src/components/InfoTooltipWithTrigger.tsx
+++ b/packages/superset-ui-chart-controls/src/components/InfoTooltipWithTrigger.tsx
@@ -20,11 +20,11 @@ import React from 'react';
 import { kebabCase } from 'lodash';
 import { TooltipPlacement } from 'antd/lib/tooltip';
 import { t } from '@superset-ui/core';
-import { Tooltip } from './Tooltip';
+import { Tooltip, TooltipProps } from './Tooltip';
 
 export interface InfoTooltipWithTriggerProps {
   label?: string;
-  tooltip?: string;
+  tooltip?: TooltipProps['title'];
   icon?: string;
   onClick?: () => void;
   placement?: TooltipPlacement;

--- a/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -32,7 +32,7 @@ const FlexRowContainer = styled.div`
 `;
 
 export interface MetricOptionProps {
-  metric: Metric;
+  metric: Omit<Metric, 'id'> & { label?: string };
   openInNewWindow?: boolean;
   showFormula?: boolean;
   showType?: boolean;

--- a/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -17,11 +17,10 @@
  * under the License.
  */
 import React from 'react';
-import { styled } from '@superset-ui/core';
+import { styled, Metric } from '@superset-ui/core';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
-import { Metric } from '../types';
 
 const FlexRowContainer = styled.div`
   align-items: center;

--- a/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
+++ b/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
@@ -3,6 +3,8 @@ import { useTheme } from '@superset-ui/core';
 import { Tooltip as BaseTooltip } from 'antd';
 import { TooltipProps } from 'antd/lib/tooltip';
 
+export { TooltipProps } from 'antd/lib/tooltip';
+
 export const Tooltip = ({ overlayStyle, color, ...props }: TooltipProps) => {
   const theme = useTheme();
   const defaultColor = `${theme.colors.grayscale.dark2}e6`;

--- a/packages/superset-ui-chart-controls/src/index.ts
+++ b/packages/superset-ui-chart-controls/src/index.ts
@@ -30,7 +30,8 @@ export * from './components/ColumnTypeLabel';
 export * from './components/MetricOption';
 
 // React control components
-export * from './components/RadioButtonControl';
+export { default as sharedControlComponents } from './shared-controls/components';
+export * from './shared-controls/components';
 export * from './types';
 
 // hack for fixing invalid webpack builds when using `npm link`

--- a/packages/superset-ui-chart-controls/src/index.ts
+++ b/packages/superset-ui-chart-controls/src/index.ts
@@ -33,6 +33,3 @@ export * from './components/MetricOption';
 export { default as sharedControlComponents } from './shared-controls/components';
 export * from './shared-controls/components';
 export * from './types';
-
-// hack for fixing invalid webpack builds when using `npm link`
-export { default as __hack_reexport__ } from './types';

--- a/packages/superset-ui-chart-controls/src/shared-controls/components/RadioButtonControl.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/components/RadioButtonControl.tsx
@@ -18,7 +18,7 @@
  */
 import React, { ReactText, ReactNode, MouseEvent, useCallback } from 'react';
 import { styled } from '@superset-ui/core';
-import { InfoTooltipWithTrigger } from './InfoTooltipWithTrigger';
+import { InfoTooltipWithTrigger } from '../../components/InfoTooltipWithTrigger';
 
 export interface RadioButtonOption {
   label: string;

--- a/packages/superset-ui-chart-controls/src/shared-controls/components/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/components/index.tsx
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import RadioButtonControl from '../components/RadioButtonControl';
+import RadioButtonControl from './RadioButtonControl';
 
-export * from '../components/RadioButtonControl';
+export * from './RadioButtonControl';
 
 /**
- * Aliases for Control Components
+ * Shared chart controls. Can be referred via string shortcuts in chart control
+ * configs.
  */
 export default {
   RadioButtonControl,

--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -18,21 +18,11 @@
  * under the License.
  */
 import React, { ReactNode, ReactText, ReactElement } from 'react';
-import { QueryFormData, DatasourceType } from '@superset-ui/core';
+import { QueryFormData, DatasourceType, Metric } from '@superset-ui/core';
 import sharedControls from './shared-controls';
 import sharedControlComponents from './shared-controls/components';
 
-export type Metric = {
-  metric_name: string;
-  verbose_name?: string;
-  label?: string;
-  description?: string;
-  warning_text?: string;
-  expression?: string;
-  is_certified?: boolean;
-  certified_by?: string | null;
-  certification_details?: string | null;
-};
+export { Metric } from '@superset-ui/core';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyDict = Record<string, any>;

--- a/packages/superset-ui-chart-controls/test/utils/expandControlConfig.test.tsx
+++ b/packages/superset-ui-chart-controls/test/utils/expandControlConfig.test.tsx
@@ -17,8 +17,12 @@
  * under the License.
  */
 import React from 'react';
-import { expandControlConfig, sharedControls, CustomControlItem } from '../../src';
-import RadioButtonControl from '../../src/components/RadioButtonControl';
+import {
+  expandControlConfig,
+  sharedControls,
+  CustomControlItem,
+  sharedControlComponents,
+} from '../../src';
 
 describe('expandControlConfig()', () => {
   it('expands shared control alias', () => {
@@ -65,7 +69,7 @@ describe('expandControlConfig()', () => {
       },
     };
     expect((expandControlConfig(input) as CustomControlItem).config.type).toEqual(
-      RadioButtonControl,
+      sharedControlComponents.RadioButtonControl,
     );
   });
 

--- a/packages/superset-ui-core/src/chart/index.ts
+++ b/packages/superset-ui-core/src/chart/index.ts
@@ -19,6 +19,6 @@ export * from './types/Base';
 export * from './types/TransformFunction';
 export * from './types/QueryResponse';
 
-export { default as __hask_reexport_chart_Base } from './types/Base';
-export { default as __hask_reexport_chart_TransformFunction } from './types/TransformFunction';
-export { default as __hask_reexport_chart_QueryResponse } from './types/QueryResponse';
+export { default as __hack_reexport_chart_Base } from './types/Base';
+export { default as __hack_reexport_chart_TransformFunction } from './types/TransformFunction';
+export { default as __hack_reexport_chart_QueryResponse } from './types/QueryResponse';

--- a/packages/superset-ui-core/src/chart/index.ts
+++ b/packages/superset-ui-core/src/chart/index.ts
@@ -18,3 +18,7 @@ export { default as ChartDataProvider } from './components/ChartDataProvider';
 export * from './types/Base';
 export * from './types/TransformFunction';
 export * from './types/QueryResponse';
+
+export { default as __hask_reexport_chart_Base } from './types/Base';
+export { default as __hask_reexport_chart_TransformFunction } from './types/TransformFunction';
+export { default as __hask_reexport_chart_QueryResponse } from './types/QueryResponse';

--- a/packages/superset-ui-core/src/chart/types/Base.ts
+++ b/packages/superset-ui-core/src/chart/types/Base.ts
@@ -21,3 +21,5 @@ export interface PlainObject {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
+
+export default {};

--- a/packages/superset-ui-core/src/chart/types/QueryResponse.ts
+++ b/packages/superset-ui-core/src/chart/types/QueryResponse.ts
@@ -25,3 +25,5 @@ export type LegacyQueryData = PlainObject;
  * Don't use this for a specific chart (since you know which API it uses already).
  */
 export type QueryData = LegacyQueryData | ChartDataResponseResult;
+
+export default {};

--- a/packages/superset-ui-core/src/chart/types/TransformFunction.ts
+++ b/packages/superset-ui-core/src/chart/types/TransformFunction.ts
@@ -11,3 +11,5 @@ export type TransformProps<Props extends ChartProps = ChartProps> = TransformFun
 export type PostTransformProps = TransformFunction;
 
 export type BuildQueryFunction<T extends QueryFormData> = (formData: T) => QueryContext;
+
+export default {};

--- a/packages/superset-ui-core/src/connection/index.ts
+++ b/packages/superset-ui-core/src/connection/index.ts
@@ -3,4 +3,4 @@ export { default as SupersetClient } from './SupersetClient';
 export { default as SupersetClientClass } from './SupersetClientClass';
 
 export * from './types';
-export { default as __hask_reexport_connection } from './types';
+export { default as __hack_reexport_connection } from './types';

--- a/packages/superset-ui-core/src/connection/index.ts
+++ b/packages/superset-ui-core/src/connection/index.ts
@@ -1,4 +1,6 @@
 export { default as callApi } from './callApi';
 export { default as SupersetClient } from './SupersetClient';
 export { default as SupersetClientClass } from './SupersetClientClass';
+
 export * from './types';
+export { default as __hask_reexport_connection } from './types';

--- a/packages/superset-ui-core/src/connection/types.ts
+++ b/packages/superset-ui-core/src/connection/types.ts
@@ -140,3 +140,5 @@ export interface SupersetClientInterface
 }
 
 export type SupersetClientResponse = Response | JsonResponse | TextResponse;
+
+export default {};

--- a/packages/superset-ui-core/src/dimension/index.ts
+++ b/packages/superset-ui-core/src/dimension/index.ts
@@ -5,3 +5,4 @@ export { default as mergeMargin } from './mergeMargin';
 export { default as parseLength } from './parseLength';
 
 export * from './types';
+export { default as __hask_reexport_dimension } from './types';

--- a/packages/superset-ui-core/src/dimension/index.ts
+++ b/packages/superset-ui-core/src/dimension/index.ts
@@ -5,4 +5,4 @@ export { default as mergeMargin } from './mergeMargin';
 export { default as parseLength } from './parseLength';
 
 export * from './types';
-export { default as __hask_reexport_dimension } from './types';
+export { default as __hack_reexport_dimension } from './types';

--- a/packages/superset-ui-core/src/dimension/types.ts
+++ b/packages/superset-ui-core/src/dimension/types.ts
@@ -18,3 +18,5 @@ export interface Dimension {
   width: number;
   height: number;
 }
+
+export default {};

--- a/packages/superset-ui-core/src/query/api/legacy/index.ts
+++ b/packages/superset-ui-core/src/query/api/legacy/index.ts
@@ -3,3 +3,4 @@ export { default as getFormData } from './getFormData';
 export { default as getDatasourceMetadata } from './getDatasourceMetadata';
 
 export * from './types';
+export { default as __hask_reexport_query_api_legacy } from './types';

--- a/packages/superset-ui-core/src/query/api/legacy/index.ts
+++ b/packages/superset-ui-core/src/query/api/legacy/index.ts
@@ -3,4 +3,4 @@ export { default as getFormData } from './getFormData';
 export { default as getDatasourceMetadata } from './getDatasourceMetadata';
 
 export * from './types';
-export { default as __hask_reexport_query_api_legacy } from './types';
+export { default as __hack_reexport_query_api_legacy } from './types';

--- a/packages/superset-ui-core/src/query/api/legacy/types.ts
+++ b/packages/superset-ui-core/src/query/api/legacy/types.ts
@@ -21,3 +21,5 @@ import { ChartDataResponseResult } from '../../types';
 export interface LegacyChartDataResponse extends Omit<ChartDataResponseResult, 'data'> {
   data: Record<string, unknown>[] | Record<string, unknown>;
 }
+
+export default {};

--- a/packages/superset-ui-core/src/query/types/Column.ts
+++ b/packages/superset-ui-core/src/query/types/Column.ts
@@ -43,3 +43,5 @@ export interface Column {
   type: ColumnType;
   columnName: string;
 }
+
+export default {};

--- a/packages/superset-ui-core/src/query/types/Datasource.ts
+++ b/packages/superset-ui-core/src/query/types/Datasource.ts
@@ -42,3 +42,5 @@ export interface Datasource {
     [key: string]: string;
   };
 }
+
+export default {};

--- a/packages/superset-ui-core/src/query/types/Metric.ts
+++ b/packages/superset-ui-core/src/query/types/Metric.ts
@@ -50,6 +50,7 @@ export type SavedMetric = string;
  */
 export interface Metric {
   id: number;
+  label?: string;
   certification_details?: Maybe<string>;
   certified_by?: Maybe<string>;
   d3format?: Maybe<string>;
@@ -60,3 +61,5 @@ export interface Metric {
   verbose_name?: string;
   warning_text?: Maybe<string>;
 }
+
+export default {};

--- a/packages/superset-ui-core/src/query/types/Metric.ts
+++ b/packages/superset-ui-core/src/query/types/Metric.ts
@@ -49,15 +49,14 @@ export type SavedMetric = string;
  * Metric definition stored in datasource metadata.
  */
 export interface Metric {
-  id: number;
-  label?: string;
+  id?: number;
+  metric_name: string;
+  expression?: Maybe<string>;
   certification_details?: Maybe<string>;
   certified_by?: Maybe<string>;
   d3format?: Maybe<string>;
   description?: Maybe<string>;
-  expression: Maybe<string>;
   is_certified?: boolean;
-  metric_name: string;
   verbose_name?: string;
   warning_text?: Maybe<string>;
 }

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -135,3 +135,5 @@ export interface QueryContext {
   result_format: string;
   queries: QueryObject[];
 }
+
+export default {};

--- a/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -176,3 +176,5 @@ export type QueryFormData = DruidFormData | SqlaFormData;
 export function isDruidFormData(formData: QueryFormData): formData is DruidFormData {
   return 'granularity' in formData;
 }
+
+export default {};

--- a/packages/superset-ui-core/src/query/types/QueryResponse.ts
+++ b/packages/superset-ui-core/src/query/types/QueryResponse.ts
@@ -81,3 +81,5 @@ export interface TimeseriesChartDataResponseResult extends ChartDataResponseResu
 export interface ChartDataResponse {
   queries: ChartDataResponseResult[];
 }
+
+export default {};

--- a/packages/superset-ui-core/src/query/types/Time.ts
+++ b/packages/superset-ui-core/src/query/types/Time.ts
@@ -18,3 +18,5 @@ export type AppliedTimeExtras = Partial<Record<TimeColumnConfigKey, keyof QueryO
 
 export type TimeRangeEndpoint = 'unknown' | 'inclusive' | 'exclusive';
 export type TimeRangeEndpoints = [TimeRangeEndpoint, TimeRangeEndpoint];
+
+export default {};

--- a/packages/superset-ui-core/src/query/types/index.ts
+++ b/packages/superset-ui-core/src/query/types/index.ts
@@ -26,12 +26,12 @@ export * from './QueryFormData';
 export * from './QueryResponse';
 export * from './Time';
 
-export { default as __hask_reexport_Datasource } from './Datasource';
-export { default as __hask_reexport_Column } from './Column';
-export { default as __hask_reexport_Metric } from './Metric';
-export { default as __hask_reexport_Query } from './Query';
-export { default as __hask_reexport_QueryResponse } from './QueryResponse';
-export { default as __hask_reexport_QueryFormData } from './QueryFormData';
-export { default as __hask_reexport_Time } from './Time';
+export { default as __hack_reexport_Datasource } from './Datasource';
+export { default as __hack_reexport_Column } from './Column';
+export { default as __hack_reexport_Metric } from './Metric';
+export { default as __hack_reexport_Query } from './Query';
+export { default as __hack_reexport_QueryResponse } from './QueryResponse';
+export { default as __hack_reexport_QueryFormData } from './QueryFormData';
+export { default as __hack_reexport_Time } from './Time';
 
 export default {};

--- a/packages/superset-ui-core/src/query/types/index.ts
+++ b/packages/superset-ui-core/src/query/types/index.ts
@@ -25,3 +25,13 @@ export * from './Query';
 export * from './QueryFormData';
 export * from './QueryResponse';
 export * from './Time';
+
+export { default as __hask_reexport_Datasource } from './Datasource';
+export { default as __hask_reexport_Column } from './Column';
+export { default as __hask_reexport_Metric } from './Metric';
+export { default as __hask_reexport_Query } from './Query';
+export { default as __hask_reexport_QueryResponse } from './QueryResponse';
+export { default as __hask_reexport_QueryFormData } from './QueryFormData';
+export { default as __hask_reexport_Time } from './Time';
+
+export default {};

--- a/packages/superset-ui-core/src/translation/index.ts
+++ b/packages/superset-ui-core/src/translation/index.ts
@@ -3,4 +3,4 @@ export * from './types';
 
 export default {};
 
-export { default as __hask_reexport_trasnslation } from './types';
+export { default as __hack_reexport_trasnslation } from './types';

--- a/packages/superset-ui-core/src/translation/index.ts
+++ b/packages/superset-ui-core/src/translation/index.ts
@@ -1,2 +1,6 @@
 export * from './TranslatorSingleton';
 export * from './types';
+
+export default {};
+
+export { default as __hask_reexport_trasnslation } from './types';

--- a/packages/superset-ui-core/src/translation/types/index.ts
+++ b/packages/superset-ui-core/src/translation/types/index.ts
@@ -19,7 +19,7 @@
 import { Jed as BaseJed, JedOptions, DomainData, Translations } from './jed';
 
 export * from './jed';
-export { default as __hask_reexport_jed } from './jed';
+export { default as __hack_reexport_jed } from './jed';
 
 /**
  * Superset supported languages.

--- a/packages/superset-ui-core/src/translation/types/index.ts
+++ b/packages/superset-ui-core/src/translation/types/index.ts
@@ -19,6 +19,7 @@
 import { Jed as BaseJed, JedOptions, DomainData, Translations } from './jed';
 
 export * from './jed';
+export { default as __hask_reexport_jed } from './jed';
 
 /**
  * Superset supported languages.
@@ -57,3 +58,5 @@ export interface TranslatorConfig {
  * Key-value mapping of translation key and the translations.
  */
 export type LocaleData = Partial<Record<Locale, Translations>>;
+
+export default {};

--- a/packages/superset-ui-core/src/translation/types/jed.ts
+++ b/packages/superset-ui-core/src/translation/types/jed.ts
@@ -33,3 +33,5 @@ export interface Jed {
 
   options: JedOptions;
 }
+
+export default {};

--- a/plugins/legacy-plugin-chart-time-table/src/TimeTable.tsx
+++ b/plugins/legacy-plugin-chart-time-table/src/TimeTable.tsx
@@ -21,7 +21,7 @@ import Mustache from 'mustache';
 import { scaleLinear } from 'd3-scale';
 import { Table, Thead, Th, Tr, Td } from 'reactable-arc';
 import { formatNumber, formatTime, styled } from '@superset-ui/core';
-import { InfoTooltipWithTrigger, MetricOption, Metric } from '@superset-ui/chart-controls';
+import { InfoTooltipWithTrigger, MetricOption } from '@superset-ui/chart-controls';
 import moment from 'moment';
 
 import FormattedNumber from './FormattedNumber';
@@ -117,9 +117,7 @@ class TimeTable extends React.PureComponent<ChartProps, {}> {
       return column.label;
     }
 
-    return (
-      <MetricOption openInNewWindow metric={row as Metric} url={fullUrl} showFormula={false} />
-    );
+    return <MetricOption openInNewWindow metric={row} url={fullUrl} showFormula={false} />;
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
🏆 Enhancements
🏠 Internal

Improve typing and file organization for shared controls.

1. Reuse `Metric` definition in `superset-ui/core`.
2. Move the React components for shared controls to its own folder (prepare for adding more custom controls).
3. Export empty objects in pure typing files to fix build errors with `npm link`:
   <img width="578" alt="cannot-read-call" src="https://user-images.githubusercontent.com/335541/108286295-af203780-713d-11eb-8387-694c95969aa4.png">
