### PR TITLE
fix(legacy-plugin-chart-map-box): fix downloading map as image

### DIFF
--- a/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
+++ b/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
@@ -119,6 +119,7 @@ class MapBox extends React.Component {
         height={height}
         mapboxApiAccessToken={mapboxApiKey}
         onViewportChange={this.handleViewportChange}
+        preserveDrawingBuffer
       >
         <ScatterPlotGlowOverlay
           {...viewport}


### PR DESCRIPTION
Fixes downloading MapBox chart as image. Part of https://github.com/apache/superset/pull/13181
![country-of-citizenship-2021-02-17T17-01-42 411Z](https://user-images.githubusercontent.com/15073128/108240186-e3e6bb80-714a-11eb-81ed-cf0663d5a163.jpg)

CC: @villebro @junlincc