### PR TITLE
fix(chart-controls): expose datasource for some controls

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -325,7 +325,8 @@ const time_range: SharedControlConfig<'DateFilterControl'> = {
       "using the engine's local timezone. Note one can explicitly set the timezone " +
       'per the ISO 8601 format if specifying either the start and/or end time.',
   ),
-  mapStateToProps: ({ form_data }) => ({
+  mapStateToProps: ({ datasource, form_data }) => ({
+    datasource,
     endpoints: form_data?.time_range_endpoints || null,
   }),
 };
@@ -443,12 +444,13 @@ const adhoc_filters: SharedControlConfig<'AdhocFilterControl'> = {
   label: t('Filters'),
   default: null,
   description: '',
-  mapStateToProps: ({ datasource }) => ({
+  mapStateToProps: ({ datasource, form_data }) => ({
     columns: datasource?.columns.filter(c => c.filterable) || [],
     savedMetrics: datasource?.metrics || [],
+    // current active adhoc metrics
+    selectedMetrics: form_data.metrics || (form_data.metric ? [form_data.metric] : []),
     datasource,
   }),
-  provideFormDataToProps: true,
 };
 
 const color_scheme: SharedControlConfig<'ColorSchemeControl'> = {


### PR DESCRIPTION
🏠 Internal

Expose current `datasource` to the state of `adhoc_filters` and `time_range` control and clean up the `provideFormDataToProps` option. We should just be explicit what prop to expose in `mapStateToProps` so controls don't get unnecessarily re-rendered because of form data updates from other unrelated controls.

`superset-frontend` has some related changes: https://github.com/apache/superset/pull/13221


### Test Plan

Manual verification in Superset via npm link:

- Make sure both controls still work
- Make sure changing dataset will reset time filter to default value ("Last week")
