### PR TITLE
fix: remove duplicated group by field

### DIFF
--- a/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-paired-t-test/src/controlPanel.ts
@@ -28,7 +28,14 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         ['metrics'],
         ['adhoc_filters'],
-        ['groupby'],
+        [
+          {
+            name: 'groupby',
+            override: {
+              validators: [validateNonEmpty],
+            },
+          },
+        ],
         ['limit', 'timeseries_limit_metric'],
         [
           {
@@ -47,13 +54,6 @@ const config: ControlPanelConfig = {
               label: t('Contribution'),
               default: false,
               description: t('Compute the contribution to the total'),
-            },
-          },
-
-          {
-            name: 'groupby',
-            override: {
-              validators: [validateNonEmpty],
             },
           },
         ],


### PR DESCRIPTION
🐛 Bug Fix
Fixes Group By field being duplicated (see https://github.com/apache-superset/superset-ui/pull/961#issuecomment-786424421)

![image](https://user-images.githubusercontent.com/15073128/109307541-1b3b2380-7841-11eb-8213-042571ef9997.png)

CC: @junlincc