### PR TITLE
refactor(SupersetClient): use new /api/v1/security/csrf_token/ endpoint

### DIFF
--- a/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -165,11 +165,11 @@ export default class SupersetClientClass {
       method: 'GET',
       mode: this.mode,
       timeout: this.timeout,
-      url: this.getUrl({ endpoint: 'superset/csrf_token/' }),
+      url: this.getUrl({ endpoint: 'api/v1/security/csrf_token/' }),
       parseMethod: 'json',
     }).then(({ json }) => {
       if (typeof json === 'object') {
-        this.csrfToken = json.csrf_token as string;
+        this.csrfToken = json.result as string;
         if (typeof this.csrfToken === 'string') {
           this.headers = { ...this.headers, 'X-CSRFToken': this.csrfToken };
         }

--- a/packages/superset-ui-core/test/chart/clients/ChartClient.test.ts
+++ b/packages/superset-ui-core/test/chart/clients/ChartClient.test.ts
@@ -23,7 +23,7 @@ describe('ChartClient', () => {
   let chartClient: ChartClient;
 
   beforeAll(() => {
-    fetchMock.get(LOGIN_GLOB, { csrf_token: '1234' });
+    fetchMock.get(LOGIN_GLOB, { result: '1234' });
     SupersetClient.reset();
     SupersetClient.configure().init();
   });

--- a/packages/superset-ui-core/test/chart/fixtures/constants.ts
+++ b/packages/superset-ui-core/test/chart/fixtures/constants.ts
@@ -1,1 +1,1 @@
-export const LOGIN_GLOB = 'glob:*superset/csrf_token/*'; // eslint-disable-line import/prefer-default-export
+export const LOGIN_GLOB = 'glob:*api/v1/security/csrf_token/*'; // eslint-disable-line import/prefer-default-export

--- a/packages/superset-ui-core/test/connection/SupersetClient.test.ts
+++ b/packages/superset-ui-core/test/connection/SupersetClient.test.ts
@@ -23,7 +23,7 @@ import { LOGIN_GLOB } from './fixtures/constants';
 
 describe('SupersetClient', () => {
   beforeAll(() => {
-    fetchMock.get(LOGIN_GLOB, { csrf_token: '' });
+    fetchMock.get(LOGIN_GLOB, { result: '' });
   });
 
   afterAll(fetchMock.restore);

--- a/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -71,19 +71,19 @@ describe('SupersetClientClass', () => {
       fetchMock.get(LOGIN_GLOB, { csrf_token: 1234 }, { overwriteRoutes: true });
     });
 
-    it('calls superset/csrf_token/ when init() is called if no CSRF token is passed', async () => {
+    it('calls api/v1/security/csrf_token/ when init() is called if no CSRF token is passed', async () => {
       expect.assertions(1);
       await new SupersetClientClass().init();
       expect(fetchMock.calls(LOGIN_GLOB)).toHaveLength(1);
     });
 
-    it('does NOT call superset/csrf_token/ when init() is called if a CSRF token is passed', async () => {
+    it('does NOT call api/v1/security/csrf_token/ when init() is called if a CSRF token is passed', async () => {
       expect.assertions(1);
       await new SupersetClientClass({ csrfToken: 'abc' }).init();
       expect(fetchMock.calls(LOGIN_GLOB)).toHaveLength(0);
     });
 
-    it('calls superset/csrf_token/ when init(force=true) is called even if a CSRF token is passed', async () => {
+    it('calls api/v1/security/csrf_token/ when init(force=true) is called even if a CSRF token is passed', async () => {
       expect.assertions(4);
       const initialToken = 'initial_token';
       const client = new SupersetClientClass({ csrfToken: initialToken });
@@ -97,7 +97,7 @@ describe('SupersetClientClass', () => {
       expect(client.csrfToken).not.toBe(initialToken);
     });
 
-    it('throws if superset/csrf_token/ returns an error', async () => {
+    it('throws if api/v1/security/csrf_token/ returns an error', async () => {
       expect.assertions(1);
       const rejectError = { status: 403 };
       fetchMock.get(LOGIN_GLOB, () => Promise.reject(rejectError), {
@@ -116,7 +116,7 @@ describe('SupersetClientClass', () => {
 
     const invalidCsrfTokenError = { error: 'Failed to fetch CSRF token' };
 
-    it('throws if superset/csrf_token/ does not return a token', async () => {
+    it('throws if api/v1/security/csrf_token/ does not return a token', async () => {
       expect.assertions(1);
       fetchMock.get(LOGIN_GLOB, {}, { overwriteRoutes: true });
 

--- a/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -22,7 +22,7 @@ import { LOGIN_GLOB } from './fixtures/constants';
 
 describe('SupersetClientClass', () => {
   beforeAll(() => {
-    fetchMock.get(LOGIN_GLOB, { csrf_token: '' });
+    fetchMock.get(LOGIN_GLOB, { result: '' });
   });
 
   afterAll(fetchMock.restore);
@@ -68,7 +68,7 @@ describe('SupersetClientClass', () => {
     afterEach(() => {
       fetchMock.reset();
       // reset
-      fetchMock.get(LOGIN_GLOB, { csrf_token: 1234 }, { overwriteRoutes: true });
+      fetchMock.get(LOGIN_GLOB, { result: 1234 }, { overwriteRoutes: true });
     });
 
     it('calls api/v1/security/csrf_token/ when init() is called if no CSRF token is passed', async () => {
@@ -226,7 +226,7 @@ describe('SupersetClientClass', () => {
       // reset
       fetchMock.get(
         LOGIN_GLOB,
-        { csrf_token: 1234 },
+        { result: 1234 },
         {
           overwriteRoutes: true,
         },

--- a/packages/superset-ui-core/test/connection/callApi/callApi.test.ts
+++ b/packages/superset-ui-core/test/connection/callApi/callApi.test.ts
@@ -26,7 +26,7 @@ import { LOGIN_GLOB } from '../fixtures/constants';
 
 describe('callApi()', () => {
   beforeAll(() => {
-    fetchMock.get(LOGIN_GLOB, { csrf_token: '1234' });
+    fetchMock.get(LOGIN_GLOB, { result: '1234' });
   });
 
   afterAll(fetchMock.restore);

--- a/packages/superset-ui-core/test/connection/callApi/callApiAndParseWithTimeout.test.ts
+++ b/packages/superset-ui-core/test/connection/callApi/callApiAndParseWithTimeout.test.ts
@@ -29,7 +29,7 @@ import { LOGIN_GLOB } from '../fixtures/constants';
 
 describe('callApiAndParseWithTimeout()', () => {
   beforeAll(() => {
-    fetchMock.get(LOGIN_GLOB, { csrf_token: '1234' });
+    fetchMock.get(LOGIN_GLOB, { result: '1234' });
   });
 
   afterAll(fetchMock.restore);

--- a/packages/superset-ui-core/test/connection/callApi/parseResponse.test.ts
+++ b/packages/superset-ui-core/test/connection/callApi/parseResponse.test.ts
@@ -24,7 +24,7 @@ import { LOGIN_GLOB } from '../fixtures/constants';
 
 describe('parseResponse()', () => {
   beforeAll(() => {
-    fetchMock.get(LOGIN_GLOB, { csrf_token: '1234' });
+    fetchMock.get(LOGIN_GLOB, { result: '1234' });
   });
 
   afterAll(fetchMock.restore);

--- a/packages/superset-ui-core/test/connection/fixtures/constants.ts
+++ b/packages/superset-ui-core/test/connection/fixtures/constants.ts
@@ -16,4 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export const LOGIN_GLOB = 'glob:*superset/csrf_token/*'; // eslint-disable-line import/prefer-default-export
+export const LOGIN_GLOB = 'glob:*api/v1/security/csrf_token/*'; // eslint-disable-line import/prefer-default-export

--- a/packages/superset-ui-core/test/query/api/setupClientForTest.ts
+++ b/packages/superset-ui-core/test/query/api/setupClientForTest.ts
@@ -19,10 +19,10 @@
 import fetchMock from 'fetch-mock';
 import { SupersetClient } from '@superset-ui/core/src/connection';
 
-const LOGIN_GLOB = 'glob:*superset/csrf_token/*';
+const LOGIN_GLOB = 'glob:*api/v1/security/csrf_token/*';
 
 export default function setupClientForTest() {
-  fetchMock.get(LOGIN_GLOB, { csrf_token: '1234' });
+  fetchMock.get(LOGIN_GLOB, { result: '1234' });
   SupersetClient.reset();
   SupersetClient.configure().init();
 }


### PR DESCRIPTION
corresponding `SupersetClient` change for: https://github.com/apache/superset/pull/13212