### PR TITLE
fix: show question mark icon when can not infer datatype

### DIFF
--- a/packages/superset-ui-chart-controls/src/components/ColumnTypeLabel.tsx
+++ b/packages/superset-ui-chart-controls/src/components/ColumnTypeLabel.tsx
@@ -23,7 +23,7 @@ export type ColumnTypeLabelProps = {
 };
 
 export function ColumnTypeLabel({ type }: ColumnTypeLabelProps) {
-  let stringIcon = '';
+  let stringIcon;
   if (typeof type !== 'string') {
     stringIcon = '?';
   } else if (type === '' || type === 'expression') {
@@ -38,7 +38,7 @@ export function ColumnTypeLabel({ type }: ColumnTypeLabelProps) {
     stringIcon = 'T/F';
   } else if (type.match(/.*time.*/i)) {
     stringIcon = 'time';
-  } else if (type.match(/unknown/i)) {
+  } else {
     stringIcon = '?';
   }
 


### PR DESCRIPTION
🐛 Bug Fix
minor fix, show question mark icon when can not infer data type in datasource panel

<img width="660" alt="image" src="https://user-images.githubusercontent.com/2016594/109747325-e13b9a00-7c11-11eb-8ba2-c6aa0b06737f.png">
