### PR TITLE
fix: rename DnD types to match component names in Superset

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -26,8 +26,8 @@ const timeColumnOption = {
   description: t('A reference to the [Time] configuration, taking granularity into account'),
 };
 
-export const dndGroupByControl: SharedControlConfig<'DndColumnSelectControl'> = {
-  type: 'DndColumnSelectControl',
+export const dndGroupByControl: SharedControlConfig<'DndColumnSelect'> = {
+  type: 'DndColumnSelect',
   label: t('Group by'),
   default: [],
   description: t('One or many columns to group by'),

--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -139,7 +139,7 @@ export type InternalControlType =
   | 'MetricsControl'
   | 'AdhocFilterControl'
   | 'FilterBoxItemControl'
-  | 'DndColumnSelectControl'
+  | 'DndColumnSelect'
   | 'DndFilterSelect'
   | keyof SharedControlComponents; // expanded in `expandControlConfig`
 


### PR DESCRIPTION
Rename `dndGroupByControl` type from `DndColumnSelectControl` to `DndColumnSelect` so that it matches component name in Superset after refactor (https://github.com/apache/superset/pull/13340)
.