### PR TITLE
fix(plugin-chart-echarts): fix GraphViz crash when DnD FF enable

### DIFF
--- a/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx
@@ -18,8 +18,8 @@
  */
 import React from 'react';
 import { t } from '@superset-ui/core';
-import { sections, sharedControls } from '@superset-ui/chart-controls';
-import { DEFAULT_FORM_DATA, EchartsGraphFormData } from './types';
+import { ControlPanelConfig, sections, sharedControls } from '@superset-ui/chart-controls';
+import { DEFAULT_FORM_DATA } from './types';
 import {
   legendMarginControl,
   legendOrientationControl,
@@ -32,19 +32,15 @@ const noopControl = { name: 'noop', config: { type: '', renderTrigger: true } };
 const requiredEntity = {
   ...sharedControls.entity,
   clearable: false,
-  // do not export private name 'filterOption'
-  filterOption: sharedControls.entity,
 };
 
 const optionalEntity = {
   ...sharedControls.entity,
   clearable: true,
   validators: [],
-  // do not export private name 'filterOption'
-  filterOption: sharedControls.entity,
 };
 
-export default {
+const controlPanel: ControlPanelConfig = {
   controlPanelSections: [
     sections.legacyRegularTime,
     {
@@ -140,7 +136,7 @@ export default {
               renderTrigger: true,
               default: DEFAULT_FORM_DATA.draggable,
               description: t('Whether to enable node dragging in force layout mode.'),
-              visibility({ form_data: { layout } }: { form_data: EchartsGraphFormData }) {
+              visibility({ form_data: { layout } }) {
                 return layout === 'force' || (!layout && DEFAULT_FORM_DATA.layout === 'force');
               },
             },
@@ -206,7 +202,7 @@ export default {
               step: 50,
               default: DEFAULT_FORM_DATA.edgeLength,
               description: t('Edge length between nodes'),
-              visibility({ form_data: { layout } }: { form_data: EchartsGraphFormData }) {
+              visibility({ form_data: { layout } }) {
                 return layout === 'force' || (!layout && DEFAULT_FORM_DATA.layout === 'force');
               },
             },
@@ -224,7 +220,7 @@ export default {
               step: 0.1,
               default: DEFAULT_FORM_DATA.gravity,
               description: t('Strength to pull the graph toward center'),
-              visibility({ form_data: { layout } }: { form_data: EchartsGraphFormData }) {
+              visibility({ form_data: { layout } }) {
                 return layout === 'force' || (!layout && DEFAULT_FORM_DATA.layout === 'force');
               },
             },
@@ -242,7 +238,7 @@ export default {
               step: 50,
               default: DEFAULT_FORM_DATA.repulsion,
               description: t('Repulsion strength between nodes'),
-              visibility({ form_data: { layout } }: { form_data: EchartsGraphFormData }) {
+              visibility({ form_data: { layout } }) {
                 return layout === 'force' || (!layout && DEFAULT_FORM_DATA.layout === 'force');
               },
             },
@@ -260,7 +256,7 @@ export default {
               step: 0.1,
               default: DEFAULT_FORM_DATA.friction,
               description: t('Friction between nodes'),
-              visibility({ form_data: { layout } }: { form_data: EchartsGraphFormData }) {
+              visibility({ form_data: { layout } }) {
                 return layout === 'force' || (!layout && DEFAULT_FORM_DATA.layout === 'force');
               },
             },
@@ -270,3 +266,5 @@ export default {
     },
   ],
 };
+
+export default controlPanel;

--- a/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import { t } from '@superset-ui/core';
-import { sections, sharedControls, ColumnOption, ColumnMeta } from '@superset-ui/chart-controls';
+import { sections, sharedControls } from '@superset-ui/chart-controls';
 import { DEFAULT_FORM_DATA, EchartsGraphFormData } from './types';
 import {
   legendMarginControl,
@@ -28,22 +28,16 @@ import {
 } from '../controls';
 
 const noopControl = { name: 'noop', config: { type: '', renderTrigger: true } };
-const columnSelectControl = {
+
+const requiredEntity = {
   ...sharedControls.entity,
-  type: 'SelectControl',
-  multi: false,
-  freeForm: true,
-  default: null,
-  includeTime: false,
-  optionRenderer: (c: ColumnMeta) => <ColumnOption column={c} showType />,
-  valueRenderer: (c: ColumnMeta) => <ColumnOption column={c} />,
-  valueKey: 'column_name',
-  allowAll: true,
-  filterOption: ({ data: opt }: { data: ColumnMeta }, text = '') =>
-    opt.column_name?.toLowerCase().includes(text.toLowerCase()) ||
-    opt.verbose_name?.toLowerCase().includes(text.toLowerCase()),
-  promptTextCreator: (label: string) => label,
-  commaChoosesOption: false,
+  clearable: false,
+};
+
+const optionalEntity = {
+  ...sharedControls.entity,
+  clearable: true,
+  validators: [],
 };
 
 export default {
@@ -57,8 +51,7 @@ export default {
           {
             name: 'source',
             config: {
-              ...columnSelectControl,
-              clearable: false,
+              ...requiredEntity,
               label: t('Source'),
               description: t('Name of the source nodes'),
             },
@@ -68,8 +61,7 @@ export default {
           {
             name: 'target',
             config: {
-              ...columnSelectControl,
-              clearable: false,
+              ...requiredEntity,
               label: t('Target'),
               description: t('Name of the target nodes'),
             },
@@ -80,14 +72,12 @@ export default {
           {
             name: 'source_category',
             config: {
-              ...columnSelectControl,
+              ...optionalEntity,
               label: t('Source category'),
               description: t(
                 'The category of source nodes used to assign colors. ' +
                   'If a node is associated with more than one category, only the first will be used.',
               ),
-              clearable: true,
-              validators: [],
             },
           },
         ],
@@ -95,11 +85,9 @@ export default {
           {
             name: 'target_category',
             config: {
-              ...columnSelectControl,
+              ...optionalEntity,
               label: t('Target category'),
               description: t('Category of target nodes'),
-              clearable: true,
-              validators: [],
             },
           },
         ],

--- a/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx
@@ -32,12 +32,16 @@ const noopControl = { name: 'noop', config: { type: '', renderTrigger: true } };
 const requiredEntity = {
   ...sharedControls.entity,
   clearable: false,
+  // do not export private name 'filterOption'
+  filterOption: sharedControls.entity,
 };
 
 const optionalEntity = {
   ...sharedControls.entity,
   clearable: true,
   validators: [],
+  // do not export private name 'filterOption'
+  filterOption: sharedControls.entity,
 };
 
 export default {


### PR DESCRIPTION
## Summary
fix graph viz crash when dnd FF enable

## use select control in Graph Viz
![image](https://user-images.githubusercontent.com/2016594/110103737-38439980-7de1-11eb-8839-39e99c7cd669.png)

## use DnD control in Graph Viz
![image](https://user-images.githubusercontent.com/2016594/110103891-717c0980-7de1-11eb-8dd6-0fb7b8188662.png)
