### PR TITLE
feat(core): add extra form data fields for native filters

### DIFF
--- a/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -42,9 +42,9 @@ export default function buildQueryObject<T extends QueryFormData>(
   const numericRowOffset = Number(row_offset);
   const { metrics, columns, orderby } = extractQueryFields(residualFormData, queryFields);
 
-  const extras = extractExtras(formData);
   // collect all filters for conversion to simple filters/freeform clauses
-  const { filters: extraFilters = [] } = extras;
+  const extras = extractExtras(formData);
+  const { filters: extraFilters } = extras;
   const { adhoc_filters: appendAdhocFilters = [], filters: appendFilters = [] } = append_form_data;
   const filterFormData: {
     filters: QueryObjectFilterClause[];

--- a/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -44,17 +44,19 @@ export default function buildQueryObject<T extends QueryFormData>(
 
   const extras = extractExtras(formData);
   // collect all filters for conversion to simple filters/freeform clauses
+  const { filters: extraFilters = [] } = extras;
+  const { adhoc_filters: appendAdhocFilters = [], filters: appendFilters = [] } = append_form_data;
   const filterFormData: {
     filters: QueryObjectFilterClause[];
     adhoc_filters: AdhocFilter[];
   } = {
-    filters: [...(formData.filters || []), ...(append_form_data.filters || [])],
-    adhoc_filters: [...(formData.adhoc_filters || []), ...(append_form_data.adhoc_filters || [])],
+    filters: [...extraFilters, ...appendFilters],
+    adhoc_filters: [...(formData.adhoc_filters || []), ...appendAdhocFilters],
   };
   const extrasAndfilters = processFilters({
     ...formData,
-    ...filterFormData,
     ...extras,
+    ...filterFormData,
   });
 
   let queryObject: QueryObject = {
@@ -80,5 +82,6 @@ export default function buildQueryObject<T extends QueryFormData>(
   };
   // override extra form data used by native and cross filters
   queryObject = overrideExtraFormData(queryObject, override_form_data);
+
   return { ...queryObject, custom_form_data };
 }

--- a/packages/superset-ui-core/src/query/extractExtras.ts
+++ b/packages/superset-ui-core/src/query/extractExtras.ts
@@ -1,7 +1,11 @@
 /* eslint-disable camelcase */
-import { isDruidFormData, QueryFormData } from './types/QueryFormData';
-import { QueryObject } from './types/Query';
-import { AppliedTimeExtras, TimeColumnConfigKey } from './types/Time';
+import {
+  AppliedTimeExtras,
+  isDruidFormData,
+  QueryFormData,
+  QueryObject,
+  TimeColumnConfigKey,
+} from './types';
 
 export default function extractExtras(formData: QueryFormData): Partial<QueryObject> {
   const applied_time_extras: AppliedTimeExtras = {};

--- a/packages/superset-ui-core/src/query/extractExtras.ts
+++ b/packages/superset-ui-core/src/query/extractExtras.ts
@@ -3,20 +3,36 @@ import {
   AppliedTimeExtras,
   isDruidFormData,
   QueryFormData,
-  QueryObject,
+  QueryObjectExtras,
+  QueryObjectFilterClause,
   TimeColumnConfigKey,
 } from './types';
 
-export default function extractExtras(formData: QueryFormData): Partial<QueryObject> {
+type ExtraFilterQueryField = {
+  time_range?: string;
+  granularity_sqla?: string;
+  time_grain_sqla?: string;
+  druid_time_origin?: string;
+  granularity?: string;
+};
+
+type ExtractedExtra = ExtraFilterQueryField & {
+  filters: QueryObjectFilterClause[];
+  extras: QueryObjectExtras;
+  applied_time_extras: AppliedTimeExtras;
+};
+
+export default function extractExtras(formData: QueryFormData): ExtractedExtra {
   const applied_time_extras: AppliedTimeExtras = {};
-  const { extras = {}, filters = [] } = formData;
-  const partialQueryObject: Partial<QueryObject> = {
+  const filters: QueryObjectFilterClause[] = [];
+  const extras: QueryObjectExtras = {};
+  const extract: ExtractedExtra = {
     filters,
     extras,
     applied_time_extras,
   };
 
-  const reservedColumnsToQueryField: Record<TimeColumnConfigKey, keyof QueryObject> = {
+  const reservedColumnsToQueryField: Record<TimeColumnConfigKey, keyof ExtraFilterQueryField> = {
     __time_range: 'time_range',
     __time_col: 'granularity_sqla',
     __time_grain: 'time_grain_sqla',
@@ -28,7 +44,7 @@ export default function extractExtras(formData: QueryFormData): Partial<QueryObj
     if (filter.col in reservedColumnsToQueryField) {
       const key = filter.col as TimeColumnConfigKey;
       const queryField = reservedColumnsToQueryField[key];
-      partialQueryObject[queryField] = filter.val;
+      extract[queryField] = filter.val as string;
       applied_time_extras[key] = filter.val as string;
     } else {
       filters.push(filter);
@@ -36,20 +52,20 @@ export default function extractExtras(formData: QueryFormData): Partial<QueryObj
   });
 
   // map to undeprecated names and remove deprecated fields
-  if (isDruidFormData(formData) && !partialQueryObject.druid_time_origin) {
+  if (isDruidFormData(formData) && !extract.druid_time_origin) {
     extras.druid_time_origin = formData.druid_time_origin;
-    delete partialQueryObject.druid_time_origin;
+    delete extract.druid_time_origin;
   } else {
     // SQL
-    extras.time_grain_sqla = partialQueryObject.time_grain_sqla || formData.time_grain_sqla;
-    partialQueryObject.granularity =
-      partialQueryObject.granularity_sqla || formData.granularity || formData.granularity_sqla;
-    delete partialQueryObject.granularity_sqla;
-    delete partialQueryObject.time_grain_sqla;
+    extras.time_grain_sqla = extract.time_grain_sqla || formData.time_grain_sqla;
+    extract.granularity =
+      extract.granularity_sqla || formData.granularity || formData.granularity_sqla;
+    delete extract.granularity_sqla;
+    delete extract.time_grain_sqla;
   }
 
   // map time range endpoints:
   if (formData.time_range_endpoints) extras.time_range_endpoints = formData.time_range_endpoints;
 
-  return partialQueryObject;
+  return extract;
 }

--- a/packages/superset-ui-core/src/query/processFilters.ts
+++ b/packages/superset-ui-core/src/query/processFilters.ts
@@ -5,7 +5,7 @@ import { isSimpleAdhocFilter } from './types/Filter';
 import convertFilter from './convertFilter';
 
 /** Logic formerly in viz.py's process_query_filters */
-export default function processFilters(formData: QueryFormData): Partial<QueryFormData> {
+export default function processFilters(formData: Partial<QueryFormData>): Partial<QueryFormData> {
   // Split adhoc_filters into four fields according to
   // (1) clause (WHERE or HAVING)
   // (2) expressionType

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -76,6 +76,9 @@ export interface QueryObject extends QueryFields, TimeRange, ResidualQueryObject
   /** Time filters that have been applied to the query object */
   applied_time_extras?: AppliedTimeExtras;
 
+  /** add fetch value predicate to query if defined in datasource */
+  apply_fetch_values_predicate?: boolean;
+
   /**
    * Extra form data. Current stores information about time granularity, may be
    * cleaned up in the future.

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -85,11 +85,14 @@ export interface QueryObject extends QueryFields, TimeRange, ResidualQueryObject
   /** SIMPLE where filters */
   filters?: QueryObjectFilterClause[];
 
-  /** Time column. */
+  /** Time column for SQL, time-grain for Druid (deprecated) */
   granularity?: string;
 
   /** If set, will group by timestamp */
   is_timeseries?: boolean;
+
+  /** Should the rowcount of the query be fetched */
+  is_rowcount?: boolean;
 
   /** Free-form HAVING SQL, multiple clauses are concatenated by AND */
   having?: string;
@@ -104,6 +107,12 @@ export interface QueryObject extends QueryFields, TimeRange, ResidualQueryObject
 
   /** Number of rows to skip */
   row_offset?: number;
+
+  /** The column to which direct temporal filters (forthcoming) */
+  time_column?: string;
+
+  /** The size of bucket by which to group timeseries data (forthcoming) */
+  time_grain?: string;
 
   /** Maximum number of series */
   timeseries_limit?: number;

--- a/packages/superset-ui-core/test/query/buildQueryObject.test.ts
+++ b/packages/superset-ui-core/test/query/buildQueryObject.test.ts
@@ -58,6 +58,41 @@ describe('buildQueryObject', () => {
     expect(query.metrics).toEqual(['sum__num', 'avg__num']);
   });
 
+  it('should merge original and append filters', () => {
+    query = buildQueryObject({
+      datasource: '5__table',
+      granularity_sqla: 'ds',
+      viz_type: 'table',
+      filters: [{ col: 'abc', op: '==', val: 'qwerty' }],
+      adhoc_filters: [
+        {
+          expressionType: 'SIMPLE',
+          clause: 'WHERE',
+          subject: 'foo',
+          operator: '!=',
+          comparator: 'bar',
+        },
+      ],
+      where: 'a = b',
+      extra_form_data: {
+        append_form_data: {
+          adhoc_filters: [
+            {
+              expressionType: 'SQL',
+              clause: 'WHERE',
+              sqlExpression: '(1 = 1)',
+            },
+          ],
+        },
+      },
+    });
+    expect(query.filters).toEqual([
+      { col: 'abc', op: '==', val: 'qwerty' },
+      { col: 'foo', op: '!=', val: 'bar' },
+    ]);
+    expect(query.extras?.where).toEqual('(a = b) AND ((1 = 1))');
+  });
+
   it('should group custom metric control', () => {
     query = buildQueryObject(
       {

--- a/packages/superset-ui-core/test/query/buildQueryObject.test.ts
+++ b/packages/superset-ui-core/test/query/buildQueryObject.test.ts
@@ -63,7 +63,7 @@ describe('buildQueryObject', () => {
       datasource: '5__table',
       granularity_sqla: 'ds',
       viz_type: 'table',
-      filters: [{ col: 'abc', op: '==', val: 'qwerty' }],
+      extra_filters: [{ col: 'abc', op: '==', val: 'qwerty' }],
       adhoc_filters: [
         {
           expressionType: 'SIMPLE',

--- a/packages/superset-ui-core/test/query/extractExtras.test.ts
+++ b/packages/superset-ui-core/test/query/extractExtras.test.ts
@@ -24,13 +24,6 @@ describe('extractExtras', () => {
     granularity_sqla: 'ds',
     time_grain_sqla: 'PT1M',
     viz_type: 'my_viz',
-    filters: [
-      {
-        col: 'gender',
-        op: '==',
-        val: 'girl',
-      },
-    ],
   };
 
   it('should populate time range endpoints and override formData with double underscored date options', () => {
@@ -39,6 +32,88 @@ describe('extractExtras', () => {
         ...baseQueryFormData,
         time_range_endpoints: ['inclusive', 'exclusive'],
         extra_filters: [
+          {
+            col: '__time_col',
+            op: '==',
+            val: 'ds2',
+          },
+          {
+            col: '__time_grain',
+            op: '==',
+            val: 'PT5M',
+          },
+          {
+            col: '__time_range',
+            op: '==',
+            val: '2009-07-17T00:00:00 : 2020-07-17T00:00:00',
+          },
+        ],
+      }),
+    ).toEqual({
+      applied_time_extras: {
+        __time_col: 'ds2',
+        __time_grain: 'PT5M',
+        __time_range: '2009-07-17T00:00:00 : 2020-07-17T00:00:00',
+      },
+      extras: {
+        time_grain_sqla: 'PT5M',
+        time_range_endpoints: ['inclusive', 'exclusive'],
+      },
+      filters: [],
+      granularity: 'ds2',
+      time_range: '2009-07-17T00:00:00 : 2020-07-17T00:00:00',
+    });
+  });
+
+  it('should create regular filters from non-reserved columns', () => {
+    expect(
+      extractExtras({
+        ...baseQueryFormData,
+        extra_filters: [
+          {
+            col: 'gender',
+            op: '==',
+            val: 'girl',
+          },
+          {
+            col: 'name',
+            op: 'IN',
+            val: ['Eve', 'Evelyn'],
+          },
+        ],
+      }),
+    ).toEqual({
+      applied_time_extras: {},
+      extras: {
+        time_grain_sqla: 'PT1M',
+      },
+      filters: [
+        {
+          col: 'gender',
+          op: '==',
+          val: 'girl',
+        },
+        {
+          col: 'name',
+          op: 'IN',
+          val: ['Eve', 'Evelyn'],
+        },
+      ],
+      granularity: 'ds',
+    });
+  });
+
+  it('should create regular filters from reserved and non-reserved columns', () => {
+    expect(
+      extractExtras({
+        ...baseQueryFormData,
+        time_range_endpoints: ['inclusive', 'exclusive'],
+        extra_filters: [
+          {
+            col: 'gender',
+            op: '==',
+            val: 'girl',
+          },
           {
             col: '__time_col',
             op: '==',
@@ -75,39 +150,6 @@ describe('extractExtras', () => {
       ],
       granularity: 'ds2',
       time_range: '2009-07-17T00:00:00 : 2020-07-17T00:00:00',
-    });
-  });
-
-  it('should create regular filters from non-reserved columns', () => {
-    expect(
-      extractExtras({
-        ...baseQueryFormData,
-        extra_filters: [
-          {
-            col: 'name',
-            op: 'IN',
-            val: ['Eve', 'Evelyn'],
-          },
-        ],
-      }),
-    ).toEqual({
-      applied_time_extras: {},
-      extras: {
-        time_grain_sqla: 'PT1M',
-      },
-      filters: [
-        {
-          col: 'gender',
-          op: '==',
-          val: 'girl',
-        },
-        {
-          col: 'name',
-          op: 'IN',
-          val: ['Eve', 'Evelyn'],
-        },
-      ],
-      granularity: 'ds',
     });
   });
 });

--- a/packages/superset-ui-core/test/query/processExtraFormData.test.ts
+++ b/packages/superset-ui-core/test/query/processExtraFormData.test.ts
@@ -16,131 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  appendExtraFormData,
-  overrideExtraFormData,
-} from '@superset-ui/core/src/query/processExtraFormData';
-
-describe('appendExtraFormData', () => {
-  it('should add allowed values to non-existent value', () => {
-    expect(
-      appendExtraFormData(
-        {
-          datasource: 'table_1',
-          granularity: 'something',
-          viz_type: 'custom',
-        },
-        {
-          filters: [{ col: 'my_col', op: '==', val: 'my value' }],
-        },
-      ),
-    ).toEqual({
-      datasource: 'table_1',
-      filters: [{ col: 'my_col', op: '==', val: 'my value' }],
-      granularity: 'something',
-      viz_type: 'custom',
-    });
-  });
-
-  it('should add allowed values to preexisting value(s)', () => {
-    expect(
-      appendExtraFormData(
-        {
-          granularity: 'something',
-          viz_type: 'custom',
-          datasource: 'table_1',
-          filters: [{ col: 'my_col', op: '==', val: 'my value' }],
-        },
-        {
-          filters: [{ col: 'my_other_col', op: '!=', val: 'my other value' }],
-        },
-      ),
-    ).toEqual({
-      granularity: 'something',
-      viz_type: 'custom',
-      datasource: 'table_1',
-      filters: [
-        { col: 'my_col', op: '==', val: 'my value' },
-        { col: 'my_other_col', op: '!=', val: 'my other value' },
-      ],
-    });
-  });
-
-  it('should add new freeform where', () => {
-    expect(
-      appendExtraFormData(
-        {
-          datasource: 'table_1',
-          granularity: 'something',
-          viz_type: 'custom',
-        },
-        {
-          extras: {
-            where: '1 = 0',
-          },
-        },
-      ),
-    ).toEqual({
-      datasource: 'table_1',
-      granularity: 'something',
-      viz_type: 'custom',
-      extras: {
-        where: '(1 = 0)',
-      },
-    });
-  });
-
-  it('should add new freeform where to existing where clause', () => {
-    expect(
-      appendExtraFormData(
-        {
-          datasource: 'table_1',
-          granularity: 'something',
-          viz_type: 'custom',
-          extras: {
-            where: 'abc = 1',
-          },
-        },
-        {
-          extras: {
-            where: '1 = 0',
-          },
-        },
-      ),
-    ).toEqual({
-      datasource: 'table_1',
-      granularity: 'something',
-      viz_type: 'custom',
-      extras: {
-        where: '(abc = 1) AND (1 = 0)',
-      },
-    });
-  });
-  it('should not change existing where if append where is missing', () => {
-    expect(
-      appendExtraFormData(
-        {
-          datasource: 'table_1',
-          granularity: 'something',
-          viz_type: 'custom',
-          extras: {
-            where: 'abc = 1',
-          },
-        },
-        {
-          extras: {},
-        },
-      ),
-    ).toEqual({
-      datasource: 'table_1',
-      granularity: 'something',
-      viz_type: 'custom',
-      extras: {
-        where: 'abc = 1',
-      },
-    });
-  });
-});
+import { overrideExtraFormData } from '@superset-ui/core/src/query/processExtraFormData';
 
 describe('overrideExtraFormData', () => {
   it('should assign allowed non-existent value', () => {
@@ -152,14 +28,14 @@ describe('overrideExtraFormData', () => {
           datasource: 'table_1',
         },
         {
-          time_grain_sqla: 'PT1H',
+          time_range: '100 years ago',
         },
       ),
     ).toEqual({
       granularity: 'something',
       viz_type: 'custom',
       datasource: 'table_1',
-      time_grain_sqla: 'PT1H',
+      time_range: '100 years ago',
     });
   });
 
@@ -170,17 +46,17 @@ describe('overrideExtraFormData', () => {
           granularity: 'something',
           viz_type: 'custom',
           datasource: 'table_1',
-          time_grain_sqla: 'PT1H',
+          time_range: '100 years ago',
         },
         {
-          time_grain_sqla: 'PT2H',
+          time_range: '50 years ago',
         },
       ),
     ).toEqual({
       granularity: 'something',
       viz_type: 'custom',
       datasource: 'table_1',
-      time_grain_sqla: 'PT2H',
+      time_range: '50 years ago',
     });
   });
 
@@ -191,7 +67,7 @@ describe('overrideExtraFormData', () => {
           granularity: 'something',
           viz_type: 'custom',
           datasource: 'table_1',
-          time_grain_sqla: 'PT1H',
+          time_range: '100 years ago',
         },
         {
           viz_type: 'other custom viz',
@@ -201,7 +77,62 @@ describe('overrideExtraFormData', () => {
       granularity: 'something',
       viz_type: 'custom',
       datasource: 'table_1',
-      time_grain_sqla: 'PT1H',
+      time_range: '100 years ago',
+    });
+  });
+
+  it('should override pre-existing extra value', () => {
+    expect(
+      overrideExtraFormData(
+        {
+          granularity: 'something',
+          viz_type: 'custom',
+          datasource: 'table_1',
+          time_range: '100 years ago',
+          extras: {
+            time_grain_sqla: 'PT1H',
+          },
+        },
+        {
+          extras: {
+            time_grain_sqla: 'PT2H',
+          },
+        },
+      ),
+    ).toEqual({
+      granularity: 'something',
+      viz_type: 'custom',
+      datasource: 'table_1',
+      time_range: '100 years ago',
+      extras: {
+        time_grain_sqla: 'PT2H',
+      },
+    });
+  });
+
+  it('should add extra override value', () => {
+    expect(
+      overrideExtraFormData(
+        {
+          granularity: 'something',
+          viz_type: 'custom',
+          datasource: 'table_1',
+          time_range: '100 years ago',
+        },
+        {
+          extras: {
+            time_grain_sqla: 'PT1H',
+          },
+        },
+      ),
+    ).toEqual({
+      granularity: 'something',
+      viz_type: 'custom',
+      datasource: 'table_1',
+      time_range: '100 years ago',
+      extras: {
+        time_grain_sqla: 'PT1H',
+      },
     });
   });
 });


### PR DESCRIPTION
🏆 Enhancements

List of changes:
- add placeholder props `time_grain` and `time_column` fields to `QueryFormData` to get ready to streamline `granularity`, `granularity_sqla` and `time_grain_sqla`.
- fix appending of filters and adhoc filters + add tests
- remove `appendExtraFormData`, as we should only enable appending filters (are handled by `processFilters.ts` now to centralize filter handling in `buildQueryObject`)
- add new override props + add tests
- fix a few typos in `buildQueryContext.ts`