### PR TITLE
fix(core): don't add metrics to query object when in raw records mode

### DIFF
--- a/packages/superset-ui-chart-controls/src/constants.ts
+++ b/packages/superset-ui-chart-controls/src/constants.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { t } from '@superset-ui/core';
+import { ColumnMeta } from './types';
 
 // eslint-disable-next-line import/prefer-default-export
 export const TIME_FILTER_LABELS = {
@@ -25,4 +26,10 @@ export const TIME_FILTER_LABELS = {
   time_grain_sqla: t('Time Grain'),
   druid_time_origin: t('Origin'),
   granularity: t('Time Granularity'),
+};
+
+export const TIME_COLUMN_OPTION: ColumnMeta = {
+  verbose_name: t('Time'),
+  column_name: '__timestamp',
+  description: t('A reference to the [Time] configuration, taking granularity into account'),
 };

--- a/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -19,12 +19,7 @@
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
 import { ExtraControlProps, SharedControlConfig } from '../types';
-
-const timeColumnOption = {
-  verbose_name: t('Time'),
-  column_name: '__timestamp',
-  description: t('A reference to the [Time] configuration, taking granularity into account'),
-};
+import { TIME_COLUMN_OPTION } from '../constants';
 
 export const dndGroupByControl: SharedControlConfig<'DndColumnSelect'> = {
   type: 'DndColumnSelect',
@@ -36,7 +31,7 @@ export const dndGroupByControl: SharedControlConfig<'DndColumnSelect'> = {
     if (state.datasource) {
       const options = state.datasource.columns.filter(c => c.groupby);
       if (includeTime) {
-        options.unshift(timeColumnOption);
+        options.unshift(TIME_COLUMN_OPTION);
       }
       newState.options = Object.fromEntries(options.map(option => [option.column_name, option]));
     }

--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -47,7 +47,7 @@ import {
 } from '@superset-ui/core';
 
 import { mainMetric, formatSelectOptions } from '../utils';
-import { TIME_FILTER_LABELS } from '../constants';
+import { TIME_FILTER_LABELS, TIME_COLUMN_OPTION } from '../constants';
 import {
   Metric,
   SharedControlConfig,
@@ -103,12 +103,6 @@ export const D3_TIME_FORMAT_OPTIONS = [
 
 export const D3_TIME_FORMAT_DOCS = t('D3 time format syntax: https://github.com/d3/d3-time-format');
 
-const timeColumnOption = {
-  verbose_name: t('Time'),
-  column_name: '__timestamp',
-  description: t('A reference to the [Time] configuration, taking granularity into account'),
-};
-
 type Control = {
   savedMetrics?: Metric[] | null;
   default?: unknown;
@@ -137,7 +131,7 @@ const groupByControl: SharedControlConfig<'SelectControl', ColumnMeta> = {
     if (state.datasource) {
       const options = state.datasource.columns.filter(c => c.groupby);
       if (includeTime) {
-        options.unshift(timeColumnOption);
+        options.unshift(TIME_COLUMN_OPTION);
       }
       newState.options = options;
     }

--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -38,7 +38,10 @@ export type SharedControlComponents = typeof sharedControlComponents;
 /** ----------------------------------------------
  * Input data/props while rendering
  * ---------------------------------------------*/
-export type ColumnMeta = Column & AnyDict;
+export type ColumnMeta = Omit<Column, 'id' | 'type'> & {
+  id?: number;
+  type?: string;
+} & AnyDict;
 
 export interface DatasourceMeta {
   id: number;

--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -18,7 +18,7 @@
  * under the License.
  */
 import React, { ReactNode, ReactText, ReactElement } from 'react';
-import { QueryFormData, DatasourceType, Metric, JsonValue } from '@superset-ui/core';
+import { QueryFormData, DatasourceType, Metric, JsonValue, Column } from '@superset-ui/core';
 import sharedControls from './shared-controls';
 import sharedControlComponents from './shared-controls/components';
 
@@ -38,16 +38,7 @@ export type SharedControlComponents = typeof sharedControlComponents;
 /** ----------------------------------------------
  * Input data/props while rendering
  * ---------------------------------------------*/
-export interface ColumnMeta extends AnyDict {
-  column_name: string;
-  groupby?: string;
-  verbose_name?: string;
-  description?: string;
-  expression?: string;
-  is_dttm?: boolean;
-  type?: string;
-  filterable?: boolean;
-}
+export type ColumnMeta = Column & AnyDict;
 
 export interface DatasourceMeta {
   id: number;

--- a/packages/superset-ui-core/src/query/getMetricLabel.ts
+++ b/packages/superset-ui-core/src/query/getMetricLabel.ts
@@ -8,7 +8,7 @@ export default function getMetricLabel(metric: QueryFormMetric) {
     return metric.label;
   }
   if (metric.expressionType === 'SIMPLE') {
-    return `${metric.aggregate}(${metric.column.columnName})`;
+    return `${metric.aggregate}(${metric.column.columnName || metric.column.column_name})`;
   }
   return metric.sqlExpression;
 }

--- a/packages/superset-ui-core/src/query/types/Metric.ts
+++ b/packages/superset-ui-core/src/query/types/Metric.ts
@@ -29,7 +29,8 @@ export interface AdhocMetricBase {
 
 export interface AdhocMetricSimple extends AdhocMetricBase {
   expressionType: 'SIMPLE';
-  column: Column & {
+  column: Omit<Column, 'column_name'> & {
+    column_name?: string;
     columnName?: string;
   };
   aggregate: Aggregate;

--- a/packages/superset-ui-core/src/query/types/Metric.ts
+++ b/packages/superset-ui-core/src/query/types/Metric.ts
@@ -29,7 +29,9 @@ export interface AdhocMetricBase {
 
 export interface AdhocMetricSimple extends AdhocMetricBase {
   expressionType: 'SIMPLE';
-  column: Column;
+  column: Column & {
+    columnName?: string;
+  };
   aggregate: Aggregate;
 }
 

--- a/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -61,8 +61,8 @@ export enum QueryMode {
  */
 export interface QueryFields {
   columns: QueryFormColumn[];
-  metrics: QueryFormMetric[];
-  orderby: QueryFormOrderBy[];
+  metrics?: QueryFormMetric[];
+  orderby?: QueryFormOrderBy[];
 }
 
 /**

--- a/packages/superset-ui-core/test/fixtures.ts
+++ b/packages/superset-ui-core/test/fixtures.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,39 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export enum ColumnType {
-  DOUBLE = 'DOUBLE',
-  FLOAT = 'FLOAT',
-  INT = 'INT',
-  BIGINT = 'BIGINT',
-  LONG = 'LONG',
-  REAL = 'REAL',
-  NUMERIC = 'NUMERIC',
-  DECIMAL = 'DECIMAL',
-  MONEY = 'MONEY',
-  DATE = 'DATE',
-  TIME = 'TIME',
-  DATETIME = 'DATETIME',
-  VARCHAR = 'VARCHAR',
-  STRING = 'STRING',
-  CHAR = 'CHAR',
-}
+import { AdhocMetric, ColumnType } from '../src';
 
-/**
- * Column information defined in datasource.
- */
-export interface Column {
-  id: number;
-  type: ColumnType;
-  column_name: string;
-  groupby?: boolean;
-  is_dttm?: boolean;
-  filterable?: boolean;
-  verbose_name?: string | null;
-  description?: string | null;
-  expression?: string | null;
-  database_expression?: string | null;
-  python_date_format?: string | null;
-}
-
-export default {};
+export const NUM_METRIC: AdhocMetric = {
+  expressionType: 'SIMPLE',
+  label: 'Sum(num)',
+  column: {
+    id: 336,
+    type: ColumnType.BIGINT,
+    column_name: 'num',
+    verbose_name: null,
+    description: null,
+    expression: '',
+    filterable: false,
+    groupby: false,
+    is_dttm: false,
+    database_expression: null,
+    python_date_format: null,
+  },
+  aggregate: 'SUM',
+};

--- a/packages/superset-ui-core/test/query/getMetricLabel.test.ts
+++ b/packages/superset-ui-core/test/query/getMetricLabel.test.ts
@@ -29,9 +29,23 @@ describe('getMetricLabel', () => {
         expressionType: 'SIMPLE',
         aggregate: 'AVG',
         column: {
-          columnName: 'sum_girls',
           id: 5,
           type: ColumnType.BIGINT,
+          columnName: 'sum_girls',
+        },
+      }),
+    ).toEqual('AVG(sum_girls)');
+  });
+
+  it('should handle column_name in alternative field', () => {
+    expect(
+      getMetricLabel({
+        expressionType: 'SIMPLE',
+        aggregate: 'AVG',
+        column: {
+          id: 5,
+          type: ColumnType.BIGINT,
+          column_name: 'sum_girls',
         },
       }),
     ).toEqual('AVG(sum_girls)');

--- a/plugins/plugin-chart-echarts/src/BoxPlot/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/buildQuery.ts
@@ -26,7 +26,7 @@ export default function buildQuery(formData: BoxPlotQueryFormData) {
   return buildQueryContext(formData, baseQueryObject => {
     let whiskerType: BoxPlotQueryObjectWhiskerType;
     let percentiles: [number, number] | undefined;
-    const { columns, metrics } = baseQueryObject;
+    const { columns, metrics = [] } = baseQueryObject;
     const percentileMatch = PERCENTILE_REGEX.exec(whiskerOptions as string);
 
     if (whiskerOptions === 'Tukey') {

--- a/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -20,7 +20,7 @@ import { buildQueryContext, getMetricLabel, QueryFormData } from '@superset-ui/c
 
 export default function buildQuery(formData: QueryFormData) {
   return buildQueryContext(formData, baseQueryObject => {
-    const metricLabels = baseQueryObject.metrics.map(getMetricLabel);
+    const metricLabels = (baseQueryObject.metrics || []).map(getMetricLabel);
     return [
       {
         ...baseQueryObject,

--- a/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/plugins/plugin-chart-table/src/buildQuery.ts
@@ -59,7 +59,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (formData: TableChartFormData
   }
 
   return buildQueryContext(formDataCopy, baseQueryObject => {
-    let { metrics, orderby } = baseQueryObject;
+    let { metrics = [], orderby = [] } = baseQueryObject;
     let postProcessing: PostProcessingRule[] = [];
 
     if (queryMode === QueryMode.aggregate) {


### PR DESCRIPTION
🏆 Enhancements
🐛 Bug Fix

Don't set `metrics` in QueryObject is it is in raw records mode. Then we can assume it is an aggregation query as long as `metrics` is defined, even if it's just empty array.

This allows a clean deprecation of the `groupby` field.

See discussions in https://github.com/apache/superset/pull/13434 for details.