### PR TITLE
refactor(chart-controls): optimize typing

### DIFF
--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -18,7 +18,7 @@
  * under the License.
  */
 import React, { ReactNode, ReactText, ReactElement } from 'react';
-import { QueryFormData, DatasourceType, Metric } from '@superset-ui/core';
+import { QueryFormData, DatasourceType, Metric, JsonValue } from '@superset-ui/core';
 import sharedControls from './shared-controls';
 import sharedControlComponents from './shared-controls/components';
 
@@ -89,7 +89,9 @@ export interface ControlPanelActionDispatchers {
 /**
  * Additional control props obtained from `mapStateToProps`.
  */
-export type ExtraControlProps = AnyDict;
+export type ExtraControlProps = {
+  value?: JsonValue;
+} & AnyDict;
 
 // Ref:superset-frontend/src/explore/store.js
 export type ControlState<T = ControlType, O extends SelectOption = SelectOption> = ControlConfig<
@@ -179,7 +181,7 @@ export type TabOverride = 'data' | 'customize' | boolean;
 export interface BaseControlConfig<
   T extends ControlType = ControlType,
   O extends SelectOption = SelectOption,
-  V = unknown
+  V = JsonValue
 > extends AnyDict {
   type: T;
   label?: ReactNode;
@@ -205,8 +207,9 @@ export interface ControlValueValidator<
 /** --------------------------------------------
  * Additional Config for specific control Types
  * --------------------------------------------- */
-type SelectOption = AnyDict | string | [ReactText, ReactNode];
-type SelectControlType =
+export type SelectOption = AnyDict | string | [ReactText, ReactNode];
+
+export type SelectControlType =
   | 'SelectControl'
   | 'SelectAsyncControl'
   | 'MetricsControl'

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -52,7 +52,7 @@ function getQueryMode(controls: ControlStateMapping): QueryMode {
   if (mode === QueryMode.aggregate || mode === QueryMode.raw) {
     return mode as QueryMode;
   }
-  const rawColumns: QueryFormColumn[] | undefined = controls?.all_columns?.value;
+  const rawColumns = controls?.all_columns?.value as QueryFormColumn[] | undefined;
   const hasRawColumns = rawColumns && rawColumns.length > 0;
   return hasRawColumns ? QueryMode.raw : QueryMode.aggregate;
 }
@@ -212,7 +212,7 @@ const config: ControlPanelConfig = {
               choices: PAGE_SIZE_OPTIONS,
               description: t('Rows per page, 0 means no pagination'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
-                controls.server_pagination.value,
+                Boolean(controls.server_pagination.value),
             },
           },
         ],


### PR DESCRIPTION
🏠 Internal

Optimize typing for chart controls. So they can be more easily referenced in various util functions in `superset-frontend`.

See: https://github.com/apache/superset/pull/13520/files


### Test Plan

- `yarn type` should not throw error
- In `superset-frontend`, `npm run type` should not throw error with changes in https://github.com/apache/superset/pull/13520/files
