### PR TITLE
fix(plugin-chart-table): metrics should be undefined

### DIFF
--- a/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/plugins/plugin-chart-table/src/buildQuery.ts
@@ -59,10 +59,11 @@ const buildQuery: BuildQuery<TableChartFormData> = (formData: TableChartFormData
   }
 
   return buildQueryContext(formDataCopy, baseQueryObject => {
-    let { metrics = [], orderby = [] } = baseQueryObject;
+    let { metrics, orderby = [] } = baseQueryObject;
     let postProcessing: PostProcessingRule[] = [];
 
     if (queryMode === QueryMode.aggregate) {
+      metrics = metrics || [];
       // orverride orderby with timeseries metric when in aggregation mode
       if (sortByMetric) {
         orderby = [[sortByMetric, !orderDesc]];

--- a/plugins/plugin-chart-table/test/buildQuery.test.ts
+++ b/plugins/plugin-chart-table/test/buildQuery.test.ts
@@ -77,7 +77,7 @@ describe('plugin-chart-table', () => {
         columns: ['rawcol'],
         percent_metrics: ['ccc'],
       }).queries[0];
-      expect(query.metrics).toEqual([]);
+      expect(query.metrics).toBeUndefined();
       expect(query.columns).toEqual(['rawcol']);
       expect(query.post_processing).toEqual([]);
     });

--- a/plugins/plugin-chart-table/test/buildQuery.test.ts
+++ b/plugins/plugin-chart-table/test/buildQuery.test.ts
@@ -46,6 +46,18 @@ describe('plugin-chart-table', () => {
       ]);
     });
 
+    it('should not add metrics in raw records mode', () => {
+      const query = buildQuery({
+        ...basicFormData,
+        query_mode: QueryMode.raw,
+        columns: ['a'],
+        metrics: ['aaa', 'aaa'],
+        percent_metrics: ['bbb', 'bbb'],
+      }).queries[0];
+      expect(query.metrics).toBeUndefined();
+      expect(query.post_processing).toEqual([]);
+    });
+
     it('should not add post-processing when there is no percent metric', () => {
       const query = buildQuery({
         ...basicFormData,


### PR DESCRIPTION
🐛 Bug Fix

Metrics should be `undefined` when table chart is in raw records mode.

I changed the logic of `buildQuery` in `@superset-ui/core`, but failed to update the one in table chart itself.

Related to https://github.com/apache-superset/superset-ui/pull/995