### PR TITLE
feat(plugin-chart-echarts): emit filter events when clicking on pie slice

### DIFF
--- a/plugins/plugin-chart-echarts/src/Pie/EchartsPie.tsx
+++ b/plugins/plugin-chart-echarts/src/Pie/EchartsPie.tsx
@@ -17,9 +17,52 @@
  * under the License.
  */
 import React from 'react';
-import { EchartsProps } from '../types';
+import { PieChartTransformedProps } from './types';
 import Echart from '../components/Echart';
+import { EventHandlers } from '../types';
 
-export default function EchartsPie({ height, width, echartOptions }: EchartsProps) {
-  return <Echart height={height} width={width} echartOptions={echartOptions} />;
+export default function EchartsPie({
+  height,
+  width,
+  echartOptions,
+  setDataMask,
+  labelMap,
+  groupby,
+}: PieChartTransformedProps) {
+  const eventHandlers: EventHandlers = {
+    click: props => {
+      const { name } = props;
+      setDataMask({
+        crossFilters: {
+          extraFormData: {
+            append_form_data: {
+              filters: groupby.map((col, idx) => {
+                const val = labelMap[name][idx];
+                if (val === null || val === undefined)
+                  return {
+                    col,
+                    op: 'IS NULL',
+                  };
+                return {
+                  col,
+                  op: '==',
+                  val: val as string | number | boolean,
+                };
+              }),
+            },
+          },
+          currentState: name,
+        },
+      });
+    },
+  };
+
+  return (
+    <Echart
+      height={height}
+      width={width}
+      echartOptions={echartOptions}
+      eventHandlers={eventHandlers}
+    />
+  );
 }

--- a/plugins/plugin-chart-echarts/src/Pie/index.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { Behavior, ChartMetadata, ChartPlugin, t } from '@superset-ui/core';
 import buildQuery from './buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from './transformProps';
@@ -43,6 +43,7 @@ export default class EchartsPieChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsPie'),
       metadata: new ChartMetadata({
+        behaviors: [Behavior.CROSS_FILTER],
         credits: ['https://echarts.apache.org'],
         description: 'Pie Chart (Apache ECharts)',
         name: t('Pie Chart'),

--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -77,7 +77,9 @@ export function formatPieLabel({
 }
 
 export default function transformProps(chartProps: EchartsPieChartProps): PieChartTransformedProps {
-  const { formData, height, hooks, queriesData, width } = chartProps;
+  const { formData, height, hooks, ownCurrentState, queriesData, width } = chartProps;
+  const { selectedValues = [] } = ownCurrentState;
+  console.log('selectedValues', selectedValues);
   const { data = [] } = queriesData[0];
   const coltypeMapping = getColtypesMapping(queriesData[0]);
 
@@ -214,6 +216,7 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
   };
 
   return {
+    formData,
     width,
     height,
     echartOptions,

--- a/plugins/plugin-chart-echarts/src/Pie/types.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/types.ts
@@ -16,7 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChartDataResponseResult, ChartProps, QueryFormData } from '@superset-ui/core';
+import { EChartsOption } from 'echarts';
+import {
+  ChartDataResponseResult,
+  ChartProps,
+  DataRecordValue,
+  QueryFormData,
+  SetDataMaskHook,
+} from '@superset-ui/core';
 import {
   DEFAULT_LEGEND_FORM_DATA,
   EchartsLegendFormData,
@@ -72,3 +79,12 @@ export const DEFAULT_FORM_DATA: EchartsPieFormData = {
   showLabelsThreshold: 5,
   dateFormat: 'smart_date',
 };
+
+export interface PieChartTransformedProps {
+  height: number;
+  width: number;
+  echartOptions: EChartsOption;
+  setDataMask: SetDataMaskHook;
+  labelMap: Record<string, DataRecordValue[]>;
+  groupby: string[];
+}

--- a/plugins/plugin-chart-echarts/src/Pie/types.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/types.ts
@@ -34,7 +34,10 @@ import {
 export type EchartsPieFormData = QueryFormData &
   EchartsLegendFormData & {
     colorScheme?: string;
+    currentOwnValue?: string[] | null;
+    currentValue?: string[] | null;
     donut: boolean;
+    defaultValue?: string[] | null;
     groupby: string[];
     innerRadius: number;
     labelLine: boolean;
@@ -81,6 +84,7 @@ export const DEFAULT_FORM_DATA: EchartsPieFormData = {
 };
 
 export interface PieChartTransformedProps {
+  formData: EchartsPieFormData;
   height: number;
   width: number;
   echartOptions: EChartsOption;

--- a/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -26,17 +26,21 @@ const Styles = styled.div<EchartsStylesProps>`
   width: ${({ width }) => width};
 `;
 
-export default function Echart({ width, height, echartOptions }: EchartsProps) {
+export default function Echart({ width, height, echartOptions, eventHandlers }: EchartsProps) {
   const divRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<ECharts>();
 
   useEffect(() => {
     if (!divRef.current) return;
     if (!chartRef.current) {
-      chartRef.current = init(divRef.current);
+      const chart = init(divRef.current);
+      chartRef.current = chart;
+      Object.entries(eventHandlers || {}).forEach(([name, handler]) => {
+        chart.on(name, handler);
+      });
     }
     chartRef.current.setOption(echartOptions, true);
-  }, [echartOptions]);
+  }, [echartOptions, eventHandlers]);
 
   useEffect(() => {
     if (chartRef.current) {

--- a/plugins/plugin-chart-echarts/src/types.ts
+++ b/plugins/plugin-chart-echarts/src/types.ts
@@ -28,6 +28,7 @@ export interface EchartsProps {
   height: number;
   width: number;
   echartOptions: EChartsOption;
+  eventHandlers?: EventHandlers;
 }
 
 export enum ForecastSeriesEnum {
@@ -75,3 +76,5 @@ export const DEFAULT_LEGEND_FORM_DATA: EchartsLegendFormData = {
   legendType: LegendType.Scroll,
   showLegend: false,
 };
+
+export type EventHandlers = Record<string, { (props: any): void }>;


### PR DESCRIPTION
🏆 Enhancements
Add cross filtering to Pie Chart.
![pie-filter](https://user-images.githubusercontent.com/33317356/111286381-cf62e980-864a-11eb-81e5-5433a816b139.gif)

TODO:
- add checkbox to control panel to enable/disable emitting filters (default to disabled)
- add multiselect functionality
- add option to clear selection (button in corner?)