### PR TITLE
fix(plugin-chart-echarts): fill missing values when stacked chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -66,6 +66,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     annotationLayers,
     colorScheme,
     contributionMode,
+    forecastEnabled,
     legendMargin,
     legendOrientation,
     legendType,
@@ -87,7 +88,9 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
   const rebasedData = rebaseTimeseriesDatum(data);
-  const rawSeries = extractTimeseriesSeries(rebasedData);
+  const rawSeries = extractTimeseriesSeries(rebasedData, {
+    fillNeighborValue: stack && !forecastEnabled ? 0 : undefined,
+  });
   const series: SeriesOption[] = [];
   const formatter = getNumberFormatter(contributionMode ? ',.0%' : yAxisFormat);
 

--- a/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -31,9 +31,17 @@ import { NULL_STRING, TIMESERIES_CONSTANTS } from '../constants';
 import { LegendOrientation, LegendType } from '../types';
 import { defaultLegendPadding } from '../defaults';
 
-export function extractTimeseriesSeries(data: TimeseriesDataRecord[]): SeriesOption[] {
+function isDefined<T>(value: T | undefined | null): boolean {
+  return value !== undefined && value !== null;
+}
+
+export function extractTimeseriesSeries(
+  data: TimeseriesDataRecord[],
+  opts: { fillNeighborValue?: number } = {},
+): SeriesOption[] {
+  const { fillNeighborValue } = opts;
   if (data.length === 0) return [];
-  const rows = data.map(datum => ({
+  const rows: TimeseriesDataRecord[] = data.map(datum => ({
     ...datum,
     __timestamp: datum.__timestamp || datum.__timestamp === 0 ? new Date(datum.__timestamp) : null,
   }));
@@ -43,10 +51,16 @@ export function extractTimeseriesSeries(data: TimeseriesDataRecord[]): SeriesOpt
     .map(key => ({
       id: key,
       name: key,
-      data: rows.map((datum: { [p: string]: DataRecordValue; __timestamp: Date | null }) => [
-        datum.__timestamp,
-        datum[key],
-      ]),
+      data: rows.map((row, idx) => {
+        const isNextToDefinedValue =
+          isDefined(rows[idx - 1]?.[key]) || isDefined(rows[idx + 1]?.[key]);
+        return [
+          row.__timestamp,
+          !isDefined(row[key]) && isNextToDefinedValue && fillNeighborValue !== undefined
+            ? fillNeighborValue
+            : row[key],
+        ];
+      }),
     }));
 }
 

--- a/plugins/plugin-chart-echarts/test/index.test.ts
+++ b/plugins/plugin-chart-echarts/test/index.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import {
+  EchartsBoxPlotChartPlugin,
   EchartsPieChartPlugin,
   EchartsTimeseriesChartPlugin,
   EchartsGraphChartPlugin,
@@ -24,6 +25,7 @@ import {
 
 describe('@superset-ui/plugin-chart-echarts', () => {
   it('exists', () => {
+    expect(EchartsBoxPlotChartPlugin).toBeDefined();
     expect(EchartsPieChartPlugin).toBeDefined();
     expect(EchartsTimeseriesChartPlugin).toBeDefined();
     expect(EchartsGraphChartPlugin).toBeDefined();

--- a/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -67,6 +67,69 @@ describe('extractTimeseriesSeries', () => {
       },
     ]);
   });
+
+  it('should do missing value imputation', () => {
+    const data = [
+      {
+        __timestamp: '2000-01-01',
+        abc: null,
+      },
+      {
+        __timestamp: '2000-02-01',
+        abc: null,
+      },
+      {
+        __timestamp: '2000-03-01',
+        abc: 1,
+      },
+      {
+        __timestamp: '2000-04-01',
+        abc: null,
+      },
+      {
+        __timestamp: '2000-05-01',
+        abc: null,
+      },
+      {
+        __timestamp: '2000-06-01',
+        abc: null,
+      },
+      {
+        __timestamp: '2000-07-01',
+        abc: 2,
+      },
+      {
+        __timestamp: '2000-08-01',
+        abc: 3,
+      },
+      {
+        __timestamp: '2000-09-01',
+        abc: null,
+      },
+      {
+        __timestamp: '2000-10-01',
+        abc: null,
+      },
+    ];
+    expect(extractTimeseriesSeries(data, { fillNeighborValue: 0 })).toEqual([
+      {
+        id: 'abc',
+        name: 'abc',
+        data: [
+          [new Date('2000-01-01'), null],
+          [new Date('2000-02-01'), 0],
+          [new Date('2000-03-01'), 1],
+          [new Date('2000-04-01'), 0],
+          [new Date('2000-05-01'), null],
+          [new Date('2000-06-01'), 0],
+          [new Date('2000-07-01'), 2],
+          [new Date('2000-08-01'), 3],
+          [new Date('2000-09-01'), 0],
+          [new Date('2000-10-01'), null],
+        ],
+      },
+    ]);
+  });
 });
 
 describe('extractGroupbyLabel', () => {


### PR DESCRIPTION
🐛 Bug Fix

Fill missing values that are next to non-null values with 0 when stacking is enabled to avoid gaps. Avoids imputing all missing values with zero to avoid overlapping lines (empirically observed that the lines became blurry due to many overlapping lines).

### AFTER
![image](https://user-images.githubusercontent.com/33317356/111766723-890dc480-88ae-11eb-93a3-d379162733db.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/111766901-bf4b4400-88ae-11eb-95a3-8a3831e864e3.png)
