### PR TITLE
fix(plugin-chart-table): add text align to table header

### DIFF
--- a/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/plugins/plugin-chart-table/src/TableChart.tsx
@@ -231,6 +231,12 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       const columnWidth = Number.isNaN(Number(config.columnWidth))
         ? config.columnWidth
         : Number(config.columnWidth);
+
+      // inline style for both th and td cell
+      const sharedStyle: CSSProperties = {
+        textAlign,
+      };
+
       const alignPositiveNegative =
         config.alignPositiveNegative === undefined ? defaultAlignPN : config.alignPositiveNegative;
       const colorPositiveNegative =
@@ -264,17 +270,6 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             value,
           );
           const html = isHtml ? { __html: text } : undefined;
-          const style: CSSProperties = {
-            background: valueRange
-              ? cellBar({
-                  value: value as number,
-                  valueRange,
-                  alignPositiveNegative,
-                  colorPositiveNegative,
-                })
-              : undefined,
-            textAlign,
-          };
           const cellProps = {
             // show raw number in title in case of numeric values
             title: typeof value === 'number' ? String(value) : undefined,
@@ -284,7 +279,17 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               value == null ? 'dt-is-null' : '',
               isActiveFilterValue(key, value) ? ' dt-is-active-filter' : '',
             ].join(' '),
-            style,
+            style: {
+              ...sharedStyle,
+              background: valueRange
+                ? cellBar({
+                    value: value as number,
+                    valueRange,
+                    alignPositiveNegative,
+                    colorPositiveNegative,
+                  })
+                : undefined,
+            },
           };
           if (html) {
             // eslint-disable-next-line react/no-danger
@@ -299,6 +304,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             title="Shift + Click to sort by multiple columns"
             className={[className, col.isSorted ? 'is-sorted' : ''].join(' ')}
             style={{
+              ...sharedStyle,
               ...style,
             }}
             onClick={onClick}


### PR DESCRIPTION
🐛 Bug Fix

Let table header also follow the text align configs. Note this also changes the behavior for the table headers of metric columns when column format config is not set---it will align to the right, like the metric values themselves, instead of to the left.

### Before

<img width="971" alt="center-align-before" src="https://user-images.githubusercontent.com/335541/113595135-735a0800-95ed-11eb-95cd-e2585c9e2625.png">


### After

<img width="966" alt="center-align-after" src="https://user-images.githubusercontent.com/335541/113595043-558ca300-95ed-11eb-8caa-e58fc63ff7df.png">

