### PR TITLE
feat(plugin-chart-table): enable emitting cross-filters

### DIFF
--- a/plugins/plugin-chart-table/src/Styles.tsx
+++ b/plugins/plugin-chart-table/src/Styles.tsx
@@ -48,11 +48,11 @@ export default styled.div`
     cursor: pointer;
   }
   td.dt-is-filter:hover {
-    background-color: linen;
+    background-color: ${({ theme: { colors } }) => colors.secondary.light4};
   }
   td.dt-is-active-filter,
   td.dt-is-active-filter:hover {
-    background-color: lightcyan;
+    background-color: ${({ theme: { colors } }) => colors.secondary.light3};
   }
 
   .dt-global-filter {

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -340,18 +340,22 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [
-          {
-            name: 'table_filter',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Enable emitting filters'),
-              renderTrigger: true,
-              default: false,
-              description: t('Whether to apply filter to dashboards when table cells are clicked'),
-            },
-          },
-        ],
+        isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
+          ? [
+              {
+                name: 'table_filter',
+                config: {
+                  type: 'CheckboxControl',
+                  label: t('Enable emitting filters'),
+                  renderTrigger: true,
+                  default: false,
+                  description: t(
+                    'Whether to apply filter to dashboards when table cells are clicked',
+                  ),
+                },
+              },
+            ]
+          : [],
         [
           {
             name: 'column_config',

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -345,7 +345,7 @@ const config: ControlPanelConfig = {
             name: 'table_filter',
             config: {
               type: 'CheckboxControl',
-              label: t('Allow cross filter'),
+              label: t('Enable emitting filters'),
               renderTrigger: true,
               default: false,
               description: t('Whether to apply filter to dashboards when table cells are clicked'),

--- a/plugins/plugin-chart-table/src/index.ts
+++ b/plugins/plugin-chart-table/src/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, Behavior } from '@superset-ui/core';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
 import controlPanel from './controlPanel';
@@ -28,6 +28,7 @@ export { default as __hack__ } from './types';
 export * from './types';
 
 const metadata = new ChartMetadata({
+  behaviors: [Behavior.CROSS_FILTER],
   canBeAnnotationTypes: ['EVENT', 'INTERVAL'],
   description: '',
   name: t('Table'),

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -241,7 +241,7 @@ const transformProps = (chartProps: TableChartProps): TableChartTransformedProps
       ? serverPageLength
       : getPageSize(pageLength, data.length, columns.length),
     filters,
-    emitFilter: tableFilter === true,
+    emitFilter: tableFilter,
     onChangeFilter,
   };
 };


### PR DESCRIPTION
This PR enables emitting cross-filters from Table chart.
To enable the feature, set the feature flag `DASHBOARD_CROSS_FILTERS` in `superset/config.py` and select "ENABLE EMITTING FILTERS" checkbox in Customize tab.
To select filter values, click on cells in groupby columns. Selecting a value emits a filter with an `IN` operator.

https://user-images.githubusercontent.com/15073128/113731815-5c084100-96f9-11eb-92c5-bdfb969ae9e9.mov
![image](https://user-images.githubusercontent.com/15073128/113732271-bc977e00-96f9-11eb-8e55-61df12dfd05a.png)

CC @junlincc @villebro @ktmud 