### PR TITLE
fix(plugin-chart-echarts): fix unnecessary chart clearing

### DIFF
--- a/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -26,14 +26,6 @@ const Styles = styled.div<EchartsStylesProps>`
   width: ${({ width }) => width};
 `;
 
-const usePrevious = <T extends unknown>(value: T): T | undefined => {
-  const ref = useRef<T>();
-  useEffect(() => {
-    ref.current = value;
-  });
-  return ref.current;
-};
-
 export default function Echart({
   width,
   height,
@@ -44,7 +36,7 @@ export default function Echart({
   const divRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<ECharts>();
   const currentSelection = Object.keys(selectedValues) || [];
-  const previousSelection = usePrevious<string[]>(currentSelection) || [];
+  const previousSelection = useRef<string[]>([]);
 
   useEffect(() => {
     if (!divRef.current) return;
@@ -59,20 +51,15 @@ export default function Echart({
 
     chartRef.current.setOption(echartOptions, true);
 
-    const highlights = currentSelection.filter(value => !previousSelection.includes(value));
-    if (highlights.length) {
-      chartRef.current.dispatchAction({
-        type: 'highlight',
-        dataIndex: highlights,
-      });
-    }
-    const downplays = previousSelection.filter(value => !currentSelection.includes(value));
-    if (downplays.length) {
-      chartRef.current.dispatchAction({
-        type: 'downplay',
-        dataIndex: downplays,
-      });
-    }
+    chartRef.current.dispatchAction({
+      type: 'downplay',
+      dataIndex: previousSelection.current.filter(value => !currentSelection.includes(value)),
+    });
+    chartRef.current.dispatchAction({
+      type: 'highlight',
+      dataIndex: currentSelection,
+    });
+    previousSelection.current = currentSelection;
   }, [echartOptions, eventHandlers, selectedValues]);
 
   useEffect(() => {


### PR DESCRIPTION
🐛 Bug Fix
This removes flicker in the ECharts charts introduced in #1010 caused by calling `clear()` on the ECharts instance. This was previously done to clear old highlighted values, as old highlights have to be explicitly "downplayed". This PR removes the `clear()` call, and to downplay non-selected values, the previous selection is compared to the current selection; if a previously selected value is no longer present, it is"downplayed".

### BEFORE
Previously, the chart would rerender every time the `useEffect` hook was called:
![bloxplot-before](https://user-images.githubusercontent.com/33317356/113889942-5fb8c800-97cc-11eb-80f6-f3d028cf7a1a.gif)

### AFTER
After the PR, no flashing occurs:
![boxplot-after](https://user-images.githubusercontent.com/33317356/113889973-66473f80-97cc-11eb-965a-a70908c085e0.gif)

