### PR TITLE
fix(plugin-chart-echarts): add series deduplication

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -36,7 +36,12 @@ import { EChartsOption, SeriesOption } from 'echarts';
 import { DEFAULT_FORM_DATA, EchartsTimeseriesFormData } from './types';
 import { EchartsProps, ForecastSeriesEnum, ProphetValue, LegendOrientation } from '../types';
 import { parseYAxisBound } from '../utils/controls';
-import { extractTimeseriesSeries, getChartPadding, getLegendProps } from '../utils/series';
+import {
+  dedupSeries,
+  extractTimeseriesSeries,
+  getChartPadding,
+  getLegendProps,
+} from '../utils/series';
 import { extractAnnotationLabels } from '../utils/annotation';
 import {
   extractForecastSeriesContext,
@@ -214,7 +219,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
         .map(entry => entry.name || '')
         .concat(extractAnnotationLabels(annotationLayers, annotationData)),
     },
-    series,
+    series: dedupSeries(series),
     toolbox: {
       show: zoomable,
       top: TIMESERIES_CONSTANTS.toolboxTop,

--- a/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -184,3 +184,23 @@ export function getChartPadding(
     bottom: bottom + (orientation === LegendOrientation.Bottom ? legendMargin : 0),
   };
 }
+
+export function dedupSeries(series: SeriesOption[]): SeriesOption[] {
+  const counter: Record<string, number> = {};
+  return series.map(row => {
+    const { id } = row;
+    if (id === undefined) return row;
+    const count = counter[id as string];
+    if (count === undefined) {
+      counter[id] = 1;
+    } else {
+      counter[id] += 1;
+    }
+    const prefix = count ? ` (${count})` : '';
+
+    return {
+      ...row,
+      id: `${id}${prefix}`,
+    };
+  });
+}

--- a/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -186,21 +186,17 @@ export function getChartPadding(
 }
 
 export function dedupSeries(series: SeriesOption[]): SeriesOption[] {
-  const counter: Record<string, number> = {};
+  const counter = new Map<string, number>();
   return series.map(row => {
-    const { id } = row;
+    let { id } = row;
     if (id === undefined) return row;
-    const count = counter[id as string];
-    if (count === undefined) {
-      counter[id] = 1;
-    } else {
-      counter[id] += 1;
-    }
-    const prefix = count ? ` (${count})` : '';
-
+    id = String(id);
+    const count = counter.get(id) || 0;
+    const suffix = count > 0 ? ` (${count})` : '';
+    counter.set(id, count + 1);
     return {
       ...row,
-      id: `${id}${prefix}`,
+      id: `${id}${suffix}`,
     };
   });
 }

--- a/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -18,6 +18,7 @@
  */
 import { getNumberFormatter, getTimeFormatter } from '@superset-ui/core';
 import {
+  dedupSeries,
   extractGroupbyLabel,
   extractTimeseriesSeries,
   formatSeriesName,
@@ -326,6 +327,27 @@ describe('formatSeriesName', () => {
         right: 0,
         top: 0,
       });
+    });
+  });
+
+  describe('dedupSeries', () => {
+    it('should deduplicate ids in series', () => {
+      expect(
+        dedupSeries([
+          {
+            id: 'foo',
+          },
+          {
+            id: 'bar',
+          },
+          {
+            id: 'foo',
+          },
+          {
+            id: 'foo',
+          },
+        ]),
+      ).toEqual([{ id: 'foo' }, { id: 'bar' }, { id: 'foo (1)' }, { id: 'foo (2)' }]);
     });
   });
 });


### PR DESCRIPTION
🐛 Bug Fix
If an annotation layer has a series name that already exists in the chart, the chart raises an error. This PR adds series name deduplication to ensure the chart can be drawn.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/114015710-b11b9280-9872-11eb-9668-b356190a5904.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/114015768-c1337200-9872-11eb-843e-9ef1bfe1ef60.png)
