### PR TITLE
fix(plugin-chart-table): fix empty metrics

### DIFF
--- a/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/plugins/plugin-chart-table/src/buildQuery.ts
@@ -116,7 +116,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (formData: TableChartFormData
     options?.hooks?.setCachedChanges({ [formData.slice_id]: queryObject.filters });
 
     const extraQueries: QueryObject[] = [];
-    if (metrics && formData.show_totals && queryMode === QueryMode.aggregate) {
+    if (metrics?.length && formData.show_totals && queryMode === QueryMode.aggregate) {
       extraQueries.push({
         ...queryObject,
         columns: [],


### PR DESCRIPTION
🐛 Bug Fix
The totals query should not be added if there are no metrics present. The check needs to verify that 1) `metrics` is not `undefined`/`null` and 2) it's `length` is truthy.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/114042352-04e7a500-988e-11eb-94a1-06ef8e33fe70.png)

# BEFORE
![image](https://user-images.githubusercontent.com/33317356/114042593-3b252480-988e-11eb-9845-dfcc503cf8e4.png)
