### PR TITLE
fix(legacy-preset-chart-nvd3): fix tokenizer input type

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/utils/tokenize.ts
@@ -18,15 +18,15 @@
  */
 import { validateNumber } from '@superset-ui/core';
 
-export function tokenizeToNumericArray(value: string): number[] | null {
-  if (!value.trim()) return null;
+export function tokenizeToNumericArray(value?: string): number[] | null {
+  if (!value?.trim()) return null;
   const tokens = value.split(',');
   if (tokens.some(token => validateNumber(token))) throw new Error('All values should be numeric');
   return tokens.map(token => parseFloat(token));
 }
 
-export function tokenizeToStringArray(value: string): string[] | null {
-  if (!value.trim()) return null;
+export function tokenizeToStringArray(value?: string): string[] | null {
+  if (!value?.trim()) return null;
   const tokens = value.split(',');
   return tokens.map(token => token.trim());
 }

--- a/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -26,6 +26,10 @@ describe('tokenizeToNumericArray', () => {
     expect(tokenizeToNumericArray('   1, 2,   3,    4 ')).toStrictEqual([1, 2, 3, 4]);
   });
 
+  it('evals undefined to null', () => {
+    expect(tokenizeToNumericArray(undefined)).toBeNull();
+  });
+
   it('evals empty strings to null', () => {
     expect(tokenizeToNumericArray('')).toBeNull();
     expect(tokenizeToNumericArray('    ')).toBeNull();
@@ -41,6 +45,10 @@ describe('tokenizeToStringArray', () => {
     expect(tokenizeToStringArray('a')).toStrictEqual(['a']);
     expect(tokenizeToStringArray('1.1 , 2.2, 3.0 ,4')).toStrictEqual(['1.1', '2.2', '3.0', '4']);
     expect(tokenizeToStringArray('1.1,a,3, bc ,d')).toStrictEqual(['1.1', 'a', '3', 'bc', 'd']);
+  });
+
+  it('evals undefined to null', () => {
+    expect(tokenizeToStringArray(undefined)).toBeNull();
   });
 
   it('evals empty string to null', () => {


### PR DESCRIPTION
🐛 Bug Fix
In the bullet chart, the value for ranges can be undefined, causing the chart to break if no ranges are specified.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/114141553-6ead9080-991a-11eb-8809-f1c0d7ad9542.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/114141661-93096d00-991a-11eb-9f29-cb9b1ab60265.png)
