### PR TITLE
chore(plugin-chart-table): Add muted attribute of video tag to whitelist

### DIFF
--- a/plugins/plugin-chart-table/src/utils/formatValue.ts
+++ b/plugins/plugin-chart-table/src/utils/formatValue.ts
@@ -27,6 +27,7 @@ const xss = new FilterXSS({
     div: ['style', 'class'],
     a: ['style', 'class', 'href', 'title', 'target'],
     img: ['style', 'class', 'src', 'alt', 'title', 'width', 'height'],
+    video: ['autoplay', 'controls', 'loop', 'preload', 'src', 'height', 'width', 'muted'],
   },
   stripIgnoreTag: true,
   css: false,


### PR DESCRIPTION
🏆 Enhancements

Add `muted` attribute of `video` tag to whitelist.

The `muted` is very useful because `autoplay` attribute will not work if not added `muted` on Chrome.

Default: https://github.com/leizongmin/js-xss/blob/master/lib/default.js#L75
```js
video: ["autoplay", "controls", "loop", "preload", "src", "height", "width"]
```