### PR TITLE
fix(plugin-chart-echarts): fix unnecessary highlight

### DIFF
--- a/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -55,7 +55,7 @@ export default function Echart({
       type: 'downplay',
       dataIndex: previousSelection.current.filter(value => !currentSelection.includes(value)),
     });
-    if (currentSelection.length > 0) {
+    if (currentSelection.length) {
       chartRef.current.dispatchAction({
         type: 'highlight',
         dataIndex: currentSelection,

--- a/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -55,10 +55,12 @@ export default function Echart({
       type: 'downplay',
       dataIndex: previousSelection.current.filter(value => !currentSelection.includes(value)),
     });
-    chartRef.current.dispatchAction({
-      type: 'highlight',
-      dataIndex: currentSelection,
-    });
+    if (currentSelection.length > 0) {
+      chartRef.current.dispatchAction({
+        type: 'highlight',
+        dataIndex: currentSelection,
+      });
+    }
     previousSelection.current = currentSelection;
   }, [echartOptions, eventHandlers, selectedValues]);
 


### PR DESCRIPTION
🐛 Bug Fix
Currently, `Timeseries` chart highlighted by default.
This will fix it.

## BEFORE
![image](https://user-images.githubusercontent.com/18044730/114534822-fa5c4f80-9c81-11eb-92ed-17bcd047d0e2.png)

## AFTER
![image](https://user-images.githubusercontent.com/18044730/114534885-0cd68900-9c82-11eb-95e1-7dad7b59d9d1.png)
