### PR TITLE
chore(core): simplify ExtraFormData

### DIFF
--- a/packages/superset-ui-core/src/chart/types/Base.ts
+++ b/packages/superset-ui-core/src/chart/types/Base.ts
@@ -4,7 +4,7 @@ import { JsonObject } from '../..';
 export type HandlerFunction = (...args: unknown[]) => void;
 
 export enum Behavior {
-  CROSS_FILTER = 'CROSS_FILTER',
+  INTERACTIVE_CHART = 'INTERACTIVE_CHART',
   NATIVE_FILTER = 'NATIVE_FILTER',
 }
 

--- a/packages/superset-ui-core/src/query/buildQueryContext.ts
+++ b/packages/superset-ui-core/src/query/buildQueryContext.ts
@@ -48,6 +48,5 @@ export default function buildQueryContext(
     }),
     result_format: formData.result_format || 'json',
     result_type: formData.result_type || 'full',
-    extra_jwt: formData.extra_jwt,
   };
 }

--- a/packages/superset-ui-core/src/query/buildQueryObject.ts
+++ b/packages/superset-ui-core/src/query/buildQueryObject.ts
@@ -20,7 +20,7 @@ export default function buildQueryObject<T extends QueryFormData>(
 ): QueryObject {
   const {
     annotation_layers = [],
-    extra_form_data = {},
+    extra_form_data,
     time_range,
     since,
     until,
@@ -34,7 +34,12 @@ export default function buildQueryObject<T extends QueryFormData>(
     custom_params = {},
     ...residualFormData
   } = formData;
-  const { append_form_data = {}, override_form_data = {}, custom_form_data = {} } = extra_form_data;
+  const {
+    adhoc_filters: appendAdhocFilters = [],
+    filters: appendFilters = [],
+    custom_form_data = {},
+    ...overrides
+  } = extra_form_data || {};
 
   const numericRowLimit = Number(row_limit);
   const numericRowOffset = Number(row_offset);
@@ -43,7 +48,6 @@ export default function buildQueryObject<T extends QueryFormData>(
   // collect all filters for conversion to simple filters/freeform clauses
   const extras = extractExtras(formData);
   const { filters: extraFilters } = extras;
-  const { adhoc_filters: appendAdhocFilters = [], filters: appendFilters = [] } = append_form_data;
   const filterFormData: {
     filters: QueryObjectFilterClause[];
     adhoc_filters: AdhocFilter[];
@@ -79,7 +83,7 @@ export default function buildQueryObject<T extends QueryFormData>(
     custom_params,
   };
   // override extra form data used by native and cross filters
-  queryObject = overrideExtraFormData(queryObject, override_form_data);
+  queryObject = overrideExtraFormData(queryObject, overrides);
 
   return { ...queryObject, custom_form_data };
 }

--- a/packages/superset-ui-core/src/query/constants.ts
+++ b/packages/superset-ui-core/src/query/constants.ts
@@ -26,25 +26,12 @@ import {
  */
 export const DTTM_ALIAS = '__timestamp';
 
-export const EXTRA_FORM_DATA_OVERRIDE_REGULAR_KEYS: (keyof ExtraFormDataOverrideRegular)[] = [
-  'granularity',
-  'granularity_sqla',
-  'time_column',
-  'time_grain',
-  'time_range',
-];
-
 export const EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS: (keyof ExtraFormDataOverrideExtras)[] = [
   'druid_time_origin',
   'relative_start',
   'relative_end',
   'time_grain_sqla',
   'time_range_endpoints',
-];
-
-export const EXTRA_FORM_DATA_OVERRIDE_KEYS: (keyof ExtraFormDataOverride)[] = [
-  ...EXTRA_FORM_DATA_OVERRIDE_REGULAR_KEYS,
-  ...EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS,
 ];
 
 export const EXTRA_FORM_DATA_APPEND_KEYS: (keyof ExtraFormDataAppend)[] = [
@@ -66,3 +53,12 @@ export const EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS: Record<
   time_grain: 'time_grain',
   time_range: 'time_range',
 };
+
+export const EXTRA_FORM_DATA_OVERRIDE_REGULAR_KEYS = Object.keys(
+  EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS,
+) as (keyof ExtraFormDataOverrideRegular)[];
+
+export const EXTRA_FORM_DATA_OVERRIDE_KEYS: (keyof ExtraFormDataOverride)[] = [
+  ...EXTRA_FORM_DATA_OVERRIDE_REGULAR_KEYS,
+  ...EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS,
+];

--- a/packages/superset-ui-core/src/query/constants.ts
+++ b/packages/superset-ui-core/src/query/constants.ts
@@ -1,3 +1,11 @@
+import {
+  ExtraFormDataAppend,
+  ExtraFormDataOverrideExtras,
+  ExtraFormDataOverrideRegular,
+  ExtraFormDataOverride,
+  QueryObject,
+} from './types';
+
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,3 +25,44 @@
  * under the License.
  */
 export const DTTM_ALIAS = '__timestamp';
+
+export const EXTRA_FORM_DATA_OVERRIDE_REGULAR_KEYS: (keyof ExtraFormDataOverrideRegular)[] = [
+  'granularity',
+  'granularity_sqla',
+  'time_column',
+  'time_grain',
+  'time_range',
+];
+
+export const EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS: (keyof ExtraFormDataOverrideExtras)[] = [
+  'druid_time_origin',
+  'relative_start',
+  'relative_end',
+  'time_grain_sqla',
+  'time_range_endpoints',
+];
+
+export const EXTRA_FORM_DATA_OVERRIDE_KEYS: (keyof ExtraFormDataOverride)[] = [
+  ...EXTRA_FORM_DATA_OVERRIDE_REGULAR_KEYS,
+  ...EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS,
+];
+
+export const EXTRA_FORM_DATA_APPEND_KEYS: (keyof ExtraFormDataAppend)[] = [
+  'adhoc_filters',
+  'filters',
+  'cross_groupby',
+  'cross_highlight',
+  'cross_drilldown',
+  'custom_form_data',
+];
+
+export const EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS: Record<
+  keyof ExtraFormDataOverrideRegular,
+  keyof QueryObject
+> = {
+  granularity: 'granularity',
+  granularity_sqla: 'granularity',
+  time_column: 'time_column',
+  time_grain: 'time_grain',
+  time_range: 'time_range',
+};

--- a/packages/superset-ui-core/src/query/constants.ts
+++ b/packages/superset-ui-core/src/query/constants.ts
@@ -37,9 +37,9 @@ export const EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS: (keyof ExtraFormDataOverrideEx
 export const EXTRA_FORM_DATA_APPEND_KEYS: (keyof ExtraFormDataAppend)[] = [
   'adhoc_filters',
   'filters',
-  'cross_groupby',
-  'cross_highlight',
-  'cross_drilldown',
+  'interactive_groupby',
+  'interactive_highlight',
+  'interactive_drilldown',
   'custom_form_data',
 ];
 

--- a/packages/superset-ui-core/src/query/processExtraFormData.ts
+++ b/packages/superset-ui-core/src/query/processExtraFormData.ts
@@ -16,39 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryObject, QueryObjectExtras, SqlaFormData } from './types';
-
-const ALLOWED_OVERRIDES: Record<keyof SqlaFormData, keyof QueryObject> = {
-  granularity: 'granularity',
-  granularity_sqla: 'granularity',
-  time_column: 'time_column',
-  time_grain: 'time_grain',
-  time_range: 'time_range',
-};
-const ALLOWED_EXTRAS_OVERRIDES: (keyof QueryObjectExtras)[] = [
-  'druid_time_origin',
-  'relative_start',
-  'relative_end',
-  'time_grain_sqla',
-  'time_range_endpoints',
-];
+import { ExtraFormDataOverride, QueryObject } from './types';
+import {
+  EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS,
+  EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS,
+} from './constants';
 
 export function overrideExtraFormData(
   queryObject: QueryObject,
-  overrideFormData: Partial<QueryObject>,
+  overrideFormData: ExtraFormDataOverride,
 ): QueryObject {
   const overriddenFormData: QueryObject = { ...queryObject };
   const { extras: overriddenExtras = {} } = overriddenFormData;
-  Object.entries(ALLOWED_OVERRIDES).forEach(([key, target]) => {
-    if (key in overrideFormData) {
-      overriddenFormData[target] = overrideFormData[key];
+  Object.entries(EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS).forEach(([key, target]) => {
+    // @ts-ignore
+    const value = overrideFormData[key];
+    if (value !== undefined) {
+      overriddenFormData[target] = value;
     }
   });
-  const { extras: overrideExtras = {} } = overrideFormData;
-  ALLOWED_EXTRAS_OVERRIDES.forEach(key => {
-    if (key in overrideExtras) {
+  EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS.forEach(key => {
+    if (key in overrideFormData) {
       // @ts-ignore
-      overriddenExtras[key] = overrideExtras[key];
+      overriddenExtras[key] = overrideFormData[key];
     }
   });
   if (Object.keys(overriddenExtras).length > 0) {

--- a/packages/superset-ui-core/src/query/processExtraFormData.ts
+++ b/packages/superset-ui-core/src/query/processExtraFormData.ts
@@ -29,8 +29,7 @@ export function overrideExtraFormData(
   const overriddenFormData: QueryObject = { ...queryObject };
   const { extras: overriddenExtras = {} } = overriddenFormData;
   Object.entries(EXTRA_FORM_DATA_OVERRIDE_REGULAR_MAPPINGS).forEach(([key, target]) => {
-    // @ts-ignore
-    const value = overrideFormData[key];
+    const value = overrideFormData[key as keyof ExtraFormDataOverride];
     if (value !== undefined) {
       overriddenFormData[target] = value;
     }

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -19,11 +19,12 @@
  */
 import { DatasourceType } from './Datasource';
 import { BinaryOperator, SetOperator, UnaryOperator } from './Operator';
-import { AppliedTimeExtras, TimeRange } from './Time';
+import { AppliedTimeExtras, TimeRange, TimeRangeEndpoints } from './Time';
 import { AnnotationLayer } from './AnnotationLayer';
 import { QueryFields, QueryFormMetric } from './QueryFormData';
 import { Maybe } from '../../types';
 import { PostProcessingRule } from './PostProcessing';
+import { JsonObject } from '../../connection';
 
 export type QueryObjectFilterClause = {
   col: string;
@@ -50,7 +51,7 @@ export type QueryObjectExtras = Partial<{
   relative_start?: string;
   relative_end?: string;
   time_grain_sqla?: string;
-  time_range_endpoints?: string[];
+  time_range_endpoints?: TimeRangeEndpoints;
   /** WHERE condition */
   where?: string;
 }>;
@@ -128,7 +129,7 @@ export interface QueryObject extends QueryFields, TimeRange, ResidualQueryObject
 
   url_params?: Record<string, string>;
 
-  custom_params?: Record<string, string>;
+  custom_params?: JsonObject;
 
   /** Free-form WHERE SQL: multiple clauses are concatenated by AND */
   where?: string;
@@ -146,7 +147,6 @@ export interface QueryContext {
   /** Response format */
   result_format: string;
   queries: QueryObject[];
-  extra_jwt?: string;
 }
 
 export default {};

--- a/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -171,7 +171,6 @@ export interface BaseFormData extends TimeRange, FormDataResidual {
   force?: boolean;
   result_format?: string;
   result_type?: string;
-  time_range?: string;
   time_range_endpoints?: TimeRangeEndpoints;
   annotation_layers?: AnnotationLayer[];
   url_params?: Record<string, string>;

--- a/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -102,9 +102,10 @@ export type QueryFormExtraFilter = {
 export type ExtraFormDataAppend = {
   adhoc_filters?: AdhocFilter[];
   filters?: QueryObjectFilterClause[];
-  cross_drilldown?: string[];
-  cross_groupby?: string[];
-  cross_highlight?: string[];
+  /** These properties are for dynamic cross chart interaction */
+  interactive_drilldown?: string[];
+  interactive_groupby?: string[];
+  interactive_highlight?: string[];
   /** This property can be used to pass non-standard form data between viz components */
   custom_form_data?: JsonObject;
 };

--- a/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -25,7 +25,7 @@ import { AdhocMetric, SavedMetric } from './Metric';
 import { AdhocFilter } from './Filter';
 import { BinaryOperator, SetOperator } from './Operator';
 import { AnnotationLayer } from './AnnotationLayer';
-import { QueryObject } from './Query';
+import { QueryObject, QueryObjectExtras, QueryObjectFilterClause } from './Query';
 import { TimeRange, TimeRangeEndpoints } from './Time';
 import { TimeGranularity } from '../../time-format';
 import { JsonObject } from '../../connection';
@@ -60,7 +60,7 @@ export enum QueryMode {
  * Query form fields related to SQL query and data outputs.
  */
 export interface QueryFields {
-  columns: QueryFormColumn[];
+  columns?: QueryFormColumn[];
   metrics?: QueryFormMetric[];
   orderby?: QueryFormOrderBy[];
 }
@@ -98,14 +98,39 @@ export type QueryFormExtraFilter = {
     }
 );
 
-export type ExtraFormData = {
-  /** params that will be passed to buildQuery and will be appended to request params */
-  append_form_data?: Partial<QueryObject>;
-  /** params that will be passed to buildQuery and will override request params with same name */
-  override_form_data?: Partial<QueryObject>;
-  /** custom params that will be passed to buildQuery and can be used for request customization */
+/** These properties will be appended to those pre-existing in the form data/query object */
+export type ExtraFormDataAppend = {
+  adhoc_filters?: AdhocFilter[];
+  filters?: QueryObjectFilterClause[];
+  cross_drilldown?: string[];
+  cross_groupby?: string[];
+  cross_highlight?: string[];
+  /** This property can be used to pass non-standard form data between viz components */
   custom_form_data?: JsonObject;
 };
+
+/** These parameters override properties in the extras parameter in the form data/query object.
+ * Not all keys of QueryObjectExtras are supported here to ensure that freeform where and having
+ * filter clauses can't be overridden */
+export type ExtraFormDataOverrideExtras = Pick<
+  QueryObjectExtras,
+  | 'druid_time_origin'
+  | 'relative_start'
+  | 'relative_end'
+  | 'time_grain_sqla'
+  | 'time_range_endpoints'
+>;
+
+/** These parameters override those already present in the form data/query object */
+export type ExtraFormDataOverrideRegular = Partial<Pick<SqlaFormData, 'granularity_sqla'>> &
+  Partial<Pick<DruidFormData, 'granularity'>> &
+  Partial<Pick<BaseFormData, 'time_range'>> &
+  Partial<Pick<QueryObject, 'time_column' | 'time_grain'>>;
+
+/** These parameters override those already present in the form data/query object */
+export type ExtraFormDataOverride = ExtraFormDataOverrideRegular & ExtraFormDataOverrideExtras;
+
+export type ExtraFormData = ExtraFormDataAppend & ExtraFormDataOverride;
 
 // Type signature for formData shared by all viz types
 // It will be gradually filled out as we build out the query object
@@ -131,6 +156,7 @@ export interface BaseFormData extends TimeRange, FormDataResidual {
   /** list of filters */
   adhoc_filters?: AdhocFilter[] | null;
   extra_filters?: QueryFormExtraFilter[] | null;
+  extra_form_data?: ExtraFormData;
   /** order descending */
   order_desc?: boolean;
   /** limit number of time series */
@@ -145,11 +171,11 @@ export interface BaseFormData extends TimeRange, FormDataResidual {
   force?: boolean;
   result_format?: string;
   result_type?: string;
+  time_range?: string;
   time_range_endpoints?: TimeRangeEndpoints;
   annotation_layers?: AnnotationLayer[];
   url_params?: Record<string, string>;
   custom_params?: Record<string, string>;
-  extra_jwt?: string;
 }
 
 /**

--- a/packages/superset-ui-core/test/query/buildQueryContext.test.ts
+++ b/packages/superset-ui-core/test/query/buildQueryContext.test.ts
@@ -31,16 +31,6 @@ describe('buildQueryContext', () => {
     expect(queryContext.result_format).toBe('json');
     expect(queryContext.result_type).toBe('full');
   });
-  it('should build with extra_jwt', () => {
-    const queryContext = buildQueryContext({
-      datasource: '5__table',
-      viz_type: 'table',
-      extra_jwt: 'ABCDEFG',
-    });
-    expect(queryContext.datasource.id).toBe(5);
-    expect(queryContext.datasource.type).toBe('table');
-    expect(queryContext.extra_jwt).toBe('ABCDEFG');
-  });
   it('should build datasource for druid sources and set force to true', () => {
     const queryContext = buildQueryContext({
       datasource: '5__druid',

--- a/packages/superset-ui-core/test/query/buildQueryObject.test.ts
+++ b/packages/superset-ui-core/test/query/buildQueryObject.test.ts
@@ -25,6 +25,7 @@ import {
   buildQueryObject,
   QueryObject,
 } from '../../src/query';
+import { JsonObject } from '../../lib';
 
 describe('buildQueryObject', () => {
   let query: QueryObject;
@@ -75,15 +76,13 @@ describe('buildQueryObject', () => {
       ],
       where: 'a = b',
       extra_form_data: {
-        append_form_data: {
-          adhoc_filters: [
-            {
-              expressionType: 'SQL',
-              clause: 'WHERE',
-              sqlExpression: '(1 = 1)',
-            },
-          ],
-        },
+        adhoc_filters: [
+          {
+            expressionType: 'SQL',
+            clause: 'WHERE',
+            sqlExpression: '(1 = 1)',
+          },
+        ],
       },
     });
     expect(query.filters).toEqual([
@@ -255,7 +254,7 @@ describe('buildQueryObject', () => {
   });
 
   it('should populate custom_params', () => {
-    const customParams = { customObject: { id: 137, name: 'C-137' } };
+    const customParams: JsonObject = { customObject: { id: 137, name: 'C-137' } };
     query = buildQueryObject({
       datasource: '5__table',
       granularity_sqla: 'ds',

--- a/packages/superset-ui-core/test/query/processExtraFormData.test.ts
+++ b/packages/superset-ui-core/test/query/processExtraFormData.test.ts
@@ -70,6 +70,7 @@ describe('overrideExtraFormData', () => {
           time_range: '100 years ago',
         },
         {
+          // @ts-expect-error
           viz_type: 'other custom viz',
         },
       ),
@@ -93,11 +94,7 @@ describe('overrideExtraFormData', () => {
             time_grain_sqla: 'PT1H',
           },
         },
-        {
-          extras: {
-            time_grain_sqla: 'PT2H',
-          },
-        },
+        { time_grain_sqla: 'PT2H' },
       ),
     ).toEqual({
       granularity: 'something',
@@ -120,9 +117,7 @@ describe('overrideExtraFormData', () => {
           time_range: '100 years ago',
         },
         {
-          extras: {
-            time_grain_sqla: 'PT1H',
-          },
+          time_grain_sqla: 'PT1H',
         },
       ),
     ).toEqual({

--- a/plugins/plugin-chart-echarts/src/BoxPlot/EchartsBoxPlot.tsx
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/EchartsBoxPlot.tsx
@@ -41,24 +41,22 @@ export default function EchartsBoxPlot({
 
       setDataMask({
         extraFormData: {
-          append_form_data: {
-            filters:
-              values.length === 0
-                ? []
-                : groupby.map((col, idx) => {
-                    const val = groupbyValues.map(v => v[idx]);
-                    if (val === null || val === undefined)
-                      return {
-                        col,
-                        op: 'IS NULL',
-                      };
+          filters:
+            values.length === 0
+              ? []
+              : groupby.map((col, idx) => {
+                  const val = groupbyValues.map(v => v[idx]);
+                  if (val === null || val === undefined)
                     return {
                       col,
-                      op: 'IN',
-                      val: val as (string | number | boolean)[],
+                      op: 'IS NULL',
                     };
-                  }),
-          },
+                  return {
+                    col,
+                    op: 'IN',
+                    val: val as (string | number | boolean)[],
+                  };
+                }),
         },
         filterState: {
           value: groupbyValues.length ? groupbyValues : null,

--- a/plugins/plugin-chart-echarts/src/BoxPlot/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/buildQuery.ts
@@ -26,7 +26,7 @@ export default function buildQuery(formData: BoxPlotQueryFormData) {
   return buildQueryContext(formData, baseQueryObject => {
     let whiskerType: BoxPlotQueryObjectWhiskerType;
     let percentiles: [number, number] | undefined;
-    const { columns, metrics = [] } = baseQueryObject;
+    const { columns = [], metrics = [] } = baseQueryObject;
     const percentileMatch = PERCENTILE_REGEX.exec(whiskerOptions as string);
 
     if (whiskerOptions === 'Tukey') {

--- a/plugins/plugin-chart-echarts/src/BoxPlot/index.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/index.ts
@@ -43,7 +43,7 @@ export default class EchartsBoxPlotChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsBoxPlot'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.CROSS_FILTER],
+        behaviors: [Behavior.INTERACTIVE_CHART],
         credits: ['https://echarts.apache.org'],
         description: 'Box Plot (Apache ECharts)',
         name: t('Box Plot'),

--- a/plugins/plugin-chart-echarts/src/Pie/EchartsPie.tsx
+++ b/plugins/plugin-chart-echarts/src/Pie/EchartsPie.tsx
@@ -41,24 +41,22 @@ export default function EchartsPie({
 
       setDataMask({
         extraFormData: {
-          append_form_data: {
-            filters:
-              values.length === 0
-                ? []
-                : groupby.map((col, idx) => {
-                    const val = groupbyValues.map(v => v[idx]);
-                    if (val === null || val === undefined)
-                      return {
-                        col,
-                        op: 'IS NULL',
-                      };
+          filters:
+            values.length === 0
+              ? []
+              : groupby.map((col, idx) => {
+                  const val = groupbyValues.map(v => v[idx]);
+                  if (val === null || val === undefined)
                     return {
                       col,
-                      op: 'IN',
-                      val: val as (string | number | boolean)[],
+                      op: 'IS NULL',
                     };
-                  }),
-          },
+                  return {
+                    col,
+                    op: 'IN',
+                    val: val as (string | number | boolean)[],
+                  };
+                }),
         },
         filterState: {
           value: groupbyValues.length ? groupbyValues : null,

--- a/plugins/plugin-chart-echarts/src/Pie/index.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/index.ts
@@ -43,7 +43,7 @@ export default class EchartsPieChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsPie'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.CROSS_FILTER],
+        behaviors: [Behavior.INTERACTIVE_CHART],
         credits: ['https://echarts.apache.org'],
         description: 'Pie Chart (Apache ECharts)',
         name: t('Pie Chart'),

--- a/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/plugins/plugin-chart-table/src/TableChart.tsx
@@ -177,24 +177,22 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       const groupByValues = Object.values(filters);
       setDataMask({
         extraFormData: {
-          append_form_data: {
-            filters:
-              groupBy.length === 0
-                ? []
-                : groupBy.map(col => {
-                    const val = filters?.[col];
-                    if (val === null || val === undefined)
-                      return {
-                        col,
-                        op: 'IS NULL',
-                      };
+          filters:
+            groupBy.length === 0
+              ? []
+              : groupBy.map(col => {
+                  const val = filters?.[col];
+                  if (val === null || val === undefined)
                     return {
                       col,
-                      op: 'IN',
-                      val: val as (string | number | boolean)[],
+                      op: 'IS NULL',
                     };
-                  }),
-          },
+                  return {
+                    col,
+                    op: 'IN',
+                    val: val as (string | number | boolean)[],
+                  };
+                }),
         },
         filterState: {
           value: groupByValues.length ? groupByValues : null,

--- a/plugins/plugin-chart-table/src/index.ts
+++ b/plugins/plugin-chart-table/src/index.ts
@@ -28,7 +28,7 @@ export { default as __hack__ } from './types';
 export * from './types';
 
 const metadata = new ChartMetadata({
-  behaviors: [Behavior.CROSS_FILTER],
+  behaviors: [Behavior.INTERACTIVE_CHART],
   canBeAnnotationTypes: ['EVENT', 'INTERVAL'],
   description: '',
   name: t('Table'),


### PR DESCRIPTION
💔 Breaking Changes
This is a follow-up to #1040 to further simplify the data mask hook and related types.

Before the `ExtraFormData` contained three properties

```
extraFormData = {
  append_form_data: {
    adhoc_filters: [],
    filters: [],
  },
  override_form_data: {
    time_range: '',
  },
  custom_form_data: {},
}
```

After this change, `append_form_data`, `override_form_data` and `custom_form_data`  are all in the same object, with the implicit assumption that filters and `custom_form_data` are appended to fields with the same name in `QueryFormData`/`QueryObject`, and the rest (mostly temporal filters, like time column, time range, time grain etc) are overridden. Example:

```
extraFormData = {
  adhoc_filters: [],
  filters: [],
  time_range: '',
  custom_form_data: {},
}
```

In addition, `Behavior.CROSS_FILTER` is renamed to `Behavior.INTERACTIVE_CHART` to more clearly communicate that it applies to any interactive chart behavior as opposed to native filters.

The details will be fully documented shortly as we stabilize these interfaces.