### PR TITLE
chore(plugin-chart-echarts): bump echarts to 5.1.0

### DIFF
--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -30,7 +30,7 @@
     "@superset-ui/core": "0.17.32",
     "@types/mathjs": "^6.0.7",
     "d3-array": "^1.2.0",
-    "echarts": "^5.0.2",
+    "echarts": "^5.1.0",
     "mathjs": "^8.0.1"
   },
   "peerDependencies": {

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -44,6 +44,8 @@ import {
   MarkArea1DDataItemOption,
   MarkArea2DDataItemOption,
 } from 'echarts/types/src/component/marker/MarkAreaModel';
+import { MarkLine1DDataItemOption } from 'echarts/types/src/component/marker/MarkLineModel';
+
 import { extractForecastSeriesContext } from '../utils/prophet';
 import { ForecastSeriesEnum, LegendOrientation } from '../types';
 import { EchartsTimeseriesSeriesType } from './types';
@@ -234,10 +236,12 @@ export function transformEventAnnotation(
     const { name, color, opacity, style, width } = layer;
     const { descriptions, time, title } = annotation;
     const label = formatAnnotationLabel(name, title, descriptions);
-    const eventData = [
+    const eventData: MarkLine1DDataItemOption[] = [
       {
         name: label,
         xAxis: (time as unknown) as number,
+        // TODO: remove when https://github.com/apache/echarts/pull/14693 is released
+        symbolOffset: 0,
       },
     ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4312,15 +4312,6 @@
     resolve-from "^5.0.0"
     store2 "^2.7.1"
 
-"@superset-ui/chart-controls@0.17.22":
-  version "0.17.22"
-  resolved "https://registry.yarnpkg.com/@superset-ui/chart-controls/-/chart-controls-0.17.22.tgz#4f4f04dc35ddec45d8a797b11f96343f2d278877"
-  integrity sha512-poxug7Wy2jkZhJiulJlISFuhQGt1HbIayoyA48T2JcSsHh/0ybgX8VP3rTCEN/G/txebisfO3P4GW4Zqqcaz2g==
-  dependencies:
-    "@superset-ui/core" "0.17.22"
-    lodash "^4.17.15"
-    prop-types "^15.7.2"
-
 "@superset-ui/commit-config@^0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@superset-ui/commit-config/-/commit-config-0.0.9.tgz#f0149945185e0908e14fec46bdc1498aa026ada7"
@@ -4334,41 +4325,6 @@
     conventional-changelog-cli "^2.0.12"
     cz-conventional-changelog "^2.1.0"
 
-"@superset-ui/core@0.17.22":
-  version "0.17.22"
-  resolved "https://registry.yarnpkg.com/@superset-ui/core/-/core-0.17.22.tgz#76ac52b1fd77f529567c058199fd7f448050ac69"
-  integrity sha512-TUXvZMAN5IgFF8VUt7NVXG2XWzR2RccVfuySlFLJ+kztcP+d/Jt/Go+dtg2KT7okW/CTY4Co7ifDOhZwk2EGeA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    "@emotion/core" "^10.0.28"
-    "@emotion/styled" "^10.0.27"
-    "@types/d3-format" "^1.3.0"
-    "@types/d3-interpolate" "^1.3.1"
-    "@types/d3-scale" "^2.1.1"
-    "@types/d3-time" "^1.0.9"
-    "@types/d3-time-format" "^2.1.0"
-    "@types/lodash" "^4.14.149"
-    "@types/rison" "0.0.6"
-    "@types/seedrandom" "^2.4.28"
-    "@vx/responsive" "^0.0.199"
-    csstype "^2.6.4"
-    d3-format "^1.3.2"
-    d3-interpolate "^1.4.0"
-    d3-scale "^3.0.0"
-    d3-time "^1.0.10"
-    d3-time-format "^2.2.0"
-    emotion-theming "^10.0.27"
-    fetch-retry "^4.0.1"
-    jed "^1.1.1"
-    lodash "^4.17.11"
-    pretty-ms "^7.0.0"
-    react-error-boundary "^1.2.5"
-    react-markdown "^4.3.1"
-    reselect "^4.0.0"
-    rison "^0.1.1"
-    seedrandom "^3.0.5"
-    whatwg-fetch "^3.0.0"
-
 "@superset-ui/core@file:packages/superset-ui-core/src":
   version "0.0.0"
 
@@ -4381,10 +4337,10 @@
     d3-cloud "^1.2.1"
     prop-types "^15.6.2"
 
-"@superset-ui/react-pivottable@^0.12.4":
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/@superset-ui/react-pivottable/-/react-pivottable-0.12.4.tgz#ca6e6adc669ea366d12e1c09404e8347c5c65b37"
-  integrity sha512-yS00r7QlxblDkye6LV5Lum/59YX52tYxjOdv5CVATcidAhFaxHIyhc864odUxMYUoFoWrLWPnQl9FFbPOtBt8A==
+"@superset-ui/react-pivottable@^0.12.5":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@superset-ui/react-pivottable/-/react-pivottable-0.12.5.tgz#11448d718f4bf3d9421767c18590604dc436ed1f"
+  integrity sha512-9Nmj/sRdc6U/OUWBqfqHAaV05MCmNLt65I/Ar39brpLcaYKWRIYpBcUT3n/HOhCr8ALilnsLdQzzfjjaNAuv5w==
   dependencies:
     immutability-helper "^3.1.1"
     prop-types "^15.7.2"
@@ -10160,13 +10116,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.0.2.tgz#1726d17a57cf05d62cd0567b4325e1201a56baf6"
-  integrity sha512-En0VYpc96nw2/2AZoBWPHsGi471zMublttj50kfFpYAeR4geup0Tj9iVgEXh7QYZFPnRiruDJEjcB5PXZ+BYzQ==
+echarts@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.1.0.tgz#768cc585aa092560f48f01b2d52de493aeecd2b0"
+  integrity sha512-/X2nnN5BXW2tuA/Hv9YY279rDfwcXaBAjK9Azi//llshbKyUXXxBknsug21GJRpwTmLZbE8rjjbhchdm01bZtw==
   dependencies:
     tslib "2.0.3"
-    zrender "5.0.4"
+    zrender "5.1.0"
 
 editions@^2.2.0:
   version "2.3.1"
@@ -23689,9 +23645,9 @@ yosay@^2.0.2:
     taketalk "^1.0.0"
     wrap-ansi "^2.0.0"
 
-zrender@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.0.4.tgz#89c355af908b9f64a301b38f751b7951f2c8a95a"
-  integrity sha512-DJpy0yrHYY5CuH6vhb9IINWbjvBUe/56J8aH86Jb7O8rRPAYZ3M2E469Qf5B3EOIfM3o3aUrO5edRQfLJ+l1Qw==
+zrender@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.1.0.tgz#b6a84c3aa7ccc6642ee0519901ca4c0835c4d85e"
+  integrity sha512-c+8VRx52ycbmqwHeHLlo/BAfIHBl/JZNLM6cfDQFgzIH05yb+f5J9F/fbRsP+zGc8dW9XHuhdt8/iqukgMZSeg==
   dependencies:
     tslib "2.0.3"


### PR DESCRIPTION
🏆 Enhancements
Bump ECharts to 5.1.0 to pull in general fixes/improvements. See changelog for details: https://github.com/apache/echarts/releases/tag/5.1.0