### PR TITLE
feat: add tooltip for full metric names

### DIFF
--- a/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -21,6 +21,7 @@ import { styled, Metric, SafeMarkdown } from '@superset-ui/core';
 import InfoTooltipWithTrigger from './InfoTooltipWithTrigger';
 import { ColumnTypeLabel } from './ColumnTypeLabel';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
+import Tooltip from './Tooltip';
 
 const FlexRowContainer = styled.div`
   align-items: center;
@@ -67,7 +68,9 @@ export function MetricOption({
           details={metric.certification_details}
         />
       )}
-      <span className="option-label">{link}</span>
+      <Tooltip id="metric-name-tooltip" title={verbose} trigger={['hover']} placement="top">
+        <span className="option-label">{link}</span>
+      </Tooltip>
       {metric.description && (
         <InfoTooltipWithTrigger
           className="text-muted"

--- a/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
+++ b/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
@@ -83,4 +83,7 @@ describe('MetricOption', () => {
     wrapper = shallow(factory(props));
     expect(wrapper.find('ColumnTypeLabel')).toHaveLength(1);
   });
+  it('shows a Tooltip for the verbose metric name', () => {
+    expect(wrapper.find('Tooltip')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
🏆 Enhancements

Adds a tooltip to the metric name so that if it overflows the container we can still read it.

Test plan:
CI. new unit test, test in superset
![Screen Shot 2021-04-20 at 10 54 11 AM](https://user-images.githubusercontent.com/7409244/115442575-06d33180-a1c7-11eb-9b76-d3de11b5beb2.png)
![Screen Shot 2021-04-20 at 10 55 03 AM](https://user-images.githubusercontent.com/7409244/115442579-076bc800-a1c7-11eb-81b7-1a9b7a6b24c1.png)

to: @pkdotson @ktmud @graceguo-supercat 