### PR TITLE
fix(plugin-chart-echarts): remove label line if below threshold

### DIFF
--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -102,6 +102,7 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
     emitFilter,
   }: EchartsPieFormData = { ...DEFAULT_LEGEND_FORM_DATA, ...DEFAULT_PIE_FORM_DATA, ...formData };
   const metricLabel = getMetricLabel(metric);
+  const minShowLabelAngle = (showLabelsThreshold || 0) * 3.6;
 
   const keys = data.map(datum =>
     extractGroupbyLabel({
@@ -157,15 +158,12 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
     {},
   );
 
-  const formatter = (params: CallbackDataParams) => {
-    if (params.percent && params.percent < showLabelsThreshold) return '';
-
-    return formatPieLabel({
+  const formatter = (params: CallbackDataParams) =>
+    formatPieLabel({
       params,
       numberFormatter,
       labelType,
     });
-  };
 
   const defaultLabel = {
     formatter,
@@ -182,6 +180,7 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
       center: ['50%', '50%'],
       avoidLabelOverlap: true,
       labelLine: labelsOutside && labelLine ? { show: true } : { show: false },
+      minShowLabelAngle,
       label: labelsOutside
         ? {
             ...defaultLabel,


### PR DESCRIPTION
🐛 Bug Fix

When `showLabelsThreshold` is set, the label lines are shown despite the labels being missing. This PR removes the hack to make labels empty strings when the threshold is not met and implements the `minShowLabelAngle` (set to `3.6 * showLabelsThreshold` as 100 % == 360 degrees) property that provides native support for removal of thin slices.

### BEFORE
As can be seen in the screenshot, the top slices show a line despite no labels being shown:
![image](https://user-images.githubusercontent.com/33317356/115949355-3d69be80-a4dd-11eb-9b6b-e6d7aeb13f85.png)

### AFTER
After the fix, no label lines are shown for the slices that don't exceed the threshold:
![image](https://user-images.githubusercontent.com/33317356/115949308-e6fc8000-a4dc-11eb-911b-813cdeedb1fb.png)
