### PR TITLE
chore: remove class support from plugin yeoman generator

### DIFF
--- a/packages/generator-superset/generators/plugin-chart/index.js
+++ b/packages/generator-superset/generators/plugin-chart/index.js
@@ -24,21 +24,6 @@ module.exports = class extends Generator {
       },
       {
         type: 'list',
-        name: 'componentType',
-        message: 'What type of React component would you like?',
-        choices: [
-          {
-            name: 'Class component',
-            value: 'class',
-          },
-          {
-            name: 'Function component (with hooks)',
-            value: 'function',
-          },
-        ],
-      },
-      {
-        type: 'list',
         name: 'chartType',
         message: 'What type of chart would you like?',
         choices: [

--- a/packages/generator-superset/generators/plugin-chart/templates/src/MyChart.erb
+++ b/packages/generator-superset/generators/plugin-chart/templates/src/MyChart.erb
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { <%if (componentType == 'class') { %>PureComponent<% } %><%if (componentType == 'function') { %>useEffect<% } %>, createRef } from 'react';
+import React, { useEffect, createRef } from 'react';
 import { styled } from '@superset-ui/core';
 import { <%= packageLabel %>Props, <%= packageLabel %>StylesProps } from './types';
 
@@ -50,39 +50,7 @@ const Styles = styled.div<<%= packageLabel %>StylesProps>`
  *  * FormData (your controls!) provided as props by transformProps.ts
  */
 
-<%if (componentType == 'class') { %>export default class <%= packageLabel %> extends PureComponent<<%= packageLabel %>Props> {
-  // Often, you just want to get a hold of the DOM and go nuts.
-  // Here, you can do that with createRef, and componentDidMount.
-
-  rootElem = createRef<HTMLDivElement>();
-
-  componentDidMount() {
-    const root = this.rootElem.current as HTMLElement;
-    console.log('Plugin element', root);
-  }
-
-  render() {
-    // height and width are the height and width of the DOM element as it exists in the dashboard.
-    // There is also a `data` prop, which is, of course, your DATA 🎉
-    console.log('Approach 1 props', this.props);
-    const { data, height, width } = this.props;
-
-    console.log('Plugin props', this.props);
-
-    return (
-      <Styles
-        ref={this.rootElem}
-        boldText={this.props.boldText}
-        headerFontSize={this.props.headerFontSize}
-        height={height}
-        width={width}
-      >
-        <h3>{this.props.headerText}</h3>
-        <pre>{JSON.stringify(data, null, 2)}</pre>
-      </Styles>
-    );
-  }
-}<% } %><%if (componentType == 'function') { %>export default function <%= packageLabel %>(props: <%= packageLabel %>Props) {
+export default function <%= packageLabel %>(props: <%= packageLabel %>Props) {
   // height and width are the height and width of the DOM element as it exists in the dashboard.
   // There is also a `data` prop, which is, of course, your DATA 🎉
   const { data, height, width } = props;
@@ -110,4 +78,4 @@ const Styles = styled.div<<%= packageLabel %>StylesProps>`
       <pre>${JSON.stringify(data, null, 2)}</pre>
     </Styles>
   );
-}<% } %>
+}


### PR DESCRIPTION
💔 Breaking Changes
Not sure if this is _really_ a breaking change, but it seems like nobody's in favor of class components these days, so I figured maybe we might as well simplify the Yeoman generator so we don't wind up with a bunch of plugins that are just on the road to a refactor.

This just seemed like a logical thing to do, but wondering if anyone feels otherwise, e.g. @ktmud @villebro @amitmiran137 

🏆 Enhancements

📜 Documentation

🐛 Bug Fix

🏠 Internal
