### PR TITLE
feat(plugin-chart-table): disable show_totals by default

### DIFF
--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -245,7 +245,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'CheckboxControl',
               label: t('Show totals'),
-              default: true,
+              default: false,
               description: t(
                 'Show total aggregations of selected metrics. Note that row limit does not apply to the result.',
               ),


### PR DESCRIPTION
🐛 Bug Fix

Show totals adds an additional SQL query to the request, which slows things down. Since it's not a critical feature, we shouldn't enable it by default.