### PR TITLE
fix(plugin-chart-table): resize and totals formatting bug

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx
@@ -73,9 +73,9 @@ const fractionDigits: ControlFormItemSpec<'Slider'> = {
 
 const columnWidth: ControlFormItemSpec<'InputNumber'> = {
   controlType: 'InputNumber',
-  label: t('Width'),
+  label: t('Min Width'),
   description: t(
-    'Default column width in pixels, may still be restricted by the shortest/longest word in the column',
+    "Default minimal column width in pixels, actual width may still be larger than this if other columns don't need much space",
   ),
   width: 120,
   placeholder: 'auto',

--- a/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -35,7 +35,6 @@ import {
   IdType,
   Row,
 } from 'react-table';
-import { t } from '@superset-ui/core';
 import { matchSorter, rankings } from 'match-sorter';
 import GlobalFilter, { GlobalFilterProps } from './components/GlobalFilter';
 import SelectPageSize, { SelectPageSizeProps, SizeOption } from './components/SelectPageSize';
@@ -45,8 +44,6 @@ import { PAGE_SIZE_OPTIONS } from '../consts';
 
 export interface DataTableProps<D extends object> extends TableOptions<D> {
   tableClassName?: string;
-  totals?: { value: string; className?: string }[];
-  totalsHeaderSpan?: number;
   searchInput?: boolean | GlobalFilterProps<D>['searchInput'];
   selectPageSize?: boolean | SelectPageSizeProps['selectRenderer'];
   pageSizeOptions?: SizeOption[]; // available page size options
@@ -73,8 +70,6 @@ export default function DataTable<D extends object>({
   tableClassName,
   columns,
   data,
-  totals,
-  totalsHeaderSpan,
   serverPaginationData,
   width: initialWidth = '100%',
   height: initialHeight = 300,
@@ -159,6 +154,7 @@ export default function DataTable<D extends object>({
     getTableBodyProps,
     prepareRow,
     headerGroups,
+    footerGroups,
     page,
     pageCount,
     gotoPage,
@@ -198,6 +194,8 @@ export default function DataTable<D extends object>({
     return (wrapStickyTable ? wrapStickyTable(getNoResults) : getNoResults()) as JSX.Element;
   }
 
+  const shouldRenderFooter = columns.some(x => !!x.Footer);
+
   const renderTable = () => (
     <table {...getTableProps({ className: tableClassName })}>
       <thead>
@@ -234,14 +232,16 @@ export default function DataTable<D extends object>({
           </tr>
         )}
       </tbody>
-      {totals && (
+      {shouldRenderFooter && (
         <tfoot>
-          <tr key="totals" className="dt-totals">
-            <td colSpan={totalsHeaderSpan}>{t('Totals')}</td>
-            {totals.map(item => (
-              <td className={item.className}>{item.value}</td>
-            ))}
-          </tr>
+          {footerGroups.map(footerGroup => {
+            const { key: footerGroupKey, ...footerGroupProps } = footerGroup.getHeaderGroupProps();
+            return (
+              <tr key={footerGroupKey || footerGroup.id} {...footerGroupProps}>
+                {footerGroup.headers.map(column => column.render('Footer', { key: column.id }))}
+              </tr>
+            );
+          })}
         </tfoot>
       )}
     </table>

--- a/plugins/plugin-chart-table/src/DataTable/types/react-table.d.ts
+++ b/plugins/plugin-chart-table/src/DataTable/types/react-table.d.ts
@@ -19,6 +19,7 @@ import {
   UseSortByHooks,
   Renderer,
   HeaderProps,
+  TableFooterProps,
 } from 'react-table';
 
 import { UseStickyState, UseStickyTableOptions, UseStickyInstanceProps } from '../hooks/useSticky';
@@ -64,6 +65,7 @@ declare module 'react-table' {
     // must define as a new property because it's not possible to override
     // the existing `Header` renderer option
     Header?: Renderer<TableSortByToggleProps & HeaderProps<D>>;
+    Footer?: Renderer<TableFooterProps<D>>;
   }
 
   export interface ColumnInstance<D extends object>

--- a/plugins/plugin-chart-table/src/i18n.ts
+++ b/plugins/plugin-chart-table/src/i18n.ts
@@ -37,9 +37,9 @@ const translations: Partial<Record<Locale, typeof en>> = {
     'Show Cell Bars': ['为指标添加条状图背景'],
     'page_size.show': ['每页显示'],
     'page_size.all': ['全部'],
-    'page_size.entries': ['条'],
-    'table.previous_page': ['以前的'],
-    'table.next_page': ['下一個'],
+    'page_size.entries': ['上一页'],
+    'table.previous_page': ['上一页'],
+    'table.next_page': ['下一页'],
     'search.num_records': ['%s条记录...'],
   },
 };

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -146,6 +146,7 @@ const processColumns = memoizeOne(function processColumns(props: TableChartProps
         key,
         label,
         dataType,
+        isNumeric: dataType === GenericDataType.NUMERIC,
         isMetric,
         isPercentMetric,
         formatter,

--- a/plugins/plugin-chart-table/src/types.ts
+++ b/plugins/plugin-chart-table/src/types.ts
@@ -44,6 +44,7 @@ export interface DataColumnMeta {
   formatter?: TimeFormatter | NumberFormatter | CustomFormatter;
   isMetric?: boolean;
   isPercentMetric?: boolean;
+  isNumeric?: boolean;
   config?: ColumnConfig;
 }
 

--- a/plugins/plugin-chart-table/src/utils/formatValue.ts
+++ b/plugins/plugin-chart-table/src/utils/formatValue.ts
@@ -44,7 +44,12 @@ function formatValue(
   formatter: DataColumnMeta['formatter'],
   value: DataRecordValue,
 ): [boolean, string] {
-  if (value === null || typeof value === 'undefined') {
+  // render undefined as empty string
+  if (value === undefined) {
+    return [false, ''];
+  }
+  // render null as `N/A`
+  if (value === null) {
     return [false, 'N/A'];
   }
   if (formatter) {


### PR DESCRIPTION
🐛 Bug Fix

Fixes two bugs:

1. Text align was not applied to totals.
2. Resizing window does not rereize the table chart.

Also updates the tooltip for the column width control to be more reflective of what it really is.

### Before

<img width="569" alt="Xnip2021-04-29_13-03-36" src="https://user-images.githubusercontent.com/335541/116611531-557d7b80-a8eb-11eb-8a81-2394cb9c4fbc.png">

### After

<img width="624" alt="Xnip2021-04-29_13-02-23" src="https://user-images.githubusercontent.com/335541/116611550-5a422f80-a8eb-11eb-8b11-701a0282beb5.png">
