### PR TITLE
feat(plugin-chart-pivot-table): enable cross filtering

### DIFF
--- a/plugins/plugin-chart-pivot-table/package.json
+++ b/plugins/plugin-chart-pivot-table/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@superset-ui/chart-controls": "0.17.42",
     "@superset-ui/core": "0.17.42",
-    "@superset-ui/react-pivottable": "^0.12.5"
+    "@superset-ui/react-pivottable": "^0.12.6"
   },
   "peerDependencies": {
     "react": "^16.13.1"

--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -104,12 +104,11 @@ export default function PivotTableChart(props: PivotTableProps) {
   const handleChange = useCallback(
     (filters: SelectedFiltersType) => {
       const groupBy = Object.keys(filters);
-      const groupByValues = Object.values(filters);
       setDataMask({
         extraFormData: {
           filters:
             groupBy.length === 0
-              ? []
+              ? undefined
               : groupBy.map(col => {
                   const val = filters?.[col];
                   if (val === null || val === undefined)
@@ -125,9 +124,6 @@ export default function PivotTableChart(props: PivotTableProps) {
                 }),
         },
         filterState: {
-          value: groupByValues.length ? groupByValues : null,
-        },
-        ownState: {
           selectedFilters: filters && Object.keys(filters).length ? filters : null,
         },
       });

--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -126,6 +126,9 @@ export default function PivotTableChart(props: PivotTableProps) {
         filterState: {
           selectedFilters: filters && Object.keys(filters).length ? filters : null,
         },
+        ownState: {
+          selectedFilters: filters && Object.keys(filters).length ? filters : null,
+        },
       });
     },
     [setDataMask],

--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-import { styled, AdhocMetric, getNumberFormatter } from '@superset-ui/core';
+import React, { useCallback } from 'react';
+import { styled, AdhocMetric, getNumberFormatter, DataRecordValue } from '@superset-ui/core';
 // @ts-ignore
 import PivotTable from '@superset-ui/react-pivottable/PivotTable';
 // @ts-ignore
 import { sortAs, aggregatorTemplates } from '@superset-ui/react-pivottable/Utilities';
 import '@superset-ui/react-pivottable/pivottable.css';
-import { PivotTableProps, PivotTableStylesProps } from './types';
+import { FilterType, PivotTableProps, PivotTableStylesProps, SelectedFiltersType } from './types';
 
 const Styles = styled.div<PivotTableStylesProps>`
   padding: ${({ theme }) => theme.gridUnit * 4}px;
@@ -33,38 +33,7 @@ const Styles = styled.div<PivotTableStylesProps>`
   }
 `;
 
-// TODO: remove eslint-disable when click callbacks are implemented
-/* eslint-disable @typescript-eslint/no-unused-vars */
-const clickCellCallback = (
-  e: MouseEvent,
-  value: number,
-  filters: Record<string, any>,
-  pivotData: Record<string, any>,
-) => {
-  // TODO: Implement a callback
-};
-
-const clickColumnHeaderCallback = (
-  e: MouseEvent,
-  value: string,
-  filters: Record<string, any>,
-  pivotData: Record<string, any>,
-  isSubtotal: boolean,
-  isGrandTotal: boolean,
-) => {
-  // TODO: Implement a callback
-};
-
-const clickRowHeaderCallback = (
-  e: MouseEvent,
-  value: string,
-  filters: Record<string, any>,
-  pivotData: Record<string, any>,
-  isSubtotal: boolean,
-  isGrandTotal: boolean,
-) => {
-  // TODO: Implement a callback
-};
+const METRIC_KEY = 'metric';
 
 export default function PivotTableChart(props: PivotTableProps) {
   const {
@@ -84,6 +53,9 @@ export default function PivotTableChart(props: PivotTableProps) {
     colTotals,
     rowTotals,
     valueFormat,
+    emitFilter,
+    setDataMask,
+    selectedFilters,
   } = props;
 
   const adaptiveFormatter = getNumberFormatter(valueFormat);
@@ -118,7 +90,7 @@ export default function PivotTableChart(props: PivotTableProps) {
       ...acc,
       ...metricNames.map((name: string) => ({
         ...record,
-        metric: name,
+        [METRIC_KEY]: name,
         value: record[name],
       })),
     ],
@@ -126,8 +98,84 @@ export default function PivotTableChart(props: PivotTableProps) {
   );
 
   const [rows, cols] = transposePivot
-    ? [groupbyColumns, ['metric', ...groupbyRows]]
-    : [groupbyRows, ['metric', ...groupbyColumns]];
+    ? [groupbyColumns, [METRIC_KEY, ...groupbyRows]]
+    : [groupbyRows, [METRIC_KEY, ...groupbyColumns]];
+
+  const handleChange = useCallback(
+    (filters: SelectedFiltersType) => {
+      const groupBy = Object.keys(filters);
+      const groupByValues = Object.values(filters);
+      setDataMask({
+        extraFormData: {
+          filters:
+            groupBy.length === 0
+              ? []
+              : groupBy.map(col => {
+                  const val = filters?.[col];
+                  if (val === null || val === undefined)
+                    return {
+                      col,
+                      op: 'IS NULL',
+                    };
+                  return {
+                    col,
+                    op: 'IN',
+                    val: val as (string | number | boolean)[],
+                  };
+                }),
+        },
+        filterState: {
+          value: groupByValues.length ? groupByValues : null,
+        },
+        ownState: {
+          selectedFilters: filters && Object.keys(filters).length ? filters : null,
+        },
+      });
+    },
+    [setDataMask],
+  );
+
+  const isActiveFilterValue = useCallback(
+    (key: string, val: DataRecordValue) => !!selectedFilters && selectedFilters[key]?.includes(val),
+    [selectedFilters],
+  );
+
+  const toggleFilter = useCallback(
+    (
+      e: MouseEvent,
+      value: string,
+      filters: FilterType,
+      pivotData: Record<string, any>,
+      isSubtotal: boolean,
+      isGrandTotal: boolean,
+    ) => {
+      if (isSubtotal || isGrandTotal || !emitFilter) {
+        return;
+      }
+
+      const filtersCopy = { ...filters };
+      delete filtersCopy[METRIC_KEY];
+
+      const filtersEntries = Object.entries(filtersCopy);
+      if (filtersEntries.length === 0) {
+        return;
+      }
+
+      const [key, val] = filtersEntries[filtersEntries.length - 1];
+
+      const updatedFilters = { ...(selectedFilters || {}) };
+      if (selectedFilters && isActiveFilterValue(key, val)) {
+        updatedFilters[key] = selectedFilters[key].filter((x: DataRecordValue) => x !== val);
+      } else {
+        updatedFilters[key] = [...(selectedFilters?.[key] || []), val];
+      }
+      if (Array.isArray(updatedFilters[key]) && updatedFilters[key].length === 0) {
+        delete updatedFilters[key];
+      }
+      handleChange(updatedFilters);
+    },
+    [emitFilter, selectedFilters, handleChange],
+  );
 
   return (
     <Styles height={height} width={width}>
@@ -145,11 +193,13 @@ export default function PivotTableChart(props: PivotTableProps) {
           metric: sortAs(metricNames),
         }}
         tableOptions={{
-          clickCallback: clickCellCallback,
-          clickRowHeaderCallback,
-          clickColumnHeaderCallback,
+          clickRowHeaderCallback: toggleFilter,
+          clickColumnHeaderCallback: toggleFilter,
           colTotals,
           rowTotals,
+          highlightHeaderCellsOnHover: emitFilter,
+          highlightedHeaderCells: selectedFilters,
+          omittedHighlightHeaderGroups: [METRIC_KEY],
         }}
         subtotalOptions={{
           colSubtotalDisplay: { displayOnTop: colSubtotalPosition },

--- a/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, validateNonEmpty } from '@superset-ui/core';
+import { FeatureFlag, isFeatureEnabled, t, validateNonEmpty } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   formatSelectOptions,
@@ -244,6 +244,22 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
+          ? [
+              {
+                name: 'emitFilter',
+                config: {
+                  type: 'CheckboxControl',
+                  label: t('Enable emitting filters'),
+                  renderTrigger: true,
+                  default: false,
+                  description: t(
+                    'Whether to apply filter to dashboards when table cells are clicked',
+                  ),
+                },
+              },
+            ]
+          : [],
       ],
     },
   ],

--- a/plugins/plugin-chart-pivot-table/src/plugin/index.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, Behavior } from '@superset-ui/core';
 import buildQuery from './buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from './transformProps';
@@ -36,6 +36,7 @@ export default class PivotTableChartPlugin extends ChartPlugin<PivotTableQueryFo
    */
   constructor() {
     const metadata = new ChartMetadata({
+      behaviors: [Behavior.INTERACTIVE_CHART],
       description: 'Pivot Table - experimental',
       name: t('Pivot Table v2'),
       thumbnail,

--- a/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -48,7 +48,14 @@ export default function transformProps(chartProps: ChartProps) {
    * function during development with hot reloading, changes won't
    * be seen until restarting the development server.
    */
-  const { width, height, queriesData, formData } = chartProps;
+  const {
+    width,
+    height,
+    queriesData,
+    formData,
+    hooks: { setDataMask = () => {} },
+    ownState,
+  } = chartProps;
   const data = queriesData[0].data as DataRecord[];
   const {
     groupbyRows,
@@ -64,7 +71,9 @@ export default function transformProps(chartProps: ChartProps) {
     colTotals,
     rowTotals,
     valueFormat,
+    emitFilter,
   } = formData;
+  const { selectedFilters } = ownState;
 
   return {
     width,
@@ -83,5 +92,8 @@ export default function transformProps(chartProps: ChartProps) {
     colTotals,
     rowTotals,
     valueFormat,
+    emitFilter,
+    setDataMask,
+    selectedFilters,
   };
 }

--- a/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -54,7 +54,7 @@ export default function transformProps(chartProps: ChartProps) {
     queriesData,
     formData,
     hooks: { setDataMask = () => {} },
-    ownState,
+    filterState,
   } = chartProps;
   const data = queriesData[0].data as DataRecord[];
   const {
@@ -73,7 +73,7 @@ export default function transformProps(chartProps: ChartProps) {
     valueFormat,
     emitFilter,
   } = formData;
-  const { selectedFilters } = ownState;
+  const { selectedFilters } = filterState;
 
   return {
     width,

--- a/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/plugins/plugin-chart-pivot-table/src/types.ts
@@ -16,12 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryFormData, DataRecord, AdhocMetric } from '@superset-ui/core';
+import {
+  QueryFormData,
+  DataRecord,
+  AdhocMetric,
+  SetDataMaskHook,
+  DataRecordValue,
+} from '@superset-ui/core';
 
 export interface PivotTableStylesProps {
   height: number;
   width: number;
 }
+
+export type FilterType = Record<string, DataRecordValue>;
+export type SelectedFiltersType = Record<string, DataRecordValue[]>;
 
 interface PivotTableCustomizeProps {
   groupbyRows: string[];
@@ -37,6 +46,9 @@ interface PivotTableCustomizeProps {
   colTotals: boolean;
   rowTotals: boolean;
   valueFormat: string;
+  setDataMask: SetDataMaskHook;
+  emitFilter?: boolean;
+  selectedFilters?: SelectedFiltersType;
 }
 
 export type PivotTableQueryFormData = QueryFormData &

--- a/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -17,8 +17,6 @@ describe('PivotTableChart transformProps', () => {
     rowTotals: true,
     valueFormat: 'SMART_NUMBER',
     emitFilter: false,
-    setDataMask: () => {},
-    selectedFilters: {},
   };
   const chartProps = new ChartProps({
     formData,
@@ -29,6 +27,8 @@ describe('PivotTableChart transformProps', () => {
         data: [{ name: 'Hulk', sum__num: 1, __timestamp: 599616000000 }],
       },
     ],
+    hooks: { setDataMask: () => {} },
+    ownState: { selectedFilters: {} },
   });
 
   it('should transform chart props for viz', () => {

--- a/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -16,6 +16,9 @@ describe('PivotTableChart transformProps', () => {
     colTotals: true,
     rowTotals: true,
     valueFormat: 'SMART_NUMBER',
+    emitFilter: false,
+    setDataMask: () => {},
+    selectedFilters: {},
   };
   const chartProps = new ChartProps({
     formData,
@@ -46,6 +49,9 @@ describe('PivotTableChart transformProps', () => {
       rowTotals: true,
       valueFormat: 'SMART_NUMBER',
       data: [{ name: 'Hulk', sum__num: 1, __timestamp: 599616000000 }],
+      emitFilter: false,
+      setDataMask: () => {},
+      selectedFilters: {},
     });
   });
 });

--- a/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -29,7 +29,7 @@ describe('PivotTableChart transformProps', () => {
       },
     ],
     hooks: { setDataMask },
-    ownState: { selectedFilters: {} },
+    filterState: { selectedFilters: {} },
   });
 
   it('should transform chart props for viz', () => {

--- a/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -32,7 +32,7 @@ describe('PivotTableChart transformProps', () => {
   });
 
   it('should transform chart props for viz', () => {
-    expect(transformProps(chartProps)).toEqual({
+    expect(transformProps(chartProps)).toMatchObject({
       width: 800,
       height: 600,
       groupbyRows: ['row1', 'row2'],

--- a/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -2,6 +2,7 @@ import { ChartProps } from '@superset-ui/core';
 import transformProps from '../../src/plugin/transformProps';
 
 describe('PivotTableChart transformProps', () => {
+  const setDataMask = jest.fn();
   const formData = {
     groupbyRows: ['row1', 'row2'],
     groupbyColumns: ['col1', 'col2'],
@@ -27,12 +28,12 @@ describe('PivotTableChart transformProps', () => {
         data: [{ name: 'Hulk', sum__num: 1, __timestamp: 599616000000 }],
       },
     ],
-    hooks: { setDataMask: () => {} },
+    hooks: { setDataMask },
     ownState: { selectedFilters: {} },
   });
 
   it('should transform chart props for viz', () => {
-    expect(transformProps(chartProps)).toMatchObject({
+    expect(transformProps(chartProps)).toEqual({
       width: 800,
       height: 600,
       groupbyRows: ['row1', 'row2'],
@@ -50,7 +51,7 @@ describe('PivotTableChart transformProps', () => {
       valueFormat: 'SMART_NUMBER',
       data: [{ name: 'Hulk', sum__num: 1, __timestamp: 599616000000 }],
       emitFilter: false,
-      setDataMask: () => {},
+      setDataMask,
       selectedFilters: {},
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4391,10 +4391,10 @@
     d3-cloud "^1.2.1"
     prop-types "^15.6.2"
 
-"@superset-ui/react-pivottable@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/react-pivottable/-/react-pivottable-0.12.5.tgz#11448d718f4bf3d9421767c18590604dc436ed1f"
-  integrity sha512-9Nmj/sRdc6U/OUWBqfqHAaV05MCmNLt65I/Ar39brpLcaYKWRIYpBcUT3n/HOhCr8ALilnsLdQzzfjjaNAuv5w==
+"@superset-ui/react-pivottable@^0.12.6":
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/@superset-ui/react-pivottable/-/react-pivottable-0.12.6.tgz#c1d62a71e5f729381f8be0b1653b9a9e353d3dc3"
+  integrity sha512-2+81WL4ocv4VFzgkj3wOBcEgejnJfsJ2D08kMvFfeBt6fhqC35nkendeZMAjl4bFBmzSJIFS6H+agjoeOUyq5A==
   dependencies:
     immutability-helper "^3.1.1"
     prop-types "^15.7.2"


### PR DESCRIPTION
Enable cross filtering in pivot table chart.
Clicking on any header cell that represents selected rows and columns emits a filter `group_name IN ('value1', 'value2', ...)`.

![image](https://user-images.githubusercontent.com/15073128/116720900-fe57d380-a9dc-11eb-9e38-44bf9879104d.png)
https://user-images.githubusercontent.com/15073128/116720817-e97b4000-a9dc-11eb-800e-9003538d0031.mov

CC @villebro @junlincc 
