### PR TITLE
fix(plugin-chart-table): hide column configs when no columns

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/ColumnConfigControl.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/ColumnConfigControl.tsx
@@ -94,7 +94,7 @@ export default function ColumnConfigControl<T extends ColumnConfig>({
     }
   };
 
-  if (!colnames) return null;
+  if (!colnames || colnames.length === 0) return null;
 
   const needShowMoreButton = colnames.length > MAX_NUM_COLS + 2;
   const cols = needShowMoreButton && !showAllColumns ? colnames.slice(0, MAX_NUM_COLS) : colnames;


### PR DESCRIPTION
🐛 Bug Fix

Hide column config control when chart data returns no columns. This can happen when there is a backend error.

### Before

<img width="897" alt="Xnip2021-05-03_11-28-23" src="https://user-images.githubusercontent.com/335541/116916847-b2867380-ac02-11eb-8639-3e7eda69e92f.png">

### After

<img width="905" alt="Xnip2021-05-03_11-27-34" src="https://user-images.githubusercontent.com/335541/116916853-b5816400-ac02-11eb-9d3a-140d2eda2313.png">

