### PR TITLE
fix(legacy-plugin-chart-sankey): ensure tooltip position is within chart

### DIFF
--- a/plugins/legacy-plugin-chart-sankey/src/Sankey.js
+++ b/plugins/legacy-plugin-chart-sankey/src/Sankey.js
@@ -115,9 +115,11 @@ function Sankey(element, props) {
     tooltip
       .html(() => getTooltipHtml(d))
       .transition()
-      .duration(200)
-      .style('left', `${d3.event.offsetX + 10}px`)
-      .style('top', `${d3.event.offsetY + 10}px`)
+      .duration(200);
+    const { height: tooltipHeight, width: tooltipWidth } = tooltip.node().getBoundingClientRect();
+    tooltip
+      .style('left', `${Math.min(d3.event.offsetX + 10, width - tooltipWidth)}px`)
+      .style('top', `${Math.min(d3.event.offsetY + 10, height - tooltipHeight)}px`)
       .style('position', 'absolute')
       .style('opacity', 0.95);
   }


### PR DESCRIPTION
🐛 Bug Fix
Sankey tooltips sometimes overflow off the chart, which causes problems in Superset because tooltips are sometimes not readable by users. This PR tweaks the positioning of the tooltip so that the tooltip always appears within the chart boundaries.

See: https://github.com/apache/superset/issues/14437

BEFORE:

https://user-images.githubusercontent.com/14146019/117058244-3f006700-acd3-11eb-9436-0a2a10dba646.mov

AFTER:

https://user-images.githubusercontent.com/14146019/117057970-f052cd00-acd2-11eb-8d03-b072b37c0e5c.mov
