### PR TITLE
fix: avoid unnecessary requeries caused by ownState

### DIFF
--- a/plugins/plugin-chart-echarts/src/BoxPlot/EchartsBoxPlot.tsx
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/EchartsBoxPlot.tsx
@@ -60,8 +60,6 @@ export default function EchartsBoxPlot({
         },
         filterState: {
           value: groupbyValues.length ? groupbyValues : null,
-        },
-        ownState: {
           selectedValues: values.length ? values : null,
         },
       });

--- a/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
@@ -36,7 +36,7 @@ import { defaultGrid, defaultTooltip, defaultYAxis } from '../defaults';
 export default function transformProps(
   chartProps: EchartsBoxPlotChartProps,
 ): BoxPlotChartTransformedProps {
-  const { width, height, formData, hooks, ownState, queriesData } = chartProps;
+  const { width, height, formData, hooks, filterState, queriesData } = chartProps;
   const { data = [] } = queriesData[0];
   const { setDataMask = () => {} } = hooks;
   const coltypeMapping = getColtypesMapping(queriesData[0]);
@@ -128,7 +128,7 @@ export default function transformProps(
     };
   }, {});
 
-  const selectedValues = (ownState.selectedValues || []).reduce(
+  const selectedValues = (filterState.selectedValues || []).reduce(
     (acc: Record<string, number>, selectedValue: string) => {
       const index = transformedData.findIndex(({ name }) => name === selectedValue);
       return {

--- a/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
@@ -20,7 +20,6 @@ import {
   ChartDataResponseResult,
   ChartProps,
   DataRecordValue,
-  JsonObject,
   QueryFormData,
   SetDataMaskHook,
 } from '@superset-ui/core';
@@ -48,7 +47,6 @@ export const DEFAULT_FORM_DATA: BoxPlotQueryFormData = {
 };
 
 export interface EchartsBoxPlotChartProps extends ChartProps {
-  ownState: JsonObject;
   formData: BoxPlotQueryFormData;
   queriesData: ChartDataResponseResult[];
 }

--- a/plugins/plugin-chart-echarts/src/Funnel/EchartsFunnel.tsx
+++ b/plugins/plugin-chart-echarts/src/Funnel/EchartsFunnel.tsx
@@ -60,8 +60,6 @@ export default function EchartsFunnel({
         },
         filterState: {
           value: groupbyValues.length ? groupbyValues : null,
-        },
-        ownState: {
           selectedValues: values.length ? values : null,
         },
       });

--- a/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -73,7 +73,7 @@ export function formatFunnelLabel({
 export default function transformProps(
   chartProps: EchartsFunnelChartProps,
 ): FunnelChartTransformedProps {
-  const { formData, height, hooks, ownState, queriesData, width } = chartProps;
+  const { formData, height, hooks, filterState, queriesData, width } = chartProps;
   const data: DataRecord[] = queriesData[0].data || [];
 
   const {
@@ -127,7 +127,7 @@ export default function transformProps(
     };
   });
 
-  const selectedValues = (ownState.selectedValues || []).reduce(
+  const selectedValues = (filterState.selectedValues || []).reduce(
     (acc: Record<string, number>, selectedValue: string) => {
       const index = transformedData.findIndex(({ name }) => name === selectedValue);
       return {

--- a/plugins/plugin-chart-echarts/src/Pie/EchartsPie.tsx
+++ b/plugins/plugin-chart-echarts/src/Pie/EchartsPie.tsx
@@ -60,8 +60,6 @@ export default function EchartsPie({
         },
         filterState: {
           value: groupbyValues.length ? groupbyValues : null,
-        },
-        ownState: {
           selectedValues: values.length ? values : null,
         },
       });

--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -77,7 +77,7 @@ export function formatPieLabel({
 }
 
 export default function transformProps(chartProps: EchartsPieChartProps): PieChartTransformedProps {
-  const { formData, height, hooks, ownState, queriesData, width } = chartProps;
+  const { formData, height, hooks, filterState, queriesData, width } = chartProps;
   const { data = [] } = queriesData[0];
   const coltypeMapping = getColtypesMapping(queriesData[0]);
 
@@ -147,7 +147,7 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
     };
   });
 
-  const selectedValues = (ownState.selectedValues || []).reduce(
+  const selectedValues = (filterState.selectedValues || []).reduce(
     (acc: Record<string, number>, selectedValue: string) => {
       const index = transformedData.findIndex(({ name }) => name === selectedValue);
       return {

--- a/plugins/plugin-chart-echarts/src/Radar/EchartsRadar.tsx
+++ b/plugins/plugin-chart-echarts/src/Radar/EchartsRadar.tsx
@@ -60,8 +60,6 @@ export default function EchartsRadar({
         },
         filterState: {
           value: groupbyValues.length ? groupbyValues : null,
-        },
-        ownState: {
           selectedValues: values.length ? values : null,
         },
       });

--- a/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
@@ -63,7 +63,7 @@ export function formatLabel({
 export default function transformProps(
   chartProps: EchartsRadarChartProps,
 ): RadarChartTransformedProps {
-  const { formData, height, hooks, ownState, queriesData, width } = chartProps;
+  const { formData, height, hooks, filterState, queriesData, width } = chartProps;
   const { data = [] } = queriesData[0];
   const coltypeMapping = getColtypesMapping(queriesData[0]);
 
@@ -129,7 +129,7 @@ export default function transformProps(
     } as RadarSeriesDataItemOption);
   });
 
-  const selectedValues = (ownState.selectedValues || []).reduce(
+  const selectedValues = (filterState.selectedValues || []).reduce(
     (acc: Record<string, number>, selectedValue: string) => {
       const index = transformedData.findIndex(({ name }) => name === selectedValue);
       return {

--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -124,9 +124,7 @@ export default function PivotTableChart(props: PivotTableProps) {
                 }),
         },
         filterState: {
-          selectedFilters: filters && Object.keys(filters).length ? filters : null,
-        },
-        ownState: {
+          value: filters && Object.keys(filters).length ? Object.values(filters) : null,
           selectedFilters: filters && Object.keys(filters).length ? filters : null,
         },
       });


### PR DESCRIPTION
🐛 Bug Fix
Using `ownState` will retrigger a new query, which is unnecessary in the majority of cross filtering cases. This moves the selected labels in the ECharts plugin into `filterState`, thus avoiding the need to set `ownState`.

### BEFORE
Notice how clicking on a box causes the chart to trigger a query:
![own-before](https://user-images.githubusercontent.com/33317356/117268165-a9461280-ae5f-11eb-8537-0da7c487a305.gif)

### AFTER
After moving the selection state to `filterState`, the chart no longer needs to trigger a query when clicking a box:
![own-after](https://user-images.githubusercontent.com/33317356/117268252-bfec6980-ae5f-11eb-95d8-66efde17795c.gif)
