### PR TITLE
fix(plugin-chart-echarts): add orderby

### DIFF
--- a/plugins/plugin-chart-echarts/src/Funnel/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/Funnel/buildQuery.ts
@@ -19,9 +19,11 @@
 import { buildQueryContext, QueryFormData } from '@superset-ui/core';
 
 export default function buildQuery(formData: QueryFormData) {
+  const { metric, sort_by_metric } = formData;
   return buildQueryContext(formData, baseQueryObject => [
     {
       ...baseQueryObject,
+      ...(sort_by_metric && { orderby: [[metric, false]] }),
     },
   ]);
 }

--- a/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
@@ -57,6 +57,16 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [
+          {
+            name: 'sort_by_metric',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort by metric'),
+              description: t('Whether to sort results by the selected metric in descending order.'),
+            },
+          },
+        ],
       ],
     },
     {


### PR DESCRIPTION
🐛 Bug Fix
https://github.com/apache/superset/issues/14534
- add orderby for the fist one
- Maybe should ignore the second one. because user SHOULD write a `null filter` or preprocess the data source for the visualization.