### PR TITLE
fix(legacy-plugin-chart-horizon): error on missing groupby

### DIFF
--- a/plugins/legacy-plugin-chart-horizon/src/HorizonChart.jsx
+++ b/plugins/legacy-plugin-chart-horizon/src/HorizonChart.jsx
@@ -20,6 +20,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { extent as d3Extent } from 'd3-array';
+import { ensureIsArray } from '@superset-ui/core';
 import HorizonRow, { DEFAULT_COLORS } from './HorizonRow';
 import './HorizonChart.css';
 
@@ -85,7 +86,7 @@ class HorizonChart extends React.PureComponent {
             key={row.key}
             width={width}
             height={seriesHeight}
-            title={row.key.join(', ')}
+            title={ensureIsArray(row.key).join(', ')}
             data={row.values}
             bands={bands}
             colors={colors}


### PR DESCRIPTION
🐛 Bug Fix

When creating a horizon chart without a groupby, an error is raised.

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/117623479-875cd080-b17c-11eb-822f-28a76fe3cc84.png)

### AFTER
![image](https://user-images.githubusercontent.com/33317356/117623417-71e7a680-b17c-11eb-8847-8602ac80ceab.png)
