### PR TITLE
fix: use proper time grain when using native filters or filter box

### DIFF
--- a/packages/superset-ui-core/src/query/extractTimegrain.ts
+++ b/packages/superset-ui-core/src/query/extractTimegrain.ts
@@ -16,22 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { extractTimegrain } from '@superset-ui/core';
+/* eslint-disable no-underscore-dangle */
 
-export default function transformProps(chartProps) {
-  const { height, datasource, formData, queriesData, rawFormData } = chartProps;
-  const { groupby, numberFormat, dateFormat } = formData;
-  const { columnFormats, verboseMap } = datasource;
-  const granularity = extractTimegrain(rawFormData);
+import { QueryFormData } from './types';
+import { TimeGranularity } from '../time-format';
 
-  return {
-    columnFormats,
-    data: queriesData[0].data,
-    dateFormat,
-    granularity,
-    height,
-    numberFormat,
-    numGroups: groupby.length,
-    verboseMap,
-  };
+export default function extractTimegrain(formData: QueryFormData): TimeGranularity | undefined {
+  const { time_grain_sqla, extra_filters, extra_form_data } = formData;
+  if (extra_form_data?.time_grain_sqla) {
+    return extra_form_data.time_grain_sqla;
+  }
+  const extra_grain = (extra_filters || []).filter(filter => filter.col === '__time_grain');
+  if (extra_grain.length) {
+    return extra_grain[0].val as TimeGranularity;
+  }
+  return time_grain_sqla;
 }

--- a/packages/superset-ui-core/src/query/index.ts
+++ b/packages/superset-ui-core/src/query/index.ts
@@ -23,6 +23,7 @@ export * from './constants';
 export { default as buildQueryContext } from './buildQueryContext';
 export { default as buildQueryObject } from './buildQueryObject';
 export { default as convertFilter } from './convertFilter';
+export { default as extractTimegrain } from './extractTimegrain';
 export { default as getMetricLabel } from './getMetricLabel';
 export { default as DatasourceKey } from './DatasourceKey';
 

--- a/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
+++ b/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
@@ -1,5 +1,6 @@
 /* eslint camelcase: 0 */
 import { DataRecord } from './QueryResponse';
+import { TimeGranularity } from '../../time-format';
 
 export enum AnnotationType {
   Event = 'EVENT',
@@ -40,7 +41,7 @@ type BaseAnnotationLayer = {
 
 type AnnotationOverrides = {
   granularity?: string | null;
-  time_grain_sqla?: string | null;
+  time_grain_sqla?: TimeGranularity | null;
   time_range?: string | null;
   time_shift?: string | null;
 };

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -25,6 +25,7 @@ import { QueryFields, QueryFormMetric } from './QueryFormData';
 import { Maybe } from '../../types';
 import { PostProcessingRule } from './PostProcessing';
 import { JsonObject } from '../../connection';
+import { TimeGranularity } from '../../time-format';
 
 export type QueryObjectFilterClause = {
   col: string;
@@ -50,7 +51,7 @@ export type QueryObjectExtras = Partial<{
   having?: string;
   relative_start?: string;
   relative_end?: string;
-  time_grain_sqla?: string;
+  time_grain_sqla?: TimeGranularity;
   time_range_endpoints?: TimeRangeEndpoints;
   /** WHERE condition */
   where?: string;

--- a/packages/superset-ui-core/test/query/extractTimegrain.test.ts
+++ b/packages/superset-ui-core/test/query/extractTimegrain.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import extractTimegrain from '@superset-ui/core/src/query/extractTimegrain';
+import { QueryFormData } from '../../lib';
+
+describe('extractTimegrain', () => {
+  const baseFormData: QueryFormData = {
+    datasource: 'table__1',
+    viz_type: 'my_viz',
+  };
+  it('should extract regular from form data', () => {
+    expect(
+      extractTimegrain({
+        ...baseFormData,
+        time_grain_sqla: 'P1D',
+      }),
+    ).toEqual('P1D');
+  });
+
+  it('should extract filter box time grain from form data', () => {
+    expect(
+      extractTimegrain({
+        ...baseFormData,
+        time_grain_sqla: 'P1D',
+        extra_filters: [
+          {
+            col: '__time_grain',
+            op: '==',
+            val: 'P1M',
+          },
+        ],
+      }),
+    ).toEqual('P1M');
+  });
+
+  it('should extract native filter time grain from form data', () => {
+    expect(
+      extractTimegrain({
+        ...baseFormData,
+        time_grain_sqla: 'P1D',
+        extra_form_data: {
+          time_grain_sqla: 'P1W',
+        },
+      }),
+    ).toEqual('P1W');
+  });
+
+  it('should give priority to native filters', () => {
+    expect(
+      extractTimegrain({
+        ...baseFormData,
+        time_grain_sqla: 'P1D',
+        extra_filters: [
+          {
+            col: '__time_grain',
+            op: '==',
+            val: 'P1M',
+          },
+        ],
+        extra_form_data: {
+          time_grain_sqla: 'P1W',
+        },
+      }),
+    ).toEqual('P1W');
+  });
+
+  it('returns undefined if timegrain not defined', () => {
+    expect(extractTimegrain({ ...baseFormData })).toEqual(undefined);
+  });
+});

--- a/plugins/legacy-preset-chart-big-number/src/BigNumber/transformProps.ts
+++ b/plugins/legacy-preset-chart-big-number/src/BigNumber/transformProps.ts
@@ -18,7 +18,7 @@
  */
 import * as color from 'd3-color';
 import {
-  TimeGranularity,
+  extractTimegrain,
   getTimeFormatterForGranularity,
   getNumberFormatter,
   NumberFormats,
@@ -48,7 +48,6 @@ export type BigNumberFormData = QueryFormData & {
     | string;
   compareLag?: string | number;
   yAxisFormat?: string;
-  timeGrainSqla?: TimeGranularity;
 };
 
 export type BigNumberChartProps = ChartProps & {
@@ -59,7 +58,7 @@ export type BigNumberChartProps = ChartProps & {
 };
 
 export default function transformProps(chartProps: BigNumberChartProps) {
-  const { width, height, queriesData, formData } = chartProps;
+  const { width, height, queriesData, formData, rawFormData } = chartProps;
   const {
     colorPicker,
     compareLag: compareLag_,
@@ -70,10 +69,10 @@ export default function transformProps(chartProps: BigNumberChartProps) {
     startYAxisAtZero,
     subheader = '',
     subheaderFontSize,
-    timeGrainSqla: granularity,
     vizType,
     timeRangeFixed = false,
   } = formData;
+  const granularity = extractTimegrain(rawFormData as QueryFormData);
   let { yAxisFormat } = formData;
   const { data = [], from_dttm: fromDatetime, to_dttm: toDatetime } = queriesData[0];
   const metricName = typeof metric === 'string' ? metric : metric.label;

--- a/plugins/legacy-preset-chart-big-number/test/transformProps.test.ts
+++ b/plugins/legacy-preset-chart-big-number/test/transformProps.test.ts
@@ -37,6 +37,21 @@ const formData = {
   yAxisFormat: '.3s',
 };
 
+const rawFormData = {
+  metric: 'value',
+  color_picker: {
+    r: 0,
+    g: 122,
+    b: 135,
+    a: 1,
+  },
+  compare_lag: 1,
+  time_grain_sqla: 'P0.25Y' as TimeGranularity,
+  compare_suffix: 'over last quarter',
+  viz_type: 'big_number',
+  y_axis_format: '.3s',
+};
+
 function generateProps(
   data: BigNumberDatum[],
   extraFormData = {},
@@ -56,7 +71,7 @@ function generateProps(
       verboseMap: {},
     },
     rawDatasource: {},
-    rawFormData: {},
+    rawFormData,
     hooks: {},
     initialValues: {},
     formData: {

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -19,6 +19,7 @@
 import memoizeOne from 'memoize-one';
 import {
   DataRecord,
+  extractTimegrain,
   GenericDataType,
   getMetricLabel,
   getNumberFormatter,
@@ -75,13 +76,13 @@ const processColumns = memoizeOne(function processColumns(props: TableChartProps
     datasource: { columnFormats, verboseMap },
     rawFormData: {
       table_timestamp_format: tableTimestampFormat,
-      time_grain_sqla: granularity,
       metrics: metrics_,
       percent_metrics: percentMetrics_,
       column_config: columnConfig = {},
     },
     queriesData,
   } = props;
+  const granularity = extractTimegrain(props.rawFormData);
   const { data: records, colnames, coltypes } = queriesData[0] || {};
   // convert `metrics` and `percentMetrics` to the key names in `data.records`
   const metrics = (metrics_ ?? []).map(getMetricLabel);

--- a/plugins/plugin-chart-table/src/utils/isEqualColumns.ts
+++ b/plugins/plugin-chart-table/src/utils/isEqualColumns.ts
@@ -31,6 +31,10 @@ export default function isEqualColumns(propsA: TableChartProps[], propsB: TableC
       JSON.stringify(b.formData.columnConfig || null) &&
     isEqualArray(a.formData.metrics, b.formData.metrics) &&
     isEqualArray(a.queriesData?.[0]?.colnames, b.queriesData?.[0]?.colnames) &&
-    isEqualArray(a.queriesData?.[0]?.coltypes, b.queriesData?.[0]?.coltypes)
+    isEqualArray(a.queriesData?.[0]?.coltypes, b.queriesData?.[0]?.coltypes) &&
+    JSON.stringify(a.formData.extraFilters || null) ===
+      JSON.stringify(b.formData.extraFilters || null) &&
+    JSON.stringify(a.formData.extraFormData || null) ===
+      JSON.stringify(b.formData.extraFormData || null)
   );
 }


### PR DESCRIPTION
🐛 Bug Fix

Currently the following plugins don't apply the proper time grain formatter when the time grain has been overridden by either a Filter Box or Native Filter:
- Legacy Pivot Table
- Table Chart
- Big Number

This PR adds a util to `@superset-ui/core` for extracting the time grain from the raw form data and implements said function in all charts that support time grain formatting. After the change both Filter Box and Native Filter timegrains will be properly reflected in the time formatter.

### BEFORE
Currently overriding the time grain on the dashboard isn't reflected in the time formatter if it's set to timegrain (see time grain `Week` on the Filter Box):
![image](https://user-images.githubusercontent.com/33317356/117931187-8d32ed00-b307-11eb-8445-1fa97145f620.png)

### AFTER
After the change all charts that use the time grain formatter will properly pick up the time grain even on the dashboard:
![image](https://user-images.githubusercontent.com/33317356/117930908-39c09f00-b307-11eb-8804-822b14f49afd.png)
