### PR TITLE
fix: adjusts ControlHeader tooltip layout, exports ControlHeader 

### DIFF
--- a/packages/superset-ui-chart-controls/src/components/ControlHeader.tsx
+++ b/packages/superset-ui-chart-controls/src/components/ControlHeader.tsx
@@ -1,3 +1,4 @@
+/** @jsx jsx */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,8 +17,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode } from 'react';
-import { t } from '@superset-ui/core';
+import { ReactNode } from 'react';
+import { t, css, jsx, SupersetTheme } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from './InfoTooltipWithTrigger';
 import { Tooltip } from './Tooltip';
 
@@ -57,7 +58,16 @@ export default function ControlHeader({
   const renderOptionalIcons = () => {
     if (hovered) {
       return (
-        <span>
+        <span
+          css={(theme: any) => css`
+            position: absolute;
+            top: 50%;
+            right: 0;
+            padding-left: ${theme.gridUnit}px;
+            transform: translate(100%, -50%);
+            white-space: nowrap;
+          `}
+        >
           {description && (
             <span>
               <InfoTooltipWithTrigger
@@ -91,7 +101,15 @@ export default function ControlHeader({
   return (
     <div className="ControlHeader" data-test={`${name}-header`}>
       <div className="pull-left">
-        <label className="control-label" htmlFor={name}>
+        <label
+          className="control-label"
+          htmlFor={name}
+          css={{
+            marginBottom: 0,
+            position: 'relative',
+            whiteSpace: 'nowrap',
+          }}
+        >
           {leftNode && <span>{leftNode}</span>}
           <span
             role="button"

--- a/packages/superset-ui-chart-controls/src/components/ControlHeader.tsx
+++ b/packages/superset-ui-chart-controls/src/components/ControlHeader.tsx
@@ -18,7 +18,7 @@
  * under the License.
  */
 import { ReactNode } from 'react';
-import { t, css, jsx, SupersetTheme } from '@superset-ui/core';
+import { t, css, jsx } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from './InfoTooltipWithTrigger';
 import { Tooltip } from './Tooltip';
 

--- a/packages/superset-ui-chart-controls/src/index.ts
+++ b/packages/superset-ui-chart-controls/src/index.ts
@@ -28,6 +28,7 @@ export * from './components/InfoTooltipWithTrigger';
 export * from './components/ColumnOption';
 export * from './components/ColumnTypeLabel';
 export * from './components/MetricOption';
+export { default as ControlHeader } from './components/ControlHeader';
 
 // React control components
 export { default as sharedControls } from './shared-controls';


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix

Adds similar layout tweaks to https://github.com/apache/superset/pull/14529
This time, over on the twin component in Superset UI.

This also exports this updated component, so that we can use it everywhere in Superset, and delete the twin over in that repo.

![tenor](https://user-images.githubusercontent.com/812905/118087025-bf7d3280-b379-11eb-87b5-bb8f41474a88.gif)

🏠 Internal
