### PR TITLE
fix(plugin-chart-echarts): funnel chart improvements

### DIFF
--- a/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
@@ -138,7 +138,7 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
-  onInit: function (state: ControlStateMapping) {
+  onInit(state: ControlStateMapping) {
     return {
       ...state,
       row_limit: {

--- a/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
@@ -20,23 +20,18 @@ import React from 'react';
 import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
-  ControlPanelsContainerProps,
   D3_FORMAT_OPTIONS,
   sections,
   sharedControls,
+  ControlStateMapping,
 } from '@superset-ui/chart-controls';
 import { DEFAULT_FORM_DATA, EchartsFunnelLabelTypeType } from './types';
 import { legendSection } from '../controls';
 
-const {
-  sort,
-  orient,
-  labelLine,
-  labelType,
-  numberFormat,
-  showLabels,
-  emitFilter,
-} = DEFAULT_FORM_DATA;
+const { labelType, numberFormat, showLabels, emitFilter } = DEFAULT_FORM_DATA;
+
+const funnelLegendSection = [...legendSection];
+funnelLegendSection.splice(2, 1);
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -89,7 +84,7 @@ const config: ControlPanelConfig = {
               },
             ]
           : [],
-        ...legendSection,
+        ...funnelLegendSection,
         // eslint-disable-next-line react/jsx-key
         [<h1 className="section-header">{t('Labels')}</h1>],
         [
@@ -140,57 +135,18 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [
-          {
-            name: 'label_line',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Label Line'),
-              default: labelLine,
-              renderTrigger: true,
-              description: t('Draw line from Funnel to label when labels outside?'),
-              visibility: ({ controls }: ControlPanelsContainerProps) =>
-                Boolean(controls?.show_labels?.value),
-            },
-          },
-        ],
-        // eslint-disable-next-line react/jsx-key
-        [<h1 className="section-header">{t('Funnel shape')}</h1>],
-        [
-          {
-            name: 'sort',
-            config: {
-              type: 'SelectControl',
-              label: t('sort'),
-              default: sort,
-              renderTrigger: true,
-              choices: [
-                [null, 'Default'],
-                ['ascending', 'Ascending'],
-                ['descending', 'Descending'],
-              ],
-              description: t('Sort data'),
-            },
-          },
-          {
-            name: 'orient',
-            config: {
-              type: 'SelectControl',
-              label: t('orient'),
-              default: orient,
-              renderTrigger: true,
-              choices: [
-                [null, 'Default'],
-                ['vertical', 'Vertical'],
-                ['horizontal', 'Horizontal'],
-              ],
-              description: t('Funnel chart orientation. The options are vertical, horizontal'),
-            },
-          },
-        ],
       ],
     },
   ],
+  onInit: function (state: ControlStateMapping) {
+    return {
+      ...state,
+      row_limit: {
+        ...state.row_limit,
+        value: state.row_limit.default,
+      },
+    };
+  },
 };
 
 export default config;

--- a/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -162,6 +162,7 @@ export default function transformProps(
       label: {
         ...defaultLabel,
         position: labelLine ? 'outer' : 'inner',
+        textBorderColor: 'transparent',
       },
       emphasis: {
         label: {


### PR DESCRIPTION
🏆 Enhancements

#### 1: add `onInit function` to make `row_limit` default value  into effect
###### 1.1: before
![onInit before](https://user-images.githubusercontent.com/10264972/118347836-b312f880-b578-11eb-8dfb-a658e9d4b134.gif)
###### 1.2: after
![onInit after](https://user-images.githubusercontent.com/10264972/118347905-156bf900-b579-11eb-8d02-ec6f48a374a2.gif)

#### 2: rm `LABEL LINE `
###### 2.1: before
![rm LABEL LINE before](https://user-images.githubusercontent.com/10264972/118352815-0cd5eb80-b596-11eb-823b-f1320bcd0997.gif)
###### 2.2: after
![rm LABEL LINE after](https://user-images.githubusercontent.com/10264972/118353035-317e9300-b597-11eb-8f2f-451bd46b792b.gif)

#### 3: rm label's textBorderColor
###### 3.1: before
![label's textBorderColor before](https://user-images.githubusercontent.com/10264972/118353308-44459780-b598-11eb-9783-4dbf19736ed4.gif)
###### 3.2: after
![label's textBorderColor after](https://user-images.githubusercontent.com/10264972/118353323-532c4a00-b598-11eb-98b4-2b1e24b3cdd0.gif)



#### 4: rm `Funnel shape`
###### 4.1: rm Funnel shape before
![Funnel shape before](https://user-images.githubusercontent.com/10264972/118353489-0a28c580-b599-11eb-87cc-02db5b0d65d6.gif)
###### 4.1: rm Funnel shape after
![Funnel shape after](https://user-images.githubusercontent.com/10264972/118353563-6f7cb680-b599-11eb-84a3-3ea3df3097c0.gif)


#### 5: rm `legend type`
###### 5.1: before
![legend type before](https://user-images.githubusercontent.com/10264972/118354350-3cd4bd00-b59d-11eb-95db-896fc3e66205.gif)
###### 5.2: after
![legend type after](https://user-images.githubusercontent.com/10264972/118354354-42320780-b59d-11eb-983c-763eafaf5b63.gif)