### PR TITLE
feat(plugin-chart-echarts): set up orderby by default on Pie chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
@@ -56,6 +56,7 @@ const config: ControlPanelConfig = {
           {
             name: 'sort_by_metric',
             config: {
+              default: true,
               type: 'CheckboxControl',
               label: t('Sort by metric'),
               description: t('Whether to sort results by the selected metric in descending order.'),


### PR DESCRIPTION
SORT BY METRIC checkbox check by default in Pie chart. so the query is:
<pre>
SELECT value AS value,
       SUM(value) AS sum__value
FROM energy_usage
GROUP BY value
ORDER BY sum__value DESC
LIMIT 10000;
</pre>

### before
![pie  sort by metric  after](https://user-images.githubusercontent.com/10264972/118363307-4e7e8a80-b5c6-11eb-81c1-08cb7ae13b32.gif)

### after
![pie  sort by metric  before](https://user-images.githubusercontent.com/10264972/118363310-550d0200-b5c6-11eb-809f-88ea73537ce6.gif)
