### PR TITLE
feat(plugin-chart-echarts): add orderby on Radar chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Radar/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/Radar/buildQuery.ts
@@ -16,14 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { buildQueryContext, QueryFormData } from '@superset-ui/core';
+import { buildQueryContext, QueryFormData, getMetricLabel } from '@superset-ui/core';
 
 export default function buildQuery(formData: QueryFormData) {
-  const { metric, sort_by_metric } = formData;
-  return buildQueryContext(formData, baseQueryObject => [
-    {
-      ...baseQueryObject,
-      ...(sort_by_metric && { orderby: [[metric, false]] }),
-    },
-  ]);
+  const { sort_by_metric } = formData;
+  return buildQueryContext(formData, baseQueryObject => {
+    const { metrics = [] } = baseQueryObject;
+    return [
+      {
+        ...baseQueryObject,
+        ...(sort_by_metric && { orderby: metrics.map(metric => [getMetricLabel(metric), false]) }),
+      },
+    ];
+  });
 }

--- a/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
@@ -70,6 +70,7 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         ['groupby'],
         ['metrics'],
+        ['timeseries_limit_metric'],
         ['adhoc_filters'],
         [
           {
@@ -77,17 +78,6 @@ const config: ControlPanelConfig = {
             config: {
               ...sharedControls.row_limit,
               default: 10,
-            },
-          },
-        ],
-        [
-          {
-            name: 'sort_by_metric',
-            config: {
-              default: true,
-              type: 'CheckboxControl',
-              label: t('Sort by metric'),
-              description: t('Whether to sort results by the selected metric in descending order.'),
             },
           },
         ],

--- a/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
@@ -80,6 +80,17 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [
+          {
+            name: 'sort_by_metric',
+            config: {
+              default: true,
+              type: 'CheckboxControl',
+              label: t('Sort by metric'),
+              description: t('Whether to sort results by the selected metric in descending order.'),
+            },
+          },
+        ],
       ],
     },
     {


### PR DESCRIPTION
add SORT BY metrics to Radar chart to avoid random values.

### before
![radar sort by metrics before](https://user-images.githubusercontent.com/10264972/118362750-61dc2680-b5c3-11eb-983c-c4cdfad5ebda.gif)


### after
![radar sort by metrics after 2](https://user-images.githubusercontent.com/10264972/118381759-e6a95d80-b620-11eb-9e0f-a535c9da9597.gif)

