### PR TITLE
feat(core): remove defaults for time range filter and Metrics

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -17,15 +17,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Metric, t, validateNonEmpty } from '@superset-ui/core';
+import { t, validateNonEmpty } from '@superset-ui/core';
 import { ExtraControlProps, SharedControlConfig } from '../types';
-import { mainMetric } from '../utils';
 import { TIME_COLUMN_OPTION } from '../constants';
-
-type Control = {
-  savedMetrics?: Metric[] | null;
-  default?: unknown;
-};
 
 export const dndGroupByControl: SharedControlConfig<'DndColumnSelect'> = {
   type: 'DndColumnSelect',
@@ -93,10 +87,6 @@ export const dnd_adhoc_metrics: SharedControlConfig<'DndMetricSelect'> = {
   multi: true,
   label: t('Metrics'),
   validators: [validateNonEmpty],
-  default: (c: Control) => {
-    const metric = mainMetric(c.savedMetrics);
-    return metric ? [metric] : null;
-  },
   mapStateToProps: ({ datasource }) => ({
     columns: datasource ? datasource.columns : [],
     savedMetrics: datasource ? datasource.metrics : [],
@@ -110,7 +100,6 @@ export const dnd_adhoc_metric: SharedControlConfig<'DndMetricSelect'> = {
   multi: false,
   label: t('Metric'),
   description: t('Metric'),
-  default: (c: Control) => mainMetric(c.savedMetrics),
 };
 
 export const dnd_sort_by: SharedControlConfig<'DndMetricSelect'> = {

--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -46,7 +46,6 @@ import {
 } from '@superset-ui/core';
 
 import {
-  mainMetric,
   formatSelectOptions,
   D3_FORMAT_OPTIONS,
   D3_FORMAT_DOCS,
@@ -130,10 +129,6 @@ const metrics: SharedControlConfig<'MetricsControl'> = {
   multi: true,
   label: t('Metrics'),
   validators: [validateNonEmpty],
-  default: (c: Control) => {
-    const metric = mainMetric(c.savedMetrics);
-    return metric ? [metric] : null;
-  },
   mapStateToProps: ({ datasource }) => ({
     columns: datasource ? datasource.columns : [],
     savedMetrics: datasource ? datasource.metrics : [],
@@ -147,7 +142,6 @@ const metric: SharedControlConfig<'MetricsControl'> = {
   multi: false,
   label: t('Metric'),
   description: t('Metric'),
-  default: (c: Control) => mainMetric(c.savedMetrics),
 };
 
 const datasourceControl: SharedControlConfig<'DatasourceControl'> = {
@@ -304,7 +298,7 @@ const time_range: SharedControlConfig<'DateFilterControl'> = {
   type: 'DateFilterControl',
   freeForm: true,
   label: TIME_FILTER_LABELS.time_range,
-  default: t('Last week'), // this value is translated, but the backend wouldn't understand a translated value?
+  default: t('No filter'), // this value is translated, but the backend wouldn't understand a translated value?
   description: t(
     'The time range for the visualization. All relative times, e.g. "Last month", ' +
       '"Last 7 days", "now", etc. are evaluated on the server using the server\'s ' +


### PR DESCRIPTION
Changes default Time Range from "Last week" to "No filter"
Changes using "COUNT(*)" or other saved metric as a default metric to empty metrics control.

In the case of Table chart, removing default metric was a bit more complex. We use Groupby, Metrics and Percentage Metrics there, and at least one of them must have a value to construct a correct query. However, we can only write control validator that use values of its own control - for instance, we can't create a validator for groupby that checks if metrics or percentage_metrics are empty or not. We also couldn't simply mark all 3 controls as required, as only 1 is really required. The result was that upon creating a table chart, an incorrect request to backend was sent and we displayed an `Empty query?` error. It was quite a bad user experience - a strange error was the first thing that user sees after creating a chart (and what's more, we sent a query that we knew would fail).
For that reason, I created something like a "dynamic" validator - we check the state of groupby, metrics and percentage_metrics in `mapStateToProps` field of groupby. If all of those fields are empty, we set an error in a new field `externalValidationErrors`. Since `mapStateToProps` function is run only when the field changes, we needed a way to trigger it when not only groupby, but also metrics or percentage_metrics fields change. To achieve that, I added a field `rerender: ['groupby']` to metrics and percentage_metrics. It is later checked in `superset/superset-frontend/src/explore/reducers` - if `rerender` array exists, it triggers `getControlStateFromControlConfig` for each control in `rerender` array, which in turn triggers `mapStateToProps` of that control. Then, `externalValidationErrors` are merged with calculated `validationErrors`.
Checkout the video to see the result.

https://user-images.githubusercontent.com/15073128/118494563-94506580-b722-11eb-9015-845ff0cdb632.mov

<img width="1791" alt="Screenshot 2021-05-17 at 10 45 42" src="https://user-
images.githubusercontent.com/15073128/118466623-4f690680-b703-11eb-9411-776980a6dbf7.png">

To test, see https://github.com/apache/superset/pull/14661.
CC: @villebro @junlincc 