### PR TITLE
feat(core): add support for case insensitive LIKE operator

### DIFF
--- a/packages/superset-ui-core/src/query/types/Operator.ts
+++ b/packages/superset-ui-core/src/query/types/Operator.ts
@@ -2,7 +2,7 @@
 const UNARY_OPERATORS = ['IS NOT NULL', 'IS NULL'] as const;
 
 /** List of operators that require another operand that is a single value */
-const BINARY_OPERATORS = ['==', '!=', '>', '<', '>=', '<=', 'LIKE', 'REGEX'] as const;
+const BINARY_OPERATORS = ['==', '!=', '>', '<', '>=', '<=', 'ILIKE', 'LIKE', 'REGEX'] as const;
 
 /** List of operators that require another operand that is a set */
 const SET_OPERATORS = ['IN', 'NOT IN'] as const;


### PR DESCRIPTION
🏆 Enhancements

Adds support for the `ILIKE` binary operator: https://docs.sqlalchemy.org/en/13/core/sqlelement.html#sqlalchemy.sql.operators.ColumnOperators.ilike
