### PR TITLE
fix(plugin-chart-pivot-table): fix displaying column names when labels are available

### DIFF
--- a/plugins/plugin-chart-pivot-table/package.json
+++ b/plugins/plugin-chart-pivot-table/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@superset-ui/chart-controls": "0.17.50",
     "@superset-ui/core": "0.17.50",
-    "@superset-ui/react-pivottable": "^0.12.6"
+    "@superset-ui/react-pivottable": "^0.12.8"
   },
   "peerDependencies": {
     "react": "^16.13.1"

--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -56,6 +56,7 @@ export default function PivotTableChart(props: PivotTableProps) {
     emitFilter,
     setDataMask,
     selectedFilters,
+    verboseMap,
   } = props;
 
   const adaptiveFormatter = getNumberFormatter(valueFormat);
@@ -202,6 +203,7 @@ export default function PivotTableChart(props: PivotTableProps) {
           colSubtotalDisplay: { displayOnTop: colSubtotalPosition },
           rowSubtotalDisplay: { displayOnTop: rowSubtotalPosition },
         }}
+        namesMapping={verboseMap}
       />
     </Styles>
   );

--- a/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -55,6 +55,7 @@ export default function transformProps(chartProps: ChartProps) {
     formData,
     hooks: { setDataMask = () => {} },
     filterState,
+    datasource: { verboseMap = {} },
   } = chartProps;
   const data = queriesData[0].data as DataRecord[];
   const {
@@ -95,5 +96,6 @@ export default function transformProps(chartProps: ChartProps) {
     emitFilter,
     setDataMask,
     selectedFilters,
+    verboseMap,
   };
 }

--- a/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/plugins/plugin-chart-pivot-table/src/types.ts
@@ -22,6 +22,7 @@ import {
   AdhocMetric,
   SetDataMaskHook,
   DataRecordValue,
+  JsonObject,
 } from '@superset-ui/core';
 
 export interface PivotTableStylesProps {
@@ -49,6 +50,7 @@ interface PivotTableCustomizeProps {
   setDataMask: SetDataMaskHook;
   emitFilter?: boolean;
   selectedFilters?: SelectedFiltersType;
+  verboseMap?: JsonObject;
 }
 
 export type PivotTableQueryFormData = QueryFormData &

--- a/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -30,6 +30,7 @@ describe('PivotTableChart transformProps', () => {
     ],
     hooks: { setDataMask },
     filterState: { selectedFilters: {} },
+    datasource: { verboseMap: {} },
   });
 
   it('should transform chart props for viz', () => {
@@ -53,6 +54,7 @@ describe('PivotTableChart transformProps', () => {
       emitFilter: false,
       setDataMask,
       selectedFilters: {},
+      verboseMap: {},
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/apache/superset/issues/14716

In order to test this PR, link `plugin-chart-pivot-table` to Superset and create a Pivot Table chart with rows and columns which have labels assigned in dataset

Before:
![image](https://user-images.githubusercontent.com/15073128/119376238-02b19c80-bcbc-11eb-90ca-ead0b890bd39.png)

After:
![image](https://user-images.githubusercontent.com/15073128/119376164-f0376300-bcbb-11eb-81da-c666e210ee4b.png)

CC: @junlincc 