### PR TITLE
fix(plugin-chart-echarts): fix tooltip format in mixed ts chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -42,7 +42,7 @@ import {
 import { defaultGrid, defaultTooltip, defaultYAxis } from '../defaults';
 import {
   getPadding,
-  getTooltipFormatter,
+  getTooltipTimeFormatter,
   getXAxisFormatter,
   transformEventAnnotation,
   transformFormulaAnnotation,
@@ -109,6 +109,18 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
   const formatter = getNumberFormatter(contributionMode ? ',.0%' : yAxisFormat);
   const formatterSecondary = getNumberFormatter(contributionMode ? ',.0%' : yAxisFormatSecondary);
 
+  const primarySeries = new Set<string>();
+  const secondarySeries = new Set<string>();
+  const mapSeriesIdToAxis = (seriesOption: SeriesOption, index?: number): void => {
+    if (index === 1) {
+      secondarySeries.add(seriesOption.id as string);
+    } else {
+      primarySeries.add(seriesOption.id as string);
+    }
+  };
+  rawSeriesA.forEach(seriesOption => mapSeriesIdToAxis(seriesOption, yAxisIndex));
+  rawSeriesB.forEach(seriesOption => mapSeriesIdToAxis(seriesOption, yAxisIndexB));
+
   rawSeriesA.forEach(entry => {
     const transformedSeries = transformSeries(entry, colorScale, {
       area,
@@ -159,7 +171,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     if (max === undefined) max = 1;
   }
 
-  const tooltipFormatter = getTooltipFormatter(tooltipTimeFormat);
+  const tooltipTimeFormatter = getTooltipTimeFormatter(tooltipTimeFormat);
   const xAxisFormatter = getXAxisFormatter(xAxisTimeFormat);
 
   const addYAxisLabelOffset = !!(yAxisTitle || yAxisTitleSecondary);
@@ -211,7 +223,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
         const value: number = !richTooltip ? params.value : params[0].value[0];
         const prophetValue = !richTooltip ? [params] : params;
 
-        const rows: Array<string> = [`${tooltipFormatter(value)}`];
+        const rows: Array<string> = [`${tooltipTimeFormatter(value)}`];
         const prophetValues: Record<string, ProphetValue> = extractProphetValuesFromTooltipParams(
           prophetValue,
         );
@@ -222,7 +234,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
             formatProphetTooltipSeries({
               ...value,
               seriesName: key,
-              formatter,
+              formatter: primarySeries.has(key) ? formatter : formatterSecondary,
             }),
           );
         });

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -43,7 +43,7 @@ import {
 import { defaultGrid, defaultTooltip, defaultYAxis } from '../defaults';
 import {
   getPadding,
-  getTooltipFormatter,
+  getTooltipTimeFormatter,
   getXAxisFormatter,
   transformEventAnnotation,
   transformFormulaAnnotation,
@@ -135,7 +135,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     if (max === undefined) max = 1;
   }
 
-  const tooltipFormatter = getTooltipFormatter(tooltipTimeFormat);
+  const tooltipFormatter = getTooltipTimeFormatter(tooltipTimeFormat);
   const xAxisFormatter = getXAxisFormatter(xAxisTimeFormat);
 
   const addYAxisLabelOffset = !!yAxisTitle;

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -336,7 +336,7 @@ export function getPadding(
   });
 }
 
-export function getTooltipFormatter(format?: string): TimeFormatter | StringConstructor {
+export function getTooltipTimeFormatter(format?: string): TimeFormatter | StringConstructor {
   if (format === smartDateFormatter.id) {
     return smartDateDetailedFormatter;
   }


### PR DESCRIPTION
🐛 Bug Fix

Currently the Mixed Timeseries chart doesn't consider the secondary axis formatter when rendering the tooltip.

### BEFORE
Despite "girls" referencing the secondary axis (right) that applies a different formatter than the primary axis (left), the secondary axis format isn't applied in the tooltip (now displays "658k", should be "657586"):
![image](https://user-images.githubusercontent.com/33317356/120435718-c3074680-c386-11eb-931f-737702dc5f0d.png)

### AFTER
Now the tooltip format is set based on the format defined for the axis.
![image](https://user-images.githubusercontent.com/33317356/120435652-abc85900-c386-11eb-9035-f524de709d37.png)

Fixes https://github.com/apache/superset/issues/14943