### PR TITLE
fix(plugin-chart-echarts): order by timeseries limit metric

### DIFF
--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -60,6 +60,7 @@ export default function buildQuery(formData: QueryFormData) {
       {
         ...baseQueryObject,
         is_timeseries: true,
+        orderby: timeseries_limit_metric ? [[timeseries_limit_metric, !order_desc]] : [],
         post_processing: [
           {
             operation: 'pivot',
@@ -82,6 +83,7 @@ export default function buildQuery(formData: QueryFormData) {
       {
         ...baseQueryObject,
         is_timeseries: true,
+        orderby: timeseries_limit_metric_b ? [[timeseries_limit_metric_b, !order_desc_b]] : [],
         post_processing: [
           {
             operation: 'pivot',

--- a/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -21,11 +21,17 @@ import { buildQueryContext, getMetricLabel, QueryFormData } from '@superset-ui/c
 export default function buildQuery(formData: QueryFormData) {
   return buildQueryContext(formData, baseQueryObject => {
     const metricLabels = (baseQueryObject.metrics || []).map(getMetricLabel);
+    const { timeseries_limit_metric, order_desc, orderby } = baseQueryObject;
     return [
       {
         ...baseQueryObject,
         groupby: formData.groupby || [],
         is_timeseries: true,
+        orderby: orderby?.length
+          ? orderby
+          : timeseries_limit_metric
+          ? [[timeseries_limit_metric, !order_desc]]
+          : [],
         post_processing: [
           {
             operation: 'pivot',

--- a/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
+++ b/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
@@ -33,4 +33,33 @@ describe('Timeseries buildQuery', () => {
     expect(query.groupby).toEqual(['foo']);
     expect(query.metrics).toEqual(['bar', 'baz']);
   });
+
+  it('should order by timeseries limit if orderby unspecified', () => {
+    const queryContext = buildQuery({
+      ...formData,
+      timeseries_limit_metric: 'bar',
+      order_desc: true,
+    });
+    const [query] = queryContext.queries;
+    expect(query.groupby).toEqual(['foo']);
+    expect(query.metrics).toEqual(['bar', 'baz']);
+    expect(query.timeseries_limit_metric).toEqual('bar');
+    expect(query.order_desc).toEqual(true);
+    expect(query.orderby).toEqual([['bar', false]]);
+  });
+
+  it('should not order by timeseries limit if orderby provided', () => {
+    const queryContext = buildQuery({
+      ...formData,
+      timeseries_limit_metric: 'bar',
+      order_desc: true,
+      orderby: [['foo', true]],
+    });
+    const [query] = queryContext.queries;
+    expect(query.groupby).toEqual(['foo']);
+    expect(query.metrics).toEqual(['bar', 'baz']);
+    expect(query.timeseries_limit_metric).toEqual('bar');
+    expect(query.order_desc).toEqual(true);
+    expect(query.orderby).toEqual([['foo', true]]);
+  });
 });


### PR DESCRIPTION
🐛 Bug Fix
Order by timeseries limit metric if no orderby is provided (for parity with NVD3 Timeseries viz'):
![image](https://user-images.githubusercontent.com/33317356/121154049-43c6b680-c84f-11eb-9c61-697aebf4a917.png)

Added tests to ensure that ordering is correct both when `orderby` is specified/unspecified combined with timeseries limit metric.