### PR TITLE
chore(plugin-chart-echarts): bump echarts to 5.1.2

### DIFF
--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -30,7 +30,7 @@
     "@superset-ui/core": "0.17.53",
     "@types/mathjs": "^6.0.7",
     "d3-array": "^1.2.0",
-    "echarts": "^5.1.1",
+    "echarts": "^5.1.2",
     "lodash": "^4.17.15",
     "mathjs": "^8.0.1"
   },

--- a/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx
@@ -70,10 +70,10 @@ const controlPanel: ControlPanelConfig = {
         ],
         [
           {
-            // TODO: Set renderTrigger to true without getting intermittent errors in echart
             name: 'root_node_id',
             config: {
               ...optionalEntity,
+              renderTrigger: true,
               type: 'TextControl',
               label: t('Root node id'),
               description: t('Id of root node of the tree.'),

--- a/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
+++ b/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
@@ -93,7 +93,6 @@ export default function EchartsTreemap({
       echartOptions={echartOptions}
       eventHandlers={eventHandlers}
       selectedValues={selectedValues}
-      forceClear
     />
   );
 }

--- a/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -32,7 +32,6 @@ export default function Echart({
   echartOptions,
   eventHandlers,
   selectedValues = {},
-  forceClear = false,
 }: EchartsProps) {
   const divRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<ECharts>();
@@ -49,10 +48,6 @@ export default function Echart({
       chartRef.current?.off(name);
       chartRef.current?.on(name, handler);
     });
-
-    if (forceClear) {
-      chartRef.current.clear();
-    }
 
     chartRef.current.setOption(echartOptions, true);
 


### PR DESCRIPTION
🏆 Enhancements

Bump ECharts to version 5.1.2. See the changelog for details: https://github.com/apache/echarts/releases/tag/5.1.2 . Two minor tweaks/cleanups:
- Remove the `forceClear` prop from the `Echart` component as it should no longer be needed: https://github.com/apache/echarts/pull/14930 . Ping @stephenLYZ 
- Change `root_node_id` to `renderTrigger: true` thanks to this fix: https://github.com/apache/echarts/pull/14905 . Ping @mayurnewase 
