### PR TITLE
fix(plugin-chart-echarts): fix time-series chart xAxisShowMin(Max)Label default value

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -56,8 +56,6 @@ const {
   yAxisBounds,
   zoomable,
   xAxisLabelRotation,
-  xAxisShowMinLabel,
-  xAxisShowMaxLabel,
 } = DEFAULT_FORM_DATA;
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -331,30 +329,6 @@ const config: ControlPanelConfig = {
               description: `${D3_TIME_FORMAT_DOCS}. ${t(
                 'When using other than adaptive formatting, labels may overlap.',
               )}`,
-            },
-          },
-        ],
-        [
-          {
-            name: 'xAxisShowMinLabel',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Show Min Label'),
-              default: xAxisShowMinLabel,
-              renderTrigger: true,
-              description: t('Show Min Label'),
-            },
-          },
-        ],
-        [
-          {
-            name: 'xAxisShowMaxLabel',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Show Max Label'),
-              default: xAxisShowMaxLabel,
-              renderTrigger: true,
-              description: t('Show Max Label'),
             },
           },
         ],

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -79,8 +79,6 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     stack,
     truncateYAxis,
     yAxisFormat,
-    xAxisShowMinLabel,
-    xAxisShowMaxLabel,
     xAxisTimeFormat,
     yAxisBounds,
     yAxisTitle,
@@ -148,8 +146,6 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     xAxis: {
       type: 'time',
       axisLabel: {
-        showMinLabel: xAxisShowMinLabel,
-        showMaxLabel: xAxisShowMaxLabel,
         formatter: xAxisFormatter,
         rotate: xAxisLabelRotation,
       },

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -58,6 +58,8 @@ export type EchartsTimeseriesFormData = {
   truncateYAxis: boolean;
   yAxisFormat?: string;
   yAxisTitle: string;
+  xAxisShowMinLabel?: boolean;
+  xAxisShowMaxLabel?: boolean;
   xAxisTimeFormat?: string;
   timeGrainSqla?: TimeGranularity;
   yAxisBounds: [number | undefined | null, number | undefined | null];

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -58,8 +58,6 @@ export type EchartsTimeseriesFormData = {
   truncateYAxis: boolean;
   yAxisFormat?: string;
   yAxisTitle: string;
-  xAxisShowMinLabel?: boolean;
-  xAxisShowMaxLabel?: boolean;
   xAxisTimeFormat?: string;
   timeGrainSqla?: TimeGranularity;
   yAxisBounds: [number | undefined | null, number | undefined | null];
@@ -90,8 +88,6 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   tooltipTimeFormat: 'smart_date',
   truncateYAxis: true,
   yAxisBounds: [null, null],
-  xAxisShowMinLabel: false,
-  xAxisShowMaxLabel: false,
   zoomable: false,
   richTooltip: true,
   xAxisLabelRotation: 0,


### PR DESCRIPTION
🐛 Bug Fix
https://github.com/apache/superset/issues/15042

### before
https://github.com/apache/superset/issues/15042#issuecomment-856947476

### after
* the reason is https://github.com/apache/superset/issues/15042#issuecomment-858616822
* the solution is https://github.com/apache-superset/superset-ui/pull/1161#issuecomment-873357465

![echarts-label](https://user-images.githubusercontent.com/10264972/124350171-92385c80-dc25-11eb-8bd3-5b043f602329.gif)