### PR TITLE
fix: tooltips on nvd3 charts

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -126,6 +126,8 @@ const TIMESERIES_VIZ_TYPES = [
   'time_pivot',
 ];
 
+const CHART_ID_PREFIX = 'chart-id-';
+
 const propTypes = {
   data: PropTypes.oneOfType([
     PropTypes.arrayOf(
@@ -309,10 +311,18 @@ function nvd3Vis(element, props) {
   const container = element;
   container.innerHTML = '';
   const activeAnnotationLayers = annotationLayers.filter(layer => layer.show);
-  const chartId =
-    container.parentElement && container.parentElement.id !== ''
-      ? container.parentElement.id
-      : null;
+
+  // Search for the chart id in a parent div from the nvd3 chart
+  let chartContainer = container;
+  let chartId = null;
+  while (chartContainer.parentElement) {
+    if (chartContainer.parentElement.id.startsWith(CHART_ID_PREFIX)) {
+      chartId = chartContainer.parentElement.id;
+      break;
+    }
+
+    chartContainer = chartContainer.parentElement;
+  }
 
   let chart;
   let width = maxWidth;


### PR DESCRIPTION
🐛 Bug Fix

Tooltips on nvd3 charts are buggy on dashboards, because if you hover over a chart before the rest of them load, the tooltips that have already been hovered on before disappear. This was because the migration to emotion added an extra div in between the chart container and the nvd3 chart, so we couldn't properly manage that chart's tooltips.

This fixes the bug by searching for the chart container all the way up the dom to get the proper chart id.

Test Plan:
Sync code to superset, load a dashboard with nvd3 charts, hover over a chart to see the tooltip, force refresh a different nvd3 chart, see the first tooltip again after the second chart reloads.

to: @ktmud @pkdotson 