### PR TITLE
chore(chart-controls): improve typing for mapStateToProps

### DIFF
--- a/packages/superset-ui-chart-controls/src/types.ts
+++ b/packages/superset-ui-chart-controls/src/types.ts
@@ -190,7 +190,7 @@ export interface BaseControlConfig<
    */
   mapStateToProps?: (
     state: ControlPanelState,
-    controlState: this & ExtraControlProps,
+    controlState: ControlState,
     // TODO: add strict `chartState` typing (see superset-frontend/src/explore/types)
     chartState?: AnyDict,
   ) => ExtraControlProps;

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -183,7 +183,6 @@ const config: ControlPanelConfig = {
               mapStateToProps: (state: ControlPanelState, controlState: ControlState) => {
                 const { controls } = state;
                 const originalMapStateToProps = sharedControls?.groupby?.mapStateToProps;
-                // @ts-ignore
                 const newState = originalMapStateToProps?.(state, controlState) ?? {};
                 newState.externalValidationErrors = validateAggControlValues(controls, [
                   controls.metrics?.value,


### PR DESCRIPTION
Change `mapStateToProps.controlState` type from `this & ExtraControlProps` to `ControlState`
