### PR TITLE
fix(core): remove height and width requirement on SuperChart

### DIFF
--- a/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -55,7 +55,7 @@ export type Props = Omit<SuperChartCoreProps, 'chartProps'> &
 
 type PropsWithDefault = Props & Readonly<typeof defaultProps>;
 
-export default class SuperChart extends React.PureComponent<Props, { hasBeenRendered: boolean }> {
+export default class SuperChart extends React.PureComponent<Props, {}> {
   /**
    * SuperChart's core
    */
@@ -96,19 +96,11 @@ export default class SuperChart extends React.PureComponent<Props, { hasBeenRend
 
   static defaultProps = defaultProps;
 
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      hasBeenRendered: false,
-    };
-  }
-
   private setRef = (core: SuperChartCore | null) => {
     this.core = core;
   };
 
   renderChart(width: number, height: number) {
-    this.setState({ hasBeenRendered: true });
     const {
       id,
       className,
@@ -193,7 +185,6 @@ export default class SuperChart extends React.PureComponent<Props, { hasBeenRend
         <BoundingBox>
           <ParentSize debounceTime={debounceTime}>
             {({ width, height }) =>
-              (this.state.hasBeenRendered || (width > 0 && width > 0)) &&
               this.renderChart(
                 widthInfo.isDynamic ? Math.floor(width) : widthInfo.value,
                 heightInfo.isDynamic ? Math.floor(height) : heightInfo.value,

--- a/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -55,7 +55,7 @@ export type Props = Omit<SuperChartCoreProps, 'chartProps'> &
 
 type PropsWithDefault = Props & Readonly<typeof defaultProps>;
 
-export default class SuperChart extends React.PureComponent<Props, {}> {
+export default class SuperChart extends React.PureComponent<Props, { hasBeenRendered: boolean }> {
   /**
    * SuperChart's core
    */
@@ -96,11 +96,19 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
 
   static defaultProps = defaultProps;
 
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      hasBeenRendered: false,
+    };
+  }
+
   private setRef = (core: SuperChartCore | null) => {
     this.core = core;
   };
 
   renderChart(width: number, height: number) {
+    this.setState({ hasBeenRendered: true });
     const {
       id,
       className,
@@ -185,8 +193,7 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
         <BoundingBox>
           <ParentSize debounceTime={debounceTime}>
             {({ width, height }) =>
-              width > 0 &&
-              height > 0 &&
+              (this.state.hasBeenRendered || (width > 0 && width > 0)) &&
               this.renderChart(
                 widthInfo.isDynamic ? Math.floor(width) : widthInfo.value,
                 heightInfo.isDynamic ? Math.floor(height) : heightInfo.value,


### PR DESCRIPTION
🐛 Bug Fix

When rendering a `SuperChart` with percentage width/height, the `SuperChartCore` component can sometimes get unmounted and remounted due to the initial width and height being zero before `ParentSize` provides non-zero values, causing major side-effects such as new queries being sent to the backend. This PR removes this check, making the logic for dynamic widths/heights more in-line with that of its non-dynamic counterpart.

Rejected alternative: In an earlier iteration of this PR, we introduced the state `hasBeenRendered`, which is `false` by default, but gets set to `true` at the first render. This way we could avoid rendering until width and height are greater than zero for the first time, while avoiding unmounting if they become zero at a later stage. Since this logic is not applied for non-dynamic widths/heights, and It was deemed unlikely that anyone is relying on this behavior, it was decided to prefer the simpler approach for now. Please check the initial commit for the alternative approach.