### PR TITLE
fix(plugin-chart-echarts): [time-series][mixed timeseries] marker control does not work

### DIFF
--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -129,7 +129,6 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
       opacity,
       seriesType,
       stack,
-      richTooltip,
       yAxisIndex,
     });
     if (transformedSeries) series.push(transformedSeries);
@@ -142,7 +141,6 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
       opacity: opacityB,
       seriesType: seriesTypeB,
       stack: stackB,
-      richTooltip,
       yAxisIndex: yAxisIndexB,
     });
     if (transformedSeries) series.push(transformedSeries);

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -107,7 +107,6 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
       opacity,
       seriesType,
       stack,
-      richTooltip,
     });
     if (transformedSeries) series.push(transformedSeries);
   });

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -70,7 +70,6 @@ export function transformSeries(
     opacity?: number;
     seriesType?: EchartsTimeseriesSeriesType;
     stack?: boolean;
-    richTooltip?: boolean;
     yAxisIndex?: number;
   },
 ): SeriesOption | undefined {
@@ -83,7 +82,6 @@ export function transformSeries(
     opacity,
     seriesType,
     stack,
-    richTooltip,
     yAxisIndex = 0,
   } = opts;
   const forecastSeries = extractForecastSeriesContext(name || '');
@@ -136,10 +134,7 @@ export function transformSeries(
     },
     showSymbol:
       !isConfidenceBand &&
-      (plotType === 'scatter' ||
-        (forecastEnabled && isObservation) ||
-        markerEnabled ||
-        !richTooltip), // TODO: forcing markers when richTooltip is enabled will be removed once ECharts supports item based tooltips without markers
+      (plotType === 'scatter' || (forecastEnabled && isObservation) || markerEnabled),
     symbolSize: markerSize,
   };
 }


### PR DESCRIPTION
🐛 Bug Fix

Unchecking rich tooltip will force marker to be shown, and marker control is not working. This is to support item-based tooltips. But I'd almost prefer to use only marker checkbox to control. The only side effect is that we need to check the marker after unchecking rich tooltip. But it can guarantee a single responsibility.
Or we can check the marker control when unchecking rich tooltip. It may be better implemented in dynamic control.

related to https://github.com/apache/superset/issues/15189

### before
https://user-images.githubusercontent.com/81597121/122186275-bd0f6c00-ce42-11eb-8886-448806d93993.mov

### after

https://user-images.githubusercontent.com/11830681/123062153-d6b24400-d43e-11eb-98ee-3d51a2885699.mov



