### PR TITLE
feat(core): Registry listeners

### DIFF
--- a/packages/superset-ui-core/src/models/Registry.ts
+++ b/packages/superset-ui-core/src/models/Registry.ts
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -262,27 +260,4 @@ export default class Registry<V, W extends LoaderResult<V> = LoaderResult<V>> {
       }
     });
   }
-}
-
-/**
- * A react hook that will re-render the component any time the registry gets new values
- * @param registry a superset-ui Registry (e.g. the chartMetadataRegistry)
- * @returns the result of registry.entries()
- */
-export function useRegistryEntries<V, W extends LoaderResult<V>>(
-  registry: Registry<V, W>,
-): RegistryEntry<V, W>[] {
-  const [entries, setEntries] = useState(registry.entries());
-
-  useEffect(() => {
-    const listener = () => {
-      setEntries(registry.entries());
-    };
-    registry.addListener(listener);
-    return () => {
-      registry.removeListener(listener);
-    };
-  }, [registry]);
-
-  return entries;
 }

--- a/packages/superset-ui-core/src/models/Registry.ts
+++ b/packages/superset-ui-core/src/models/Registry.ts
@@ -33,11 +33,11 @@ interface ItemWithLoader<T> {
 /**
  * Type of value returned from loader function when using registerLoader()
  */
-type LoaderResult<V> = V | Promise<V>;
+type InclusiveLoaderResult<V> = V | Promise<V>;
 
-export type RegistryValue<V, W extends LoaderResult<V>> = V | W | undefined;
+export type RegistryValue<V, W extends InclusiveLoaderResult<V>> = V | W | undefined;
 
-export type RegistryEntry<V, W extends LoaderResult<V>> = {
+export type RegistryEntry<V, W extends InclusiveLoaderResult<V>> = {
   key: string;
   value: RegistryValue<V, W>;
 };
@@ -63,7 +63,7 @@ export interface RegistryConfig {
  * By default W is set to V | Promise<V> to support
  * both synchronous and asynchronous loaders.
  */
-export default class Registry<V, W extends LoaderResult<V> = LoaderResult<V>> {
+export default class Registry<V, W extends InclusiveLoaderResult<V> = InclusiveLoaderResult<V>> {
   name: string;
 
   overwritePolicy: OverwritePolicy;

--- a/packages/superset-ui-core/src/models/Registry.ts
+++ b/packages/superset-ui-core/src/models/Registry.ts
@@ -223,7 +223,7 @@ export default class Registry<V, W extends LoaderResult<V> = LoaderResult<V>> {
   entriesAsPromise(): Promise<{ key: string; value: V }[]> {
     const keys = this.keys();
 
-    return Promise.all(keys.map(key => this.getAsPromise(key))).then(values =>
+    return this.valuesAsPromise().then(values =>
       values.map((value, i) => ({
         key: keys[i],
         value,

--- a/packages/superset-ui-core/test/models/Registry.test.ts
+++ b/packages/superset-ui-core/test/models/Registry.test.ts
@@ -405,5 +405,31 @@ describe('Registry', () => {
       registry.registerValue('foo', 'bar');
       expect(listener).not.toBeCalled();
     });
+
+    describe('with a broken listener', () => {
+      let restoreConsole: any;
+      beforeEach(() => {
+        restoreConsole = mockConsole();
+      });
+      afterEach(() => {
+        restoreConsole();
+      });
+
+      it('keeps working', () => {
+        const errorListener = jest.fn().mockImplementation(() => {
+          throw new Error('test error');
+        });
+        const lastListener = jest.fn();
+
+        registry.addListener(errorListener);
+        registry.addListener(lastListener);
+        registry.registerValue('foo', 'bar');
+
+        expect(listener).toBeCalledWith(['foo']);
+        expect(errorListener).toBeCalledWith(['foo']);
+        expect(lastListener).toBeCalledWith(['foo']);
+        expect(console.error).toBeCalled();
+      });
+    });
   });
 });

--- a/packages/superset-ui-core/test/models/Registry.test.ts
+++ b/packages/superset-ui-core/test/models/Registry.test.ts
@@ -353,4 +353,57 @@ describe('Registry', () => {
       });
     });
   });
+
+  describe('listeners', () => {
+    let registry = new Registry();
+    let listener = jest.fn();
+    beforeEach(() => {
+      registry = new Registry();
+      listener = jest.fn();
+      registry.addListener(listener);
+    });
+
+    it('calls the listener when a value is registered', () => {
+      registry.registerValue('foo', 'bar');
+      expect(listener).toBeCalledWith(['foo']);
+    });
+
+    it('calls the listener when a loader is registered', () => {
+      registry.registerLoader('foo', () => 'bar');
+      expect(listener).toBeCalledWith(['foo']);
+    });
+
+    it('calls the listener when a value is overriden', () => {
+      registry.registerValue('foo', 'bar');
+      listener.mockClear();
+      registry.registerValue('foo', 'baz');
+      expect(listener).toBeCalledWith(['foo']);
+    });
+
+    it('calls the listener when a value is removed', () => {
+      registry.registerValue('foo', 'bar');
+      listener.mockClear();
+      registry.remove('foo');
+      expect(listener).toBeCalledWith(['foo']);
+    });
+
+    it('does not call the listener when a value is not actually removed', () => {
+      registry.remove('foo');
+      expect(listener).not.toBeCalled();
+    });
+
+    it('calls the listener when registry is cleared', () => {
+      registry.registerValue('foo', 'bar');
+      registry.registerLoader('fluz', () => 'baz');
+      listener.mockClear();
+      registry.clear();
+      expect(listener).toBeCalledWith(['foo', 'fluz']);
+    });
+
+    it('removes listeners correctly', () => {
+      registry.removeListener(listener);
+      registry.registerValue('foo', 'bar');
+      expect(listener).not.toBeCalled();
+    });
+  });
 });


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

Adds a listener interface to registries. This will make it easier to use registries from React, specifically wrt dynamic plugins because we can do things like make hooks that re-render components when the registry changes.

Cleaned up some types while I was in there.

📜 Documentation

🐛 Bug Fix

🏠 Internal
