### PR TITLE
fix(plugin-chart-echarts): enable animation to clear old nodes

### DIFF
--- a/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
@@ -205,7 +205,7 @@ export default function transformProps(
       colorSaturation: COLOR_SATURATION,
       itemStyle: {
         borderColor: BORDER_COLOR,
-        color: colorFn(`${child.name}_${depth}`),
+        color: colorFn(`${child.name}`),
         borderWidth: BORDER_WIDTH,
         gapWidth: GAP_WIDTH,
       },

--- a/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
@@ -248,7 +248,6 @@ export default function transformProps(
   const series: TreemapSeriesOption[] = [
     {
       type: 'treemap',
-      animation: false,
       width: '100%',
       height: '100%',
       nodeClick: undefined,


### PR DESCRIPTION
🐛 Bug Fix

Due to a bug present in ECharts 5.1.2, Treemap doesn't properly rerender when the option changes when animation is disabled (see https://github.com/apache/echarts/issues/15282 for details). Until the fix https://github.com/apache/echarts/pull/15283 is merged and released, we should enable animations to work around the bug. I also consider the animation pretty nice, so I wouldn't mind leaving animations enabled.

In addition, the color scheme is changed to reference the group name, aligning it with colors in other charts in the dashboard.

### AFTER
https://user-images.githubusercontent.com/33317356/124273810-2b457580-db49-11eb-8444-10ace0a7a9d4.mp4

### BEFORE
https://user-images.githubusercontent.com/33317356/124270761-4b733580-db45-11eb-9400-0363cda128f9.mp4

