### PR TITLE
feat(plugin-chart-echarts): single select by default for pie chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Pie/EchartsPie.tsx
+++ b/plugins/plugin-chart-echarts/src/Pie/EchartsPie.tsx
@@ -74,7 +74,7 @@ export default function EchartsPie({
       if (values.includes(name)) {
         handleChange(values.filter(v => v !== name));
       } else {
-        handleChange([...values, name]);
+        handleChange([name]);
       }
     },
   };

--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -43,6 +43,7 @@ import {
   sanitizeHtml,
 } from '../utils/series';
 import { defaultGrid, defaultTooltip } from '../defaults';
+import { OpacityEnum } from '../constants';
 
 const percentFormatter = getNumberFormatter(NumberFormats.PERCENT_2_POINT);
 
@@ -147,7 +148,7 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
       name,
       itemStyle: {
         color: colorFn(name),
-        opacity: isFiltered ? 0.3 : 1,
+        opacity: isFiltered ? OpacityEnum.Transparent : OpacityEnum.NonTransparent,
       },
     };
   });

--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -140,11 +140,14 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
       timeFormatter: getTimeFormatter(dateFormat),
     });
 
+    const isFiltered = filterState.selectedValues && !filterState.selectedValues.includes(name);
+
     return {
       value: datum[metricLabel],
       name,
       itemStyle: {
         color: colorFn(name),
+        opacity: isFiltered ? 0.3 : 1,
       },
     };
   });


### PR DESCRIPTION
🏆 Enhancements
single select by default for pie chart and set highlighting effect when applying x-filtering. 
### after
https://user-images.githubusercontent.com/11830681/124380570-ec055900-dcef-11eb-83cb-1d36f62dd810.mov
### before

https://user-images.githubusercontent.com/11830681/124380602-1d7e2480-dcf0-11eb-8579-8367169d2a21.mov

