### PR TITLE
feat: Normalize orderby clause

### DIFF
--- a/packages/superset-ui-core/src/query/index.ts
+++ b/packages/superset-ui-core/src/query/index.ts
@@ -26,6 +26,7 @@ export { default as convertFilter } from './convertFilter';
 export { default as extractTimegrain } from './extractTimegrain';
 export { default as getMetricLabel } from './getMetricLabel';
 export { default as DatasourceKey } from './DatasourceKey';
+export { default as normalizeOrderBy } from './normalizeOrderBy';
 
 export * from './types/AnnotationLayer';
 export * from './types/QueryFormData';

--- a/packages/superset-ui-core/src/query/normalizeOrderBy.ts
+++ b/packages/superset-ui-core/src/query/normalizeOrderBy.ts
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import isEmpty from 'lodash/isEmpty';
+import isBoolean from 'lodash/isBoolean';
+
+import { QueryObject } from './types';
+
+export default function normalizeOrderBy(queryObject: QueryObject): QueryObject {
+  if (Array.isArray(queryObject.orderby) && queryObject.orderby.length > 0) {
+    // ensure a valid orderby clause
+    const orderbyClause = queryObject.orderby[0];
+    if (
+      Array.isArray(orderbyClause) &&
+      orderbyClause.length === 2 &&
+      !isEmpty(orderbyClause[0]) &&
+      isBoolean(orderbyClause[1])
+    ) {
+      return queryObject;
+    }
+  }
+
+  // ensure that remove invalid orderby clause
+  const cloneQueryObject = { ...queryObject };
+  delete cloneQueryObject.timeseries_limit_metric;
+  delete cloneQueryObject.order_desc;
+  delete cloneQueryObject.orderby;
+
+  const isAsc = !queryObject.order_desc;
+  if (
+    queryObject.timeseries_limit_metric !== undefined &&
+    queryObject.timeseries_limit_metric !== null &&
+    !isEmpty(queryObject.timeseries_limit_metric)
+  ) {
+    return {
+      ...cloneQueryObject,
+      orderby: [[queryObject.timeseries_limit_metric, isAsc]],
+    };
+  }
+
+  if (Array.isArray(queryObject.metrics) && queryObject.metrics.length > 0) {
+    return {
+      ...cloneQueryObject,
+      orderby: [[queryObject.metrics[0], isAsc]],
+    };
+  }
+
+  return cloneQueryObject;
+}

--- a/packages/superset-ui-core/test/query/normalizeOrderBy.test.ts
+++ b/packages/superset-ui-core/test/query/normalizeOrderBy.test.ts
@@ -98,7 +98,7 @@ describe('normalizeOrderBy', () => {
     expect(normalizeOrderBy(query)).toEqual(query);
   });
 
-  it('remove invalid orderby', () => {
+  it('remove empty orderby', () => {
     const query: QueryObject = {
       datasource: '5__table',
       viz_type: 'table',
@@ -108,7 +108,7 @@ describe('normalizeOrderBy', () => {
     expect(normalizeOrderBy(query)).not.toHaveProperty('orderby');
   });
 
-  it('remove invalid orderby', () => {
+  it('remove orderby with an empty array', () => {
     const query: QueryObject = {
       datasource: '5__table',
       viz_type: 'table',
@@ -118,7 +118,7 @@ describe('normalizeOrderBy', () => {
     expect(normalizeOrderBy(query)).not.toHaveProperty('orderby');
   });
 
-  it('remove invalid orderby', () => {
+  it('remove orderby with an empty metric', () => {
     const query: QueryObject = {
       datasource: '5__table',
       viz_type: 'table',
@@ -128,7 +128,7 @@ describe('normalizeOrderBy', () => {
     expect(normalizeOrderBy(query)).not.toHaveProperty('orderby');
   });
 
-  it('remove invalid orderby', () => {
+  it('remove orderby with an empty adhoc metric', () => {
     const query: QueryObject = {
       datasource: '5__table',
       viz_type: 'table',
@@ -138,7 +138,7 @@ describe('normalizeOrderBy', () => {
     expect(normalizeOrderBy(query)).not.toHaveProperty('orderby');
   });
 
-  it('remove invalid orderby', () => {
+  it('remove orderby with an non-boolean type', () => {
     const query: QueryObject = {
       datasource: '5__table',
       viz_type: 'table',

--- a/packages/superset-ui-core/test/query/normalizeOrderBy.test.ts
+++ b/packages/superset-ui-core/test/query/normalizeOrderBy.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { normalizeOrderBy, QueryObject } from '@superset-ui/core/src/query';
+
+describe('normalizeOrderBy', () => {
+  it('should not change original queryObject when orderby populated', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      orderby: [['count(*)', true]],
+    };
+    expect(normalizeOrderBy(query)).toEqual(query);
+  });
+
+  it('has timeseries_limit_metric in queryObject', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      metrics: ['count(*)'],
+      timeseries_limit_metric: {
+        expressionType: 'SIMPLE',
+        column: {
+          id: 1,
+          column_name: 'sales',
+        },
+        aggregate: 'SUM',
+      },
+      order_desc: true,
+    };
+    const expectedQueryObject = normalizeOrderBy(query);
+    expect(expectedQueryObject).not.toHaveProperty('timeseries_limit_metric');
+    expect(expectedQueryObject).not.toHaveProperty('order_desc');
+    expect(expectedQueryObject).toEqual({
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      metrics: ['count(*)'],
+      orderby: [
+        [
+          {
+            expressionType: 'SIMPLE',
+            column: {
+              id: 1,
+              column_name: 'sales',
+            },
+            aggregate: 'SUM',
+          },
+          false,
+        ],
+      ],
+    });
+  });
+
+  it('has metrics in queryObject', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      metrics: ['count(*)'],
+      order_desc: true,
+    };
+    const expectedQueryObject = normalizeOrderBy(query);
+    expect(expectedQueryObject).not.toHaveProperty('timeseries_limit_metric');
+    expect(expectedQueryObject).not.toHaveProperty('order_desc');
+    expect(expectedQueryObject).toEqual({
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      metrics: ['count(*)'],
+      orderby: [['count(*)', false]],
+    });
+  });
+
+  it('should not change', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+    };
+    expect(normalizeOrderBy(query)).toEqual(query);
+  });
+
+  it('remove invalid orderby', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      orderby: [],
+    };
+    expect(normalizeOrderBy(query)).not.toHaveProperty('orderby');
+  });
+
+  it('remove invalid orderby', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      orderby: [[]],
+    };
+    expect(normalizeOrderBy(query)).not.toHaveProperty('orderby');
+  });
+
+  it('remove invalid orderby', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      orderby: [['', true]],
+    };
+    expect(normalizeOrderBy(query)).not.toHaveProperty('orderby');
+  });
+
+  it('remove invalid orderby', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      orderby: [[{}, true]],
+    };
+    expect(normalizeOrderBy(query)).not.toHaveProperty('orderby');
+  });
+
+  it('remove invalid orderby', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      orderby: [['count(*)', 'true']],
+    };
+    expect(normalizeOrderBy(query)).not.toHaveProperty('orderby');
+  });
+});


### PR DESCRIPTION
🏆 Enhancements
This PR makes a normalized orderby object in QueryObject instead of `timeseries_limit_metric` and `order_desc`,

also fixed `mixed timeseries chart` unable to sort by. related issue: https://github.com/apache/superset/issues/15345

![image](https://user-images.githubusercontent.com/2016594/124571001-f8b5b880-de79-11eb-8d99-5f64d08d21d5.png)

