### PR TITLE
feat(plugin-chart-echarts): crossfilter with single selection in the funnel chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Funnel/EchartsFunnel.tsx
+++ b/plugins/plugin-chart-echarts/src/Funnel/EchartsFunnel.tsx
@@ -74,7 +74,7 @@ export default function EchartsFunnel({
       if (values.includes(name)) {
         handleChange(values.filter(v => v !== name));
       } else {
-        handleChange([...values, name]);
+        handleChange([name]);
       }
     },
   };

--- a/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -42,6 +42,7 @@ import {
   sanitizeHtml,
 } from '../utils/series';
 import { defaultGrid, defaultTooltip } from '../defaults';
+import { OpacityEnum } from '../constants';
 
 const percentFormatter = getNumberFormatter(NumberFormats.PERCENT_2_POINT);
 
@@ -124,11 +125,13 @@ export default function transformProps(
 
   const transformedData: FunnelSeriesOption[] = data.map(datum => {
     const name = extractGroupbyLabel({ datum, groupby, coltypeMapping: {} });
+    const isFiltered = filterState.selectedValues && !filterState.selectedValues.includes(name);
     return {
       value: datum[metricLabel],
       name,
       itemStyle: {
         color: colorFn(name),
+        opacity: isFiltered ? OpacityEnum.SemiTransparent : OpacityEnum.NonTransparent,
       },
     };
   });


### PR DESCRIPTION
add cross-filter for funnel

### after
![x-filter-funnel](https://user-images.githubusercontent.com/10264972/125467029-ee684238-b8a8-4d4f-bca3-f293353303e1.gif)
in `Video Game Sales` dashbord.