### PR TITLE
feat(plugin-chart-echarts): add x-filter for MixedTimeseries

### DIFF
--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { t } from '@superset-ui/core';
+import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelSectionConfig,
@@ -47,6 +47,7 @@ const {
   zoomable,
   xAxisLabelRotation,
   yAxisIndex,
+  emitFilter,
 } = DEFAULT_FORM_DATA;
 
 function createQuerySection(label: string, controlSuffix: string): ControlPanelSectionConfig {
@@ -243,6 +244,20 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['color_scheme', 'label_colors'],
+        isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
+          ? [
+              {
+                name: 'emit_filter',
+                config: {
+                  type: 'CheckboxControl',
+                  label: t('Enable emitting filters'),
+                  default: emitFilter,
+                  renderTrigger: true,
+                  description: t('Enable emmiting filters.'),
+                },
+              },
+            ]
+          : [],
         ...createCustomizeSection(t('Query A'), ''),
         ...createCustomizeSection(t('Query B'), 'B'),
         [

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
@@ -21,8 +21,12 @@ import buildQuery from './buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
+import { EchartsMixedTimeseriesProps, EchartsMixedTimeseriesFormData } from './types';
 
-export default class EchartsTimeseriesChartPlugin extends ChartPlugin {
+export default class EchartsTimeseriesChartPlugin extends ChartPlugin<
+  EchartsMixedTimeseriesFormData,
+  EchartsMixedTimeseriesProps
+> {
   /**
    * The constructor is used to pass relevant metadata and callbacks that get
    * registered in respective registries that are used throughout the library
@@ -53,6 +57,7 @@ export default class EchartsTimeseriesChartPlugin extends ChartPlugin {
         name: t('Mixed timeseries chart'),
         thumbnail,
       }),
+      // @ts-ignore
       transformProps,
     });
   }

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -115,7 +115,6 @@ export default function transformProps(
   const rawSeriesB = extractTimeseriesSeries(rebaseTimeseriesDatum(data2), {
     fillNeighborValue: stackB ? 0 : undefined,
   });
-  debugger;
 
   const series: SeriesOption[] = [];
   const formatter = getNumberFormatter(contributionMode ? ',.0%' : yAxisFormat);

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -16,7 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { AnnotationLayer, TimeGranularity } from '@superset-ui/core';
+import { EChartsOption } from 'echarts';
+import {
+  AnnotationLayer,
+  TimeGranularity,
+  DataRecordValue,
+  SetDataMaskHook,
+  QueryFormData,
+  ChartProps,
+  ChartDataResponseResult,
+} from '@superset-ui/core';
 import { DEFAULT_LEGEND_FORM_DATA, EchartsLegendFormData } from '../types';
 import {
   DEFAULT_FORM_DATA as TIMESERIES_DEFAULTS,
@@ -24,7 +33,7 @@ import {
   EchartsTimeseriesSeriesType,
 } from '../Timeseries/types';
 
-export type EchartsMixedTimeseriesFormData = {
+export type EchartsMixedTimeseriesFormData = QueryFormData & {
   annotationLayers: AnnotationLayer[];
   // shared properties
   minorSplitLine: boolean;
@@ -68,8 +77,12 @@ export type EchartsMixedTimeseriesFormData = {
   stackB: boolean;
   yAxisIndex?: number;
   yAxisIndexB?: number;
+  groupby: string[];
+  groupbyB: string[];
+  emitFilter: boolean;
 } & EchartsLegendFormData;
 
+// @ts-ignore
 export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   ...DEFAULT_LEGEND_FORM_DATA,
   annotationLayers: [],
@@ -104,9 +117,31 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   stackB: TIMESERIES_DEFAULTS.stack,
   yAxisIndex: 0,
   yAxisIndexB: 0,
+  groupby: [],
+  groupbyB: [],
   xAxisShowMinLabel: TIMESERIES_DEFAULTS.xAxisShowMinLabel,
   xAxisShowMaxLabel: TIMESERIES_DEFAULTS.xAxisShowMaxLabel,
   zoomable: TIMESERIES_DEFAULTS.zoomable,
   richTooltip: TIMESERIES_DEFAULTS.richTooltip,
   xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,
+  emitFilter: false,
+};
+
+export interface EchartsMixedTimeseriesProps extends ChartProps {
+  formData: EchartsMixedTimeseriesFormData;
+  queriesData: ChartDataResponseResult[];
+}
+
+export type EchartsMixedTimeseriesChartTransformedProps = {
+  formData: EchartsMixedTimeseriesFormData;
+  height: number;
+  width: number;
+  echartOptions: EChartsOption;
+  emitFilter: boolean;
+  setDataMask: SetDataMaskHook;
+  groupby: string[];
+  groupbyB: string[];
+  labelMap: Record<string, DataRecordValue[]>;
+  labelMapB: Record<string, DataRecordValue[]>;
+  selectedValues: Record<number, string>;
 };


### PR DESCRIPTION
* use `cleaned_sales_data` to test x-filter of MixedTimeseries.
* Multiple`group` and `labelMap` should be merged?


![x-filter-funnel](https://user-images.githubusercontent.com/10264972/125527481-853938fa-0599-436d-a8ef-0782b4aa405e.gif)

