### PR TITLE
feat(plugin-chart-table): implement conditional formatting

### DIFF
--- a/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/plugins/plugin-chart-table/src/TableChart.tsx
@@ -163,6 +163,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     sortDesc = false,
     filters: initialFilters = {},
     sticky = true, // whether to use sticky header
+    columnColorFormatters,
   } = props;
 
   const [filters, setFilters] = useState(initialFilters);
@@ -294,6 +295,18 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         Cell: ({ value }: { value: DataRecordValue }) => {
           const [isHtml, text] = formatColumnValue(column, value);
           const html = isHtml ? { __html: text } : undefined;
+
+          let backgroundColor;
+          isNumeric &&
+            Array.isArray(columnColorFormatters) &&
+            columnColorFormatters
+              .filter(formatter => formatter.column === column.key)
+              .forEach(formatter => {
+                const formatterResult = formatter.getColorFromValue(value as number);
+                if (formatterResult) {
+                  backgroundColor = formatterResult;
+                }
+              });
           const cellProps = {
             // show raw number in title in case of numeric values
             title: typeof value === 'number' ? String(value) : undefined,
@@ -305,14 +318,16 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             ].join(' '),
             style: {
               ...sharedStyle,
-              background: valueRange
-                ? cellBar({
-                    value: value as number,
-                    valueRange,
-                    alignPositiveNegative,
-                    colorPositiveNegative,
-                  })
-                : undefined,
+              background:
+                backgroundColor ||
+                (valueRange
+                  ? cellBar({
+                      value: value as number,
+                      valueRange,
+                      alignPositiveNegative,
+                      colorPositiveNegative,
+                    })
+                  : undefined),
             },
           };
           if (html) {
@@ -371,6 +386,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       sortDesc,
       toggleFilter,
       totals,
+      columnColorFormatters,
     ],
   );
 

--- a/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/plugins/plugin-chart-table/src/TableChart.tsx
@@ -297,8 +297,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           const html = isHtml ? { __html: text } : undefined;
 
           let backgroundColor;
-          isNumeric &&
-            Array.isArray(columnColorFormatters) &&
+          if (isNumeric && Array.isArray(columnColorFormatters)) {
             columnColorFormatters
               .filter(formatter => formatter.column === column.key)
               .forEach(formatter => {
@@ -307,6 +306,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                   backgroundColor = formatterResult;
                 }
               });
+          }
+
           const cellProps = {
             // show raw number in title in case of numeric values
             title: typeof value === 'number' ? String(value) : undefined,

--- a/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/plugins/plugin-chart-table/src/TableChart.tsx
@@ -276,7 +276,11 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       const colorPositiveNegative =
         config.colorPositiveNegative === undefined ? defaultColorPN : config.colorPositiveNegative;
 
+      const hasColumnColorFormatters =
+        isNumeric && Array.isArray(columnColorFormatters) && columnColorFormatters.length > 0;
+
       const valueRange =
+        !hasColumnColorFormatters &&
         (config.showCellBars === undefined ? showCellBars : config.showCellBars) &&
         (isMetric || isRawRecords) &&
         getValueRange(key, alignPositiveNegative);
@@ -297,8 +301,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           const html = isHtml ? { __html: text } : undefined;
 
           let backgroundColor;
-          if (isNumeric && Array.isArray(columnColorFormatters)) {
-            columnColorFormatters
+          if (hasColumnColorFormatters) {
+            columnColorFormatters!
               .filter(formatter => formatter.column === column.key)
               .forEach(formatter => {
                 const formatterResult = formatter.getColorFromValue(value as number);

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -23,6 +23,7 @@ import {
   ChartDataResponseResult,
   ensureIsArray,
   FeatureFlag,
+  GenericDataType,
   isFeatureEnabled,
   QueryFormColumn,
   QueryMode,
@@ -445,6 +446,34 @@ const config: ControlPanelConfig = {
               mapStateToProps(explore, control, chart) {
                 return {
                   queryResponse: chart?.queriesResponse?.[0] as ChartDataResponseResult | undefined,
+                };
+              },
+            },
+          },
+        ],
+        [
+          {
+            name: 'conditional_formatting',
+            config: {
+              type: 'ConditionalFormattingControl',
+              renderTrigger: true,
+              label: t('Conditional formatting'),
+              description: t('Apply conditional color formatting to numeric columns'),
+              mapStateToProps(explore, control, chart) {
+                const verboseMap = explore?.datasource?.verbose_map ?? {};
+                const { colnames, coltypes } = chart?.queriesResponse?.[0] ?? {};
+                const numericColumns =
+                  Array.isArray(colnames) && Array.isArray(coltypes)
+                    ? colnames
+                        .filter(
+                          (colname: string, index: number) =>
+                            coltypes[index] === GenericDataType.NUMERIC,
+                        )
+                        .map(colname => ({ value: colname, label: verboseMap[colname] ?? colname }))
+                    : [];
+                return {
+                  columnOptions: numericColumns,
+                  verboseMap,
                 };
               },
             },

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -31,6 +31,7 @@ import {
   TimeFormats,
   TimeFormatter,
 } from '@superset-ui/core';
+import { getColorFormatters } from '@superset-ui/chart-controls';
 
 import isEqualColumns from './utils/isEqualColumns';
 import DateWithFormatter from './utils/DateWithFormatter';
@@ -203,6 +204,7 @@ const transformProps = (chartProps: TableChartProps): TableChartTransformedProps
     order_desc: sortDesc = false,
     query_mode: queryMode,
     show_totals: showTotals,
+    conditional_formatting: conditionalFormatting,
   } = formData;
 
   const [metrics, percentMetrics, columns] = processColumns(chartProps);
@@ -220,6 +222,7 @@ const transformProps = (chartProps: TableChartProps): TableChartTransformedProps
   }
   const data = processDataRecords(baseQuery?.data, columns);
   const totals = showTotals && queryMode === QueryMode.aggregate ? totalQuery?.data[0] : undefined;
+  const columnColorFormatters = getColorFormatters(conditionalFormatting, data);
 
   return {
     height,
@@ -235,7 +238,7 @@ const transformProps = (chartProps: TableChartProps): TableChartTransformedProps
     setDataMask,
     alignPositiveNegative,
     colorPositiveNegative,
-    showCellBars,
+    showCellBars: showCellBars && columnColorFormatters.length === 0,
     sortDesc,
     includeSearch,
     rowCount,
@@ -245,6 +248,7 @@ const transformProps = (chartProps: TableChartProps): TableChartTransformedProps
     filters,
     emitFilter: tableFilter,
     onChangeFilter,
+    columnColorFormatters,
   };
 };
 

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -238,7 +238,7 @@ const transformProps = (chartProps: TableChartProps): TableChartTransformedProps
     setDataMask,
     alignPositiveNegative,
     colorPositiveNegative,
-    showCellBars: showCellBars && columnColorFormatters.length === 0,
+    showCellBars,
     sortDesc,
     includeSearch,
     rowCount,

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -222,7 +222,7 @@ const transformProps = (chartProps: TableChartProps): TableChartTransformedProps
   }
   const data = processDataRecords(baseQuery?.data, columns);
   const totals = showTotals && queryMode === QueryMode.aggregate ? totalQuery?.data[0] : undefined;
-  const columnColorFormatters = getColorFormatters(conditionalFormatting, data);
+  const columnColorFormatters = getColorFormatters(conditionalFormatting, data) ?? [];
 
   return {
     height,

--- a/plugins/plugin-chart-table/src/types.ts
+++ b/plugins/plugin-chart-table/src/types.ts
@@ -31,7 +31,7 @@ import {
   QueryFormData,
   SetDataMaskHook,
 } from '@superset-ui/core';
-import { ColumnConfig } from '@superset-ui/chart-controls';
+import { ColorFormatters, ColumnConfig } from '@superset-ui/chart-controls';
 
 export type CustomFormatter = (value: DataRecordValue) => string;
 
@@ -107,6 +107,7 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   filters?: DataRecordFilters;
   emitFilter?: boolean;
   onChangeFilter?: ChartProps['hooks']['onAddFilter'];
+  columnColorFormatters?: ColorFormatters;
 }
 
 export default {};


### PR DESCRIPTION
Adds conditional formatting to Table chart.
Conditional formatting feature is described in https://github.com/apache/superset/pull/15651
In the case of Table chart, if conditional formatting is defined (at least 1 formatter has been added), cell bars are disabled and replaced with formatter's colors.

https://user-images.githubusercontent.com/15073128/125609934-3a04ff76-c8a2-48f3-916e-23c5ca567fd0.mov

CC @junlincc @rusackas @michael-s-molina  