### PR TITLE
fix(legacy-plugin-chart-sankey-loop): clear element before redrawing

### DIFF
--- a/plugins/legacy-plugin-chart-sankey-loop/src/SankeyLoop.js
+++ b/plugins/legacy-plugin-chart-sankey-loop/src/SankeyLoop.js
@@ -98,7 +98,10 @@ function SankeyLoop(element, props) {
     )
     .linkColor(d => color(d.source.name));
 
-  const svg = select(element)
+  const div = select(element);
+  div.selectAll('*').remove();
+
+  const svg = div
     .append('svg')
     .classed('superset-legacy-chart-sankey-loop', true)
     .style('width', width)


### PR DESCRIPTION
🐛 Bug Fix

Otherwise every (re)render adds a new svg to the element. This is essentially the same as the fix that was applied to legacy-plugin-chart-sankey back in apache/superset#254