### PR TITLE
fix: Reduce bundle sizes from react-icons

### DIFF
--- a/packages/superset-ui-chart-controls/package.json
+++ b/packages/superset-ui-chart-controls/package.json
@@ -26,6 +26,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@react-icons/all-files": "^4.1.0",
     "@superset-ui/core": "0.17.64",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2"
@@ -33,7 +34,6 @@
   "peerDependencies": {
     "@types/react": "*",
     "antd": "^4.9.4",
-    "react": "^16.13.1",
-    "react-icons": "^4.2.0"
+    "react": "^16.13.1"
   }
 }

--- a/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/components/ColumnConfigControl/constants.tsx
@@ -18,7 +18,9 @@
  */
 import React from 'react';
 import { GenericDataType, t, validateNumber } from '@superset-ui/core';
-import { FaAlignLeft, FaAlignRight, FaAlignCenter } from 'react-icons/fa';
+import { FaAlignLeft } from '@react-icons/all-files/fa/FaAlignLeft';
+import { FaAlignRight } from '@react-icons/all-files/fa/FaAlignRight';
+import { FaAlignCenter } from '@react-icons/all-files/fa/FaAlignCenter';
 import {
   D3_FORMAT_DOCS,
   D3_FORMAT_OPTIONS,

--- a/packages/superset-ui-demo/package.json
+++ b/packages/superset-ui-demo/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/apache-superset/superset-ui#readme",
   "dependencies": {
     "@data-ui/event-flow": "^0.0.84",
+    "@react-icons/all-files": "^4.1.0",
     "@storybook/addon-actions": "^5.3.18",
     "@storybook/addon-info": "^5.3.18",
     "@storybook/addon-knobs": "^6.1.15",
@@ -75,7 +76,6 @@
     "jquery": "^3.4.1",
     "memoize-one": "^5.1.1",
     "react": "^16.13.1",
-    "react-icons": "^4.2.0",
     "react-loadable": "^5.5.0",
     "react-resizable": "^1.10.1",
     "storybook-addon-jsx": "^7.2.3"

--- a/plugins/plugin-chart-table/package.json
+++ b/plugins/plugin-chart-table/package.json
@@ -26,6 +26,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@react-icons/all-files": "^4.1.0",
     "@superset-ui/chart-controls": "0.17.66",
     "@superset-ui/core": "0.17.64",
     "@types/d3-array": "^2.9.0",
@@ -40,7 +41,6 @@
   "peerDependencies": {
     "@types/react": "*",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "react-icons": "^4.2.0"
+    "react-dom": "^16.13.1"
   }
 }

--- a/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/plugins/plugin-chart-table/src/TableChart.tsx
@@ -19,7 +19,9 @@
 import React, { CSSProperties, useCallback, useMemo } from 'react';
 import { ColumnInstance, ColumnWithLooseAccessor, DefaultSortTypes } from 'react-table';
 import { extent as d3Extent, max as d3Max } from 'd3-array';
-import { FaSort, FaSortDown as FaSortDesc, FaSortUp as FaSortAsc } from 'react-icons/fa';
+import { FaSort } from '@react-icons/all-files/fa/FaSort';
+import { FaSortDown as FaSortDesc } from '@react-icons/all-files/fa/FaSortDown';
+import { FaSortUp as FaSortAsc } from '@react-icons/all-files/fa/FaSortUp';
 import { DataRecord, DataRecordValue, GenericDataType, t, tn } from '@superset-ui/core';
 
 import { DataColumnMeta, TableChartTransformedProps } from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,6 +3572,11 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@react-icons/all-files@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@react-icons/all-files/-/all-files-4.1.0.tgz#477284873a0821928224b6fc84c62d2534d6650b"
+  integrity sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
@@ -10036,13 +10041,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.1.1.tgz#b186f162f017c555cfd67b12ede6762bdc3ddfda"
-  integrity sha512-b3nP8M9XwZM2jISuA+fP0EuJv8lcfgWrinel185Npy8bE/UhXTDIPJcqgQOCWdvk0c5CeT6Dsm1xBjmJXAGlxQ==
+echarts@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.1.2.tgz#aa1ab0cef5b74fa2f7c620261a5f286893d30fd1"
+  integrity sha512-okUhO4sw22vwZp+rTPNjd/bvTdpug4K4sHNHyrV8NdAncIX9/AarlolFqtJCAYKGFYhUBNjIWu1EznFrSWTFxg==
   dependencies:
     tslib "2.0.3"
-    zrender "5.1.0"
+    zrender "5.1.1"
 
 editions@^2.2.0:
   version "2.3.1"
@@ -19008,11 +19013,6 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
-react-icons@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"
-  integrity sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==
-
 react-input-autosize@^2.1.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
@@ -23469,9 +23469,9 @@ yosay@^2.0.2:
     taketalk "^1.0.0"
     wrap-ansi "^2.0.0"
 
-zrender@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.1.0.tgz#b6a84c3aa7ccc6642ee0519901ca4c0835c4d85e"
-  integrity sha512-c+8VRx52ycbmqwHeHLlo/BAfIHBl/JZNLM6cfDQFgzIH05yb+f5J9F/fbRsP+zGc8dW9XHuhdt8/iqukgMZSeg==
+zrender@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.1.1.tgz#0515f4f8cc0f4742f02a6b8819550a6d13d64c5c"
+  integrity sha512-oeWlmUZPQdS9f5hK4pV21tHPqA3wgQ7CkKkw7l0CCBgWlJ/FP+lRgLFtUBW6yam4JX8y9CdHJo1o587VVrbcoQ==
   dependencies:
     tslib "2.0.3"


### PR DESCRIPTION
🏆 Enhancements

This should allow us to tree-shake and only pull in the icons that we actually use from react-icons. see here: https://github.com/react-icons/react-icons#installation-for-meteorjs-gatsbyjs-etc

This should help us reduce the bundle size in superset proper (see the massive react-icons/fa chunk here): 
![image](https://user-images.githubusercontent.com/7409244/125838990-6840ec84-f27b-4ade-8993-e297aaf6ac08.png)


Test plan:
Load up the storybook, and see icons in the table still render
<img width="732" alt="Screen Shot 2021-07-15 at 8 25 12 PM" src="https://user-images.githubusercontent.com/7409244/125838859-c8932170-7088-4545-9893-9cc9003b7942.png">

to: @ktmud @kgabryje