### PR TITLE
fix: missing nan value in timeseries chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -38,10 +38,12 @@ export default function buildQuery(formData: QueryFormData) {
             options: {
               index: ['__timestamp'],
               columns: formData.groupby || [],
-              // Create 'dummy' sum aggregates to assign cell values in pivot table
+              // Create 'dummy' mean aggregates to assign cell values in pivot table
+              // use the 'mean' aggregates to avoid drop NaN
               aggregates: Object.fromEntries(
-                metricLabels.map(metric => [metric, { operator: 'sum' }]),
+                metricLabels.map(metric => [metric, { operator: 'mean' }]),
               ),
+              drop_missing_columns: false,
             },
           },
           formData.contributionMode


### PR DESCRIPTION
currently, the time-series line chart render `null` value as 0. this PR fix that.

A quick fix for the time-series chart. 

I will clean up all the operators when the advanced analytics merge into master.

🐛 Bug Fix
### Before
![image](https://user-images.githubusercontent.com/2016594/126629676-4331fb21-e6db-414b-920f-6a08eb0b71b8.png)

### After
![image](https://user-images.githubusercontent.com/2016594/126629518-49cba66e-101d-4702-a9e2-6bb09381dca1.png)


