### PR TITLE
fix(plugin-chart-echarts): make filtered pie slices semi-transparent

### DIFF
--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -148,7 +148,7 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
       name,
       itemStyle: {
         color: colorFn(name),
-        opacity: isFiltered ? OpacityEnum.Transparent : OpacityEnum.NonTransparent,
+        opacity: isFiltered ? OpacityEnum.SemiTransparent : OpacityEnum.NonTransparent,
       },
     };
   });


### PR DESCRIPTION
🐛 Bug Fix

Currently unselected slices are fully transparent. This changes the opacity of filtered slices to `SemiTransparent` (=0.3) instead of `Transparent` (0).

### AFTER
![image](https://user-images.githubusercontent.com/33317356/126960445-878610f5-af2c-4d5c-b6a1-83552a483db4.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/126960527-699e0712-5c17-466d-9b6a-4534f56fe4b9.png)

Closes https://github.com/apache/superset/issues/15832