### PR TITLE
feat(plugin-chart-pivot-table): sort by metric

### DIFF
--- a/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -16,19 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { buildQueryContext, ensureIsArray } from '@superset-ui/core';
+import { buildQueryContext, ensureIsArray, QueryFormOrderBy } from '@superset-ui/core';
 import { PivotTableQueryFormData } from '../types';
 
 export default function buildQuery(formData: PivotTableQueryFormData) {
-  const { groupbyColumns = [], groupbyRows = [] } = formData;
+  const { groupbyColumns = [], groupbyRows = [], orderDesc = true } = formData;
   const groupbySet = new Set([
     ...ensureIsArray<string>(groupbyColumns),
     ...ensureIsArray<string>(groupbyRows),
   ]);
-  return buildQueryContext(formData, baseQueryObject => [
-    {
-      ...baseQueryObject,
-      columns: [...groupbySet],
-    },
-  ]);
+  const sortByMetric = ensureIsArray(formData.timeseries_limit_metric)[0];
+  return buildQueryContext(formData, baseQueryObject => {
+    const metrics = ensureIsArray(baseQueryObject.metrics);
+    let orderby: QueryFormOrderBy[] = [];
+    if (sortByMetric) {
+      orderby = [[sortByMetric, !orderDesc]];
+    } else if (metrics[0]) {
+      orderby = [[metrics[0], false]];
+    }
+    return [
+      {
+        ...baseQueryObject,
+        columns: [...groupbySet],
+        orderby,
+      },
+    ];
+  });
 }

--- a/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -16,29 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { buildQueryContext, ensureIsArray, QueryFormOrderBy } from '@superset-ui/core';
+import { buildQueryContext, ensureIsArray, normalizeOrderBy } from '@superset-ui/core';
 import { PivotTableQueryFormData } from '../types';
 
 export default function buildQuery(formData: PivotTableQueryFormData) {
-  const { groupbyColumns = [], groupbyRows = [], orderDesc = true } = formData;
+  const { groupbyColumns = [], groupbyRows = [], order_desc = true } = formData;
   const groupbySet = new Set([
     ...ensureIsArray<string>(groupbyColumns),
     ...ensureIsArray<string>(groupbyRows),
   ]);
-  const sortByMetric = ensureIsArray(formData.timeseries_limit_metric)[0];
   return buildQueryContext(formData, baseQueryObject => {
-    const metrics = ensureIsArray(baseQueryObject.metrics);
-    let orderby: QueryFormOrderBy[] = [];
-    if (sortByMetric) {
-      orderby = [[sortByMetric, !orderDesc]];
-    } else if (metrics[0]) {
-      orderby = [[metrics[0], false]];
-    }
+    const queryObject = normalizeOrderBy({ ...baseQueryObject, order_desc });
     return [
       {
-        ...baseQueryObject,
+        ...queryObject,
         columns: [...groupbySet],
-        orderby,
       },
     ];
   });

--- a/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
@@ -94,6 +94,20 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        ['timeseries_limit_metric'],
+        [
+          {
+            name: 'orderDesc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort descending'),
+              default: true,
+              description: t(
+                'Whether to sort descending or ascending. Takes effect only when "Sort by" is set',
+              ),
+            },
+          },
+        ],
       ],
     },
     {

--- a/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
@@ -97,7 +97,7 @@ const config: ControlPanelConfig = {
         ['timeseries_limit_metric'],
         [
           {
-            name: 'orderDesc',
+            name: 'order_desc',
             config: {
               type: 'CheckboxControl',
               label: t('Sort descending'),

--- a/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/plugins/plugin-chart-pivot-table/src/types.ts
@@ -25,6 +25,7 @@ import {
   JsonObject,
   TimeFormatter,
   NumberFormatter,
+  QueryFormMetric,
 } from '@superset-ui/core';
 import { ColorFormatters } from '@superset-ui/chart-controls';
 
@@ -66,6 +67,8 @@ interface PivotTableCustomizeProps {
   metricsLayout?: MetricsLayoutEnum;
   metricColorFormatters: ColorFormatters;
   dateFormatters: Record<string, DateFormatter | undefined>;
+  timeseries_limit_metric: QueryFormMetric[] | QueryFormMetric | null;
+  orderDesc: boolean;
 }
 
 export type PivotTableQueryFormData = QueryFormData &

--- a/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/plugins/plugin-chart-pivot-table/src/types.ts
@@ -68,7 +68,7 @@ interface PivotTableCustomizeProps {
   metricColorFormatters: ColorFormatters;
   dateFormatters: Record<string, DateFormatter | undefined>;
   timeseries_limit_metric: QueryFormMetric[] | QueryFormMetric | null;
-  orderDesc: boolean;
+  order_desc: boolean;
 }
 
 export type PivotTableQueryFormData = QueryFormData &

--- a/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
@@ -25,6 +25,8 @@ describe('PivotTableChart buildQuery', () => {
     metricColorFormatters: [],
     dateFormatters: {},
     setDataMask: () => {},
+    timeseries_limit_metric: 'count',
+    orderDesc: true,
   };
 
   it('should build groupby with series in form data', () => {

--- a/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
@@ -26,7 +26,7 @@ describe('PivotTableChart buildQuery', () => {
     dateFormatters: {},
     setDataMask: () => {},
     timeseries_limit_metric: 'count',
-    orderDesc: true,
+    order_desc: true,
   };
 
   it('should build groupby with series in form data', () => {

--- a/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -26,7 +26,7 @@ describe('PivotTableChart transformProps', () => {
     conditionalFormatting: [],
     dateFormat: '',
     timeseries_limit_metric: 'count',
-    orderDesc: true,
+    order_desc: true,
   };
   const chartProps = new ChartProps<QueryFormData>({
     formData,

--- a/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -25,6 +25,8 @@ describe('PivotTableChart transformProps', () => {
     datasource: '',
     conditionalFormatting: [],
     dateFormat: '',
+    timeseries_limit_metric: 'count',
+    orderDesc: true,
   };
   const chartProps = new ChartProps<QueryFormData>({
     formData,


### PR DESCRIPTION
Implement sorting query results by metric, descending (default) or ascending. If no sort by metric is specified, query results will be sorted by the first adhoc metric, descending (the same behaviour as in Table chart for consistency).

Testing instructions:
1. Create a pivot table chart
2. Use a saved metric or adhoc metric in "Sort by" control. I also suggest setting a low row limit (e.g. 10) to see the effect of sort by clearly.


https://user-images.githubusercontent.com/15073128/126995425-95ccfeb6-05be-4139-93e7-883eab3f59ff.mov

CC: @junlincc 

closes https://github.com/apache/superset/issues/15883#issuecomment-885968829
