### PR TITLE
feat(plugin-chart-echarts): create separate entry points for timeseries

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/Area/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/Area/index.js
@@ -38,7 +38,7 @@ const metadata = new ChartMetadata({
     { url: example3, caption: t('Video game consoles') },
     { url: example4, caption: t('Vehicle Types') },
   ],
-  name: t('Area Chart'),
+  name: t('Area Chart (deprecated)'),
   supportedAnnotationTypes: [ANNOTATION_TYPES.INTERVAL, ANNOTATION_TYPES.EVENT],
   tags: [
     t('Aesthetic'),

--- a/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -1,0 +1,464 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import {
+  FeatureFlag,
+  isFeatureEnabled,
+  legacyValidateInteger,
+  legacyValidateNumber,
+  t,
+} from '@superset-ui/core';
+import {
+  ControlPanelConfig,
+  ControlPanelsContainerProps,
+  D3_TIME_FORMAT_DOCS,
+  sections,
+  sharedControls,
+} from '@superset-ui/chart-controls';
+
+import {
+  DEFAULT_FORM_DATA,
+  EchartsTimeseriesContributionType,
+  EchartsTimeseriesSeriesType,
+} from '../types';
+import { legendSection } from '../../controls';
+
+const {
+  annotationLayers,
+  contributionMode,
+  emitFilter,
+  forecastEnabled,
+  forecastInterval,
+  forecastPeriods,
+  forecastSeasonalityDaily,
+  forecastSeasonalityWeekly,
+  forecastSeasonalityYearly,
+  logAxis,
+  markerEnabled,
+  markerSize,
+  minorSplitLine,
+  opacity,
+  rowLimit,
+  seriesType,
+  stack,
+  tooltipTimeFormat,
+  truncateYAxis,
+  yAxisBounds,
+  zoomable,
+  xAxisLabelRotation,
+} = DEFAULT_FORM_DATA;
+const config: ControlPanelConfig = {
+  controlPanelSections: [
+    sections.legacyTimeseriesTime,
+    {
+      label: t('Query'),
+      expanded: true,
+      controlSetRows: [
+        ['metrics'],
+        ['groupby'],
+        [
+          {
+            name: 'contributionMode',
+            config: {
+              type: 'SelectControl',
+              label: t('Contribution Mode'),
+              default: contributionMode,
+              choices: [
+                [null, 'None'],
+                [EchartsTimeseriesContributionType.Row, 'Total'],
+                [EchartsTimeseriesContributionType.Column, 'Series'],
+              ],
+              description: t('Calculate contribution per series or total'),
+            },
+          },
+        ],
+        ['adhoc_filters'],
+        ['limit'],
+        ['timeseries_limit_metric'],
+        [
+          {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort Descending'),
+              default: true,
+              description: t('Whether to sort descending or ascending'),
+            },
+          },
+        ],
+        ['row_limit'],
+      ],
+    },
+    {
+      label: t('Annotations and Layers'),
+      expanded: false,
+      controlSetRows: [
+        [
+          {
+            name: 'annotation_layers',
+            config: {
+              type: 'AnnotationLayerControl',
+              label: '',
+              default: annotationLayers,
+              description: t('Annotation Layers'),
+            },
+          },
+        ],
+      ],
+    },
+    {
+      label: t('Predictive Analytics'),
+      expanded: false,
+      controlSetRows: [
+        [
+          {
+            name: 'forecastEnabled',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Enable forecast'),
+              renderTrigger: false,
+              default: forecastEnabled,
+              description: t('Enable forecasting'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'forecastPeriods',
+            config: {
+              type: 'TextControl',
+              label: t('Forecast periods'),
+              validators: [legacyValidateInteger],
+              default: forecastPeriods,
+              description: t('How many periods into the future do we want to predict'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'forecastInterval',
+            config: {
+              type: 'TextControl',
+              label: t('Confidence interval'),
+              validators: [legacyValidateNumber],
+              default: forecastInterval,
+              description: t('Width of the confidence interval. Should be between 0 and 1'),
+            },
+          },
+          {
+            name: 'forecastSeasonalityYearly',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: 'Yearly seasonality',
+              choices: [
+                [null, 'default'],
+                [true, 'Yes'],
+                [false, 'No'],
+              ],
+              default: forecastSeasonalityYearly,
+              description: t(
+                'Should yearly seasonality be applied. An integer value will specify Fourier order of seasonality.',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'forecastSeasonalityWeekly',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: 'Weekly seasonality',
+              choices: [
+                [null, 'default'],
+                [true, 'Yes'],
+                [false, 'No'],
+              ],
+              default: forecastSeasonalityWeekly,
+              description: t(
+                'Should weekly seasonality be applied. An integer value will specify Fourier order of seasonality.',
+              ),
+            },
+          },
+          {
+            name: 'forecastSeasonalityDaily',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: 'Daily seasonality',
+              choices: [
+                [null, 'default'],
+                [true, 'Yes'],
+                [false, 'No'],
+              ],
+              default: forecastSeasonalityDaily,
+              description: t(
+                'Should daily seasonality be applied. An integer value will specify Fourier order of seasonality.',
+              ),
+            },
+          },
+        ],
+      ],
+    },
+    {
+      label: t('Chart Options'),
+      expanded: true,
+      controlSetRows: [
+        ['color_scheme', 'label_colors'],
+        [
+          {
+            name: 'seriesType',
+            config: {
+              type: 'SelectControl',
+              label: t('Series Style'),
+              renderTrigger: true,
+              default: seriesType,
+              choices: [
+                [EchartsTimeseriesSeriesType.Line, 'Line'],
+                [EchartsTimeseriesSeriesType.Smooth, 'Smooth Line'],
+                [EchartsTimeseriesSeriesType.Start, 'Step - start'],
+                [EchartsTimeseriesSeriesType.Middle, 'Step - middle'],
+                [EchartsTimeseriesSeriesType.End, 'Step - end'],
+              ],
+              description: t('Series chart type (line, bar etc)'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'opacity',
+            config: {
+              type: 'SliderControl',
+              label: t('Area chart opacity'),
+              renderTrigger: true,
+              min: 0,
+              max: 1,
+              step: 0.1,
+              default: opacity,
+              description: t('Opacity of Area Chart. Also applies to confidence band.'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'stack',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Stack series'),
+              renderTrigger: true,
+              default: stack,
+              description: t('Stack series on top of each other'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'markerEnabled',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Marker'),
+              renderTrigger: true,
+              default: markerEnabled,
+              description: t('Draw a marker on data points. Only applicable for line types.'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'markerSize',
+            config: {
+              type: 'SliderControl',
+              label: t('Marker Size'),
+              renderTrigger: true,
+              min: 0,
+              max: 100,
+              default: markerSize,
+              description: t('Size of marker. Also applies to forecast observations.'),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.markerEnabled?.value),
+            },
+          },
+        ],
+        [
+          {
+            name: 'zoomable',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Data Zoom'),
+              default: zoomable,
+              renderTrigger: true,
+              description: t('Enable data zooming controls'),
+            },
+          },
+        ],
+        isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
+          ? [
+              {
+                name: 'emit_filter',
+                config: {
+                  type: 'CheckboxControl',
+                  label: t('Enable emitting filters'),
+                  default: emitFilter,
+                  renderTrigger: true,
+                  description: t('Enable emmiting filters.'),
+                },
+              },
+            ]
+          : [],
+        ...legendSection,
+        [<h1 className="section-header">{t('X Axis')}</h1>],
+        [
+          {
+            name: 'x_axis_time_format',
+            config: {
+              ...sharedControls.x_axis_time_format,
+              default: 'smart_date',
+              description: `${D3_TIME_FORMAT_DOCS}. ${t(
+                'When using other than adaptive formatting, labels may overlap.',
+              )}`,
+            },
+          },
+        ],
+        [
+          {
+            name: 'xAxisLabelRotation',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              clearable: false,
+              label: t('Rotate x axis label'),
+              choices: [
+                [0, '0°'],
+                [45, '45°'],
+              ],
+              default: xAxisLabelRotation,
+              renderTrigger: true,
+              description: t('Input field supports custom rotation. e.g. 30 for 30°'),
+            },
+          },
+        ],
+        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Tooltip')}</h1>],
+        [
+          {
+            name: 'rich_tooltip',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Rich tooltip'),
+              renderTrigger: true,
+              default: true,
+              description: t('Shows a list of all series available at that point in time'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'tooltipTimeFormat',
+            config: {
+              ...sharedControls.x_axis_time_format,
+              label: t('Tooltip time format'),
+              default: tooltipTimeFormat,
+              clearable: false,
+            },
+          },
+        ],
+        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Y Axis')}</h1>],
+        ['y_axis_format'],
+        [
+          {
+            name: 'logAxis',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Logarithmic y-axis'),
+              renderTrigger: true,
+              default: logAxis,
+              description: t('Logarithmic y-axis'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'minorSplitLine',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Minor Split Line'),
+              renderTrigger: true,
+              default: minorSplitLine,
+              description: t('Draw split lines for minor y-axis ticks'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'yAxisTitle',
+            config: {
+              type: 'TextControl',
+              label: t('Primary y-axis title'),
+              renderTrigger: true,
+              default: '',
+              description: t('Title for y-axis'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'truncateYAxis',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Truncate Y Axis'),
+              default: truncateYAxis,
+              renderTrigger: true,
+              description: t(
+                'Truncate Y Axis. Can be overridden by specifying a min or max bound.',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'y_axis_bounds',
+            config: {
+              type: 'BoundsControl',
+              label: t('Y Axis Bounds'),
+              renderTrigger: true,
+              default: yAxisBounds,
+              description: t(
+                'Bounds for the Y-axis. When left empty, the bounds are ' +
+                  'dynamically defined based on the min/max of the data. Note that ' +
+                  "this feature will only expand the axis range. It won't " +
+                  "narrow the data's extent.",
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.truncateYAxis?.value),
+            },
+          },
+        ],
+      ],
+    },
+  ],
+  controlOverrides: {
+    row_limit: {
+      default: rowLimit,
+    },
+  },
+};
+
+export default config;

--- a/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
+import buildQuery from '../buildQuery';
+import controlPanel from './controlPanel';
+import transformProps from '../transformProps';
+import thumbnail from '../images/thumbnail.png';
+import { EchartsTimeseriesChartProps, EchartsTimeseriesFormData } from '../types';
+import example from '../images/Time-series_Chart.jpg';
+
+const areaTransformProps = (chartProps: EchartsTimeseriesChartProps) =>
+  transformProps({
+    ...chartProps,
+    formData: { ...chartProps.formData, area: true },
+  });
+
+export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesChartProps
+> {
+  /**
+   * The constructor is used to pass relevant metadata and callbacks that get
+   * registered in respective registries that are used throughout the library
+   * and application. A more thorough description of each property is given in
+   * the respective imported file.
+   *
+   * It is worth noting that `buildQuery` and is optional, and only needed for
+   * advanced visualizations that require either post processing operations
+   * (pivoting, rolling aggregations, sorting etc) or submitting multiple queries.
+   */
+  constructor() {
+    super({
+      buildQuery,
+      controlPanel,
+      loadChart: () => import('../EchartsTimeseries'),
+      metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+        category: t('Evolution'),
+        credits: ['https://echarts.apache.org'],
+        description: t(
+          'Swiss army knife for visualizing area time series data. This viz type has many customization options as well.',
+        ),
+        exampleGallery: [{ url: example }],
+        supportedAnnotationTypes: [
+          AnnotationType.Event,
+          AnnotationType.Formula,
+          AnnotationType.Interval,
+          AnnotationType.Timeseries,
+        ],
+        name: t('Area Chart'),
+        tags: [
+          t('Advanced-Analytics'),
+          t('Aesthetic'),
+          t('ECharts'),
+          t('Scatter'),
+          t('Predictive'),
+          t('Time'),
+          t('Transformable'),
+          t('Highly-used'),
+          t('Comparison'),
+          t('Continuous'),
+          t('Line'),
+          t('Proportional'),
+          t('Stacked'),
+          t('Trend'),
+        ],
+        thumbnail,
+      }),
+      transformProps: areaTransformProps,
+    });
+  }
+}

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
+import buildQuery from '../../buildQuery';
+import controlPanel from '../controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from '../../images/thumbnail.png';
+import {
+  EchartsTimeseriesChartProps,
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesSeriesType,
+} from '../../types';
+import example from '../../images/Time-series_Chart.jpg';
+
+const barTransformProps = (chartProps: EchartsTimeseriesChartProps) =>
+  transformProps({
+    ...chartProps,
+    formData: { ...chartProps.formData, seriesType: EchartsTimeseriesSeriesType.Bar },
+  });
+
+export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesChartProps
+> {
+  /**
+   * The constructor is used to pass relevant metadata and callbacks that get
+   * registered in respective registries that are used throughout the library
+   * and application. A more thorough description of each property is given in
+   * the respective imported file.
+   *
+   * It is worth noting that `buildQuery` and is optional, and only needed for
+   * advanced visualizations that require either post processing operations
+   * (pivoting, rolling aggregations, sorting etc) or submitting multiple queries.
+   */
+  constructor() {
+    super({
+      buildQuery,
+      controlPanel,
+      loadChart: () => import('../../EchartsTimeseries'),
+      metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+        category: t('Evolution'),
+        credits: ['https://echarts.apache.org'],
+        description: t(
+          'Swiss army knife for visualizing line time series data. This viz type has many customization options as well.',
+        ),
+        exampleGallery: [{ url: example }],
+        supportedAnnotationTypes: [
+          AnnotationType.Event,
+          AnnotationType.Formula,
+          AnnotationType.Interval,
+          AnnotationType.Timeseries,
+        ],
+        name: t('Time-series Bar Chart'),
+        tags: [
+          t('Advanced-Analytics'),
+          t('Aesthetic'),
+          t('ECharts'),
+          t('Bar'),
+          t('Predictive'),
+          t('Time'),
+          t('Transformable'),
+          t('Highly-used'),
+        ],
+        thumbnail,
+      }),
+      transformProps: barTransformProps,
+    });
+  }
+}

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
+import buildQuery from '../../buildQuery';
+import controlPanel from '../controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from '../../images/thumbnail.png';
+import {
+  EchartsTimeseriesChartProps,
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesSeriesType,
+} from '../../types';
+import example from '../../images/Time-series_Chart.jpg';
+
+const lineTransformProps = (chartProps: EchartsTimeseriesChartProps) =>
+  transformProps({
+    ...chartProps,
+    formData: { ...chartProps.formData, seriesType: EchartsTimeseriesSeriesType.Line },
+  });
+
+export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesChartProps
+> {
+  /**
+   * The constructor is used to pass relevant metadata and callbacks that get
+   * registered in respective registries that are used throughout the library
+   * and application. A more thorough description of each property is given in
+   * the respective imported file.
+   *
+   * It is worth noting that `buildQuery` and is optional, and only needed for
+   * advanced visualizations that require either post processing operations
+   * (pivoting, rolling aggregations, sorting etc) or submitting multiple queries.
+   */
+  constructor() {
+    super({
+      buildQuery,
+      controlPanel,
+      loadChart: () => import('../../EchartsTimeseries'),
+      metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+        category: t('Evolution'),
+        credits: ['https://echarts.apache.org'],
+        description: t(
+          'Swiss army knife for visualizing line time series data. This viz type has many customization options as well.',
+        ),
+        exampleGallery: [{ url: example }],
+        supportedAnnotationTypes: [
+          AnnotationType.Event,
+          AnnotationType.Formula,
+          AnnotationType.Interval,
+          AnnotationType.Timeseries,
+        ],
+        name: t('Time-series Line Chart'),
+        tags: [
+          t('Advanced-Analytics'),
+          t('Aesthetic'),
+          t('ECharts'),
+          t('Line'),
+          t('Predictive'),
+          t('Time'),
+          t('Transformable'),
+          t('Highly-used'),
+        ],
+        thumbnail,
+      }),
+      transformProps: lineTransformProps,
+    });
+  }
+}

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
+import buildQuery from '../../buildQuery';
+import controlPanel from '../controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from '../../images/thumbnail.png';
+import {
+  EchartsTimeseriesChartProps,
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesSeriesType,
+} from '../../types';
+import example from '../../images/Time-series_Chart.jpg';
+
+const scatterTransformProps = (chartProps: EchartsTimeseriesChartProps) =>
+  transformProps({
+    ...chartProps,
+    formData: { ...chartProps.formData, seriesType: EchartsTimeseriesSeriesType.Scatter },
+  });
+
+export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesChartProps
+> {
+  /**
+   * The constructor is used to pass relevant metadata and callbacks that get
+   * registered in respective registries that are used throughout the library
+   * and application. A more thorough description of each property is given in
+   * the respective imported file.
+   *
+   * It is worth noting that `buildQuery` and is optional, and only needed for
+   * advanced visualizations that require either post processing operations
+   * (pivoting, rolling aggregations, sorting etc) or submitting multiple queries.
+   */
+  constructor() {
+    super({
+      buildQuery,
+      controlPanel,
+      loadChart: () => import('../../EchartsTimeseries'),
+      metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+        category: t('Evolution'),
+        credits: ['https://echarts.apache.org'],
+        description: t(
+          'Swiss army knife for visualizing scattered time series data. This viz type has many customization options as well.',
+        ),
+        exampleGallery: [{ url: example }],
+        supportedAnnotationTypes: [
+          AnnotationType.Event,
+          AnnotationType.Formula,
+          AnnotationType.Interval,
+          AnnotationType.Timeseries,
+        ],
+        name: t('Time-series Scatter Chart'),
+        tags: [
+          t('Advanced-Analytics'),
+          t('Aesthetic'),
+          t('ECharts'),
+          t('Scatter'),
+          t('Predictive'),
+          t('Time'),
+          t('Transformable'),
+          t('Highly-used'),
+        ],
+        thumbnail,
+      }),
+      transformProps: scatterTransformProps,
+    });
+  }
+}

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
+import buildQuery from '../../buildQuery';
+import controlPanel from '../controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from '../../images/thumbnail.png';
+import {
+  EchartsTimeseriesChartProps,
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesSeriesType,
+} from '../../types';
+import example from '../../images/Time-series_Chart.jpg';
+
+const smoothTransformProps = (chartProps: EchartsTimeseriesChartProps) =>
+  transformProps({
+    ...chartProps,
+    formData: { ...chartProps.formData, seriesType: EchartsTimeseriesSeriesType.Smooth },
+  });
+
+export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesChartProps
+> {
+  /**
+   * The constructor is used to pass relevant metadata and callbacks that get
+   * registered in respective registries that are used throughout the library
+   * and application. A more thorough description of each property is given in
+   * the respective imported file.
+   *
+   * It is worth noting that `buildQuery` and is optional, and only needed for
+   * advanced visualizations that require either post processing operations
+   * (pivoting, rolling aggregations, sorting etc) or submitting multiple queries.
+   */
+  constructor() {
+    super({
+      buildQuery,
+      controlPanel,
+      loadChart: () => import('../../EchartsTimeseries'),
+      metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+        category: t('Evolution'),
+        credits: ['https://echarts.apache.org'],
+        description: t(
+          'Swiss army knife for visualizing smooth line time series data. This viz type has many customization options as well.',
+        ),
+        exampleGallery: [{ url: example }],
+        supportedAnnotationTypes: [
+          AnnotationType.Event,
+          AnnotationType.Formula,
+          AnnotationType.Interval,
+          AnnotationType.Timeseries,
+        ],
+        name: t('Time-series Smooth Line Chart'),
+        tags: [
+          t('Advanced-Analytics'),
+          t('Aesthetic'),
+          t('ECharts'),
+          t('Line'),
+          t('Predictive'),
+          t('Time'),
+          t('Transformable'),
+          t('Highly-used'),
+        ],
+        thumbnail,
+      }),
+      transformProps: smoothTransformProps,
+    });
+  }
+}

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/StepEnd/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/StepEnd/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
+import buildQuery from '../../buildQuery';
+import controlPanel from '../controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from '../../images/thumbnail.png';
+import {
+  EchartsTimeseriesChartProps,
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesSeriesType,
+} from '../../types';
+import example from '../../images/Time-series_Chart.jpg';
+
+const endTransformProps = (chartProps: EchartsTimeseriesChartProps) =>
+  transformProps({
+    ...chartProps,
+    formData: { ...chartProps.formData, seriesType: EchartsTimeseriesSeriesType.End },
+  });
+
+export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesChartProps
+> {
+  /**
+   * The constructor is used to pass relevant metadata and callbacks that get
+   * registered in respective registries that are used throughout the library
+   * and application. A more thorough description of each property is given in
+   * the respective imported file.
+   *
+   * It is worth noting that `buildQuery` and is optional, and only needed for
+   * advanced visualizations that require either post processing operations
+   * (pivoting, rolling aggregations, sorting etc) or submitting multiple queries.
+   */
+  constructor() {
+    super({
+      buildQuery,
+      controlPanel,
+      loadChart: () => import('../../EchartsTimeseries'),
+      metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+        category: t('Evolution'),
+        credits: ['https://echarts.apache.org'],
+        description: t(
+          'Swiss army knife for visualizing step time series data. This viz type has many customization options as well.',
+        ),
+        exampleGallery: [{ url: example }],
+        supportedAnnotationTypes: [
+          AnnotationType.Event,
+          AnnotationType.Formula,
+          AnnotationType.Interval,
+          AnnotationType.Timeseries,
+        ],
+        name: t('Time-series Step-End Chart'),
+        tags: [
+          t('Advanced-Analytics'),
+          t('Aesthetic'),
+          t('ECharts'),
+          t('Step'),
+          t('Predictive'),
+          t('Time'),
+          t('Transformable'),
+          t('Highly-used'),
+        ],
+        thumbnail,
+      }),
+      transformProps: endTransformProps,
+    });
+  }
+}

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/StepMiddle/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/StepMiddle/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
+import buildQuery from '../../buildQuery';
+import controlPanel from '../controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from '../../images/thumbnail.png';
+import {
+  EchartsTimeseriesChartProps,
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesSeriesType,
+} from '../../types';
+import example from '../../images/Time-series_Chart.jpg';
+
+const middleTransformProps = (chartProps: EchartsTimeseriesChartProps) =>
+  transformProps({
+    ...chartProps,
+    formData: { ...chartProps.formData, seriesType: EchartsTimeseriesSeriesType.Middle },
+  });
+
+export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesChartProps
+> {
+  /**
+   * The constructor is used to pass relevant metadata and callbacks that get
+   * registered in respective registries that are used throughout the library
+   * and application. A more thorough description of each property is given in
+   * the respective imported file.
+   *
+   * It is worth noting that `buildQuery` and is optional, and only needed for
+   * advanced visualizations that require either post processing operations
+   * (pivoting, rolling aggregations, sorting etc) or submitting multiple queries.
+   */
+  constructor() {
+    super({
+      buildQuery,
+      controlPanel,
+      loadChart: () => import('../../EchartsTimeseries'),
+      metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+        category: t('Evolution'),
+        credits: ['https://echarts.apache.org'],
+        description: t(
+          'Swiss army knife for visualizing step time series data. This viz type has many customization options as well.',
+        ),
+        exampleGallery: [{ url: example }],
+        supportedAnnotationTypes: [
+          AnnotationType.Event,
+          AnnotationType.Formula,
+          AnnotationType.Interval,
+          AnnotationType.Timeseries,
+        ],
+        name: t('Time-series Step-Middle Chart'),
+        tags: [
+          t('Advanced-Analytics'),
+          t('Aesthetic'),
+          t('ECharts'),
+          t('Step'),
+          t('Predictive'),
+          t('Time'),
+          t('Transformable'),
+          t('Highly-used'),
+        ],
+        thumbnail,
+      }),
+      transformProps: middleTransformProps,
+    });
+  }
+}

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/StepStart/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/StepStart/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
+import buildQuery from '../../buildQuery';
+import controlPanel from '../controlPanel';
+import transformProps from '../../transformProps';
+import thumbnail from '../../images/thumbnail.png';
+import {
+  EchartsTimeseriesChartProps,
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesSeriesType,
+} from '../../types';
+import example from '../../images/Time-series_Chart.jpg';
+
+const startTransformProps = (chartProps: EchartsTimeseriesChartProps) =>
+  transformProps({
+    ...chartProps,
+    formData: { ...chartProps.formData, seriesType: EchartsTimeseriesSeriesType.Start },
+  });
+
+export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesChartProps
+> {
+  /**
+   * The constructor is used to pass relevant metadata and callbacks that get
+   * registered in respective registries that are used throughout the library
+   * and application. A more thorough description of each property is given in
+   * the respective imported file.
+   *
+   * It is worth noting that `buildQuery` and is optional, and only needed for
+   * advanced visualizations that require either post processing operations
+   * (pivoting, rolling aggregations, sorting etc) or submitting multiple queries.
+   */
+  constructor() {
+    super({
+      buildQuery,
+      controlPanel,
+      loadChart: () => import('../../EchartsTimeseries'),
+      metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+        category: t('Evolution'),
+        credits: ['https://echarts.apache.org'],
+        description: t(
+          'Swiss army knife for visualizing step time series data. This viz type has many customization options as well.',
+        ),
+        exampleGallery: [{ url: example }],
+        supportedAnnotationTypes: [
+          AnnotationType.Event,
+          AnnotationType.Formula,
+          AnnotationType.Interval,
+          AnnotationType.Timeseries,
+        ],
+        name: t('Time-series Step-Start Chart'),
+        tags: [
+          t('Advanced-Analytics'),
+          t('Aesthetic'),
+          t('ECharts'),
+          t('Step'),
+          t('Predictive'),
+          t('Time'),
+          t('Transformable'),
+          t('Highly-used'),
+        ],
+        thumbnail,
+      }),
+      transformProps: startTransformProps,
+    });
+  }
+}

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -1,0 +1,424 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import {
+  FeatureFlag,
+  isFeatureEnabled,
+  legacyValidateInteger,
+  legacyValidateNumber,
+  t,
+} from '@superset-ui/core';
+import {
+  ControlPanelConfig,
+  ControlPanelsContainerProps,
+  D3_TIME_FORMAT_DOCS,
+  sections,
+  sharedControls,
+} from '@superset-ui/chart-controls';
+
+import { DEFAULT_FORM_DATA, EchartsTimeseriesContributionType } from '../types';
+import { legendSection } from '../../controls';
+
+const {
+  annotationLayers,
+  contributionMode,
+  emitFilter,
+  forecastEnabled,
+  forecastInterval,
+  forecastPeriods,
+  forecastSeasonalityDaily,
+  forecastSeasonalityWeekly,
+  forecastSeasonalityYearly,
+  logAxis,
+  markerEnabled,
+  markerSize,
+  minorSplitLine,
+  rowLimit,
+  stack,
+  tooltipTimeFormat,
+  truncateYAxis,
+  yAxisBounds,
+  zoomable,
+  xAxisLabelRotation,
+} = DEFAULT_FORM_DATA;
+const config: ControlPanelConfig = {
+  controlPanelSections: [
+    sections.legacyTimeseriesTime,
+    {
+      label: t('Query'),
+      expanded: true,
+      controlSetRows: [
+        ['metrics'],
+        ['groupby'],
+        [
+          {
+            name: 'contributionMode',
+            config: {
+              type: 'SelectControl',
+              label: t('Contribution Mode'),
+              default: contributionMode,
+              choices: [
+                [null, 'None'],
+                [EchartsTimeseriesContributionType.Row, 'Total'],
+                [EchartsTimeseriesContributionType.Column, 'Series'],
+              ],
+              description: t('Calculate contribution per series or total'),
+            },
+          },
+        ],
+        ['adhoc_filters'],
+        ['limit'],
+        ['timeseries_limit_metric'],
+        [
+          {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort Descending'),
+              default: true,
+              description: t('Whether to sort descending or ascending'),
+            },
+          },
+        ],
+        ['row_limit'],
+      ],
+    },
+    {
+      label: t('Annotations and Layers'),
+      expanded: false,
+      controlSetRows: [
+        [
+          {
+            name: 'annotation_layers',
+            config: {
+              type: 'AnnotationLayerControl',
+              label: '',
+              default: annotationLayers,
+              description: t('Annotation Layers'),
+            },
+          },
+        ],
+      ],
+    },
+    {
+      label: t('Predictive Analytics'),
+      expanded: false,
+      controlSetRows: [
+        [
+          {
+            name: 'forecastEnabled',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Enable forecast'),
+              renderTrigger: false,
+              default: forecastEnabled,
+              description: t('Enable forecasting'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'forecastPeriods',
+            config: {
+              type: 'TextControl',
+              label: t('Forecast periods'),
+              validators: [legacyValidateInteger],
+              default: forecastPeriods,
+              description: t('How many periods into the future do we want to predict'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'forecastInterval',
+            config: {
+              type: 'TextControl',
+              label: t('Confidence interval'),
+              validators: [legacyValidateNumber],
+              default: forecastInterval,
+              description: t('Width of the confidence interval. Should be between 0 and 1'),
+            },
+          },
+          {
+            name: 'forecastSeasonalityYearly',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: 'Yearly seasonality',
+              choices: [
+                [null, 'default'],
+                [true, 'Yes'],
+                [false, 'No'],
+              ],
+              default: forecastSeasonalityYearly,
+              description: t(
+                'Should yearly seasonality be applied. An integer value will specify Fourier order of seasonality.',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'forecastSeasonalityWeekly',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: 'Weekly seasonality',
+              choices: [
+                [null, 'default'],
+                [true, 'Yes'],
+                [false, 'No'],
+              ],
+              default: forecastSeasonalityWeekly,
+              description: t(
+                'Should weekly seasonality be applied. An integer value will specify Fourier order of seasonality.',
+              ),
+            },
+          },
+          {
+            name: 'forecastSeasonalityDaily',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: 'Daily seasonality',
+              choices: [
+                [null, 'default'],
+                [true, 'Yes'],
+                [false, 'No'],
+              ],
+              default: forecastSeasonalityDaily,
+              description: t(
+                'Should daily seasonality be applied. An integer value will specify Fourier order of seasonality.',
+              ),
+            },
+          },
+        ],
+      ],
+    },
+    {
+      label: t('Chart Options'),
+      expanded: true,
+      controlSetRows: [
+        ['color_scheme', 'label_colors'],
+        [
+          {
+            name: 'stack',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Stack series'),
+              renderTrigger: true,
+              default: stack,
+              description: t('Stack series on top of each other'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'markerEnabled',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Marker'),
+              renderTrigger: true,
+              default: markerEnabled,
+              description: t('Draw a marker on data points. Only applicable for line types.'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'markerSize',
+            config: {
+              type: 'SliderControl',
+              label: t('Marker Size'),
+              renderTrigger: true,
+              min: 0,
+              max: 100,
+              default: markerSize,
+              description: t('Size of marker. Also applies to forecast observations.'),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.markerEnabled?.value),
+            },
+          },
+        ],
+        [
+          {
+            name: 'zoomable',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Data Zoom'),
+              default: zoomable,
+              renderTrigger: true,
+              description: t('Enable data zooming controls'),
+            },
+          },
+        ],
+        isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
+          ? [
+              {
+                name: 'emit_filter',
+                config: {
+                  type: 'CheckboxControl',
+                  label: t('Enable emitting filters'),
+                  default: emitFilter,
+                  renderTrigger: true,
+                  description: t('Enable emmiting filters.'),
+                },
+              },
+            ]
+          : [],
+        ...legendSection,
+        [<h1 className="section-header">{t('X Axis')}</h1>],
+        [
+          {
+            name: 'x_axis_time_format',
+            config: {
+              ...sharedControls.x_axis_time_format,
+              default: 'smart_date',
+              description: `${D3_TIME_FORMAT_DOCS}. ${t(
+                'When using other than adaptive formatting, labels may overlap.',
+              )}`,
+            },
+          },
+        ],
+        [
+          {
+            name: 'xAxisLabelRotation',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              clearable: false,
+              label: t('Rotate x axis label'),
+              choices: [
+                [0, '0°'],
+                [45, '45°'],
+              ],
+              default: xAxisLabelRotation,
+              renderTrigger: true,
+              description: t('Input field supports custom rotation. e.g. 30 for 30°'),
+            },
+          },
+        ],
+        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Tooltip')}</h1>],
+        [
+          {
+            name: 'rich_tooltip',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Rich tooltip'),
+              renderTrigger: true,
+              default: true,
+              description: t('Shows a list of all series available at that point in time'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'tooltipTimeFormat',
+            config: {
+              ...sharedControls.x_axis_time_format,
+              label: t('Tooltip time format'),
+              default: tooltipTimeFormat,
+              clearable: false,
+            },
+          },
+        ],
+        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Y Axis')}</h1>],
+        ['y_axis_format'],
+        [
+          {
+            name: 'logAxis',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Logarithmic y-axis'),
+              renderTrigger: true,
+              default: logAxis,
+              description: t('Logarithmic y-axis'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'minorSplitLine',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Minor Split Line'),
+              renderTrigger: true,
+              default: minorSplitLine,
+              description: t('Draw split lines for minor y-axis ticks'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'yAxisTitle',
+            config: {
+              type: 'TextControl',
+              label: t('Primary y-axis title'),
+              renderTrigger: true,
+              default: '',
+              description: t('Title for y-axis'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'truncateYAxis',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Truncate Y Axis'),
+              default: truncateYAxis,
+              renderTrigger: true,
+              description: t(
+                'Truncate Y Axis. Can be overridden by specifying a min or max bound.',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'y_axis_bounds',
+            config: {
+              type: 'BoundsControl',
+              label: t('Y Axis Bounds'),
+              renderTrigger: true,
+              default: yAxisBounds,
+              description: t(
+                'Bounds for the Y-axis. When left empty, the bounds are ' +
+                  'dynamically defined based on the min/max of the data. Note that ' +
+                  "this feature will only expand the axis range. It won't " +
+                  "narrow the data's extent.",
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.truncateYAxis?.value),
+            },
+          },
+        ],
+      ],
+    },
+  ],
+  controlOverrides: {
+    row_limit: {
+      default: rowLimit,
+    },
+  },
+};
+
+export default config;

--- a/plugins/plugin-chart-echarts/src/index.ts
+++ b/plugins/plugin-chart-echarts/src/index.ts
@@ -18,6 +18,14 @@
  */
 export { default as EchartsBoxPlotChartPlugin } from './BoxPlot';
 export { default as EchartsTimeseriesChartPlugin } from './Timeseries';
+export { default as EchartsAreaChartPlugin } from './Timeseries/Area';
+export { default as EchartsTimeseriesBarChartPlugin } from './Timeseries/Regular/Bar';
+export { default as EchartsTimeseriesLineChartPlugin } from './Timeseries/Regular/Line';
+export { default as EchartsTimeseriesScatterChartPlugin } from './Timeseries/Regular/Scatter';
+export { default as EchartsTimeseriesSmoothLineChartPlugin } from './Timeseries/Regular/SmoothLine';
+export { default as EchartsTimeseriesStepEndChartPlugin } from './Timeseries/Regular/StepEnd';
+export { default as EchartsTimeseriesStepMiddleChartPlugin } from './Timeseries/Regular/StepMiddle';
+export { default as EchartsTimeseriesStepStartChartPlugin } from './Timeseries/Regular/StepStart';
 export { default as EchartsMixedTimeseriesChartPlugin } from './MixedTimeseries';
 export { default as EchartsPieChartPlugin } from './Pie';
 export { default as EchartsGraphChartPlugin } from './Graph';

--- a/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { AdhocMetric, buildQueryContext, ensureIsArray, normalizeOrderBy } from '@superset-ui/core';
+import {
+  buildQueryContext,
+  ensureIsArray,
+  getMetricLabel,
+  normalizeOrderBy,
+} from '@superset-ui/core';
 import { PivotTableQueryFormData } from '../types';
 
 export default function buildQuery(formData: PivotTableQueryFormData) {
@@ -35,11 +40,8 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
     const { metrics } = queryObject;
     const orderBy = ensureIsArray(timeseries_limit_metric);
     if (
-      orderBy.length > 0 &&
-      ((typeof orderBy[0] === 'string' && !metrics?.includes(orderBy[0])) ||
-        !metrics?.find(
-          metric => (metric as AdhocMetric).label === (orderBy[0] as AdhocMetric).label,
-        ))
+      orderBy.length &&
+      !metrics?.find(metric => getMetricLabel(metric) === getMetricLabel(orderBy[0]))
     ) {
       metrics?.push(orderBy[0]);
     }


### PR DESCRIPTION
This PR creates separate entry points for Echarts Timeseries Chart series types: Area, Line, Smooth Line, Bar, Scatter, Step Start/Middle/End. Also, changes nvd3 area chart's name to "Area chart (deprecated)".
 
 In Line, Smooth Line, Bar, Scatter, Step Start/Middle/End charts user cannot change the series type nor select "Area" - those controls were removed.
In Area chart user can only select Line, Smooth Line, Step Start/Middle/End series types and cannot deselect "Area" (that controled was removed).
In the "main" Timeseries chart all controls are available as before.

TODO:
 - Add proper tags and descriptions to the new charts
 - Add new thumbnails for the new charts
 - Figure out what to do with the old Area Chart (for now I marked it as "deprecated")
 - Figure out what to do with the "main" Timeseries chart (mark it as "advanced"?)

![image](https://user-images.githubusercontent.com/15073128/127477837-2621a3c4-bae5-4f21-86d0-3251e75d6473.png)
![image](https://user-images.githubusercontent.com/15073128/127477883-7b09ad25-02f1-4a1d-b924-6fc6d236e117.png)
![image](https://user-images.githubusercontent.com/15073128/127477941-7c0dd56f-7f9f-48d1-8b5e-bdc67519e5c7.png)

CC @junlincc @rusackas @villebro 