### PR TITLE
fix: add feature flags for pagination control in table chart

### DIFF
--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -260,17 +260,20 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [
-          {
-            name: 'server_pagination',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Server pagination'),
-              description: t('Enable server side pagination of results (experimental feature)'),
-              default: false,
-            },
-          },
-        ],
+        isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS) ||
+        isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS)
+          ? [
+              {
+                name: 'server_pagination',
+                config: {
+                  type: 'CheckboxControl',
+                  label: t('Server pagination'),
+                  description: t('Enable server side pagination of results (experimental feature)'),
+                  default: false,
+                },
+              },
+            ]
+          : [],
         [
           {
             name: 'row_limit',


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements
 
📜 Documentation

🐛 Bug Fix
This Pr fixes an issue where server pagination is enable in table chart but without feature flags native filter or dashboard cross filters not enabled. Feature flags cross filters or native filters must be enabled to use table pagination.

🏠 Internal
