### PR TITLE
chore: Revert "chore: remove V2 and add Deprecated"

### DIFF
--- a/plugins/legacy-plugin-chart-pivot-table/src/index.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/index.js
@@ -26,7 +26,7 @@ const metadata = new ChartMetadata({
   description: t(`Used to summarize a set of data by grouping together multiple statistics along two axes. Examples: Sales numbers by region and month, tasks by status and assignee, active users by age and location.
 
   This chart is being deprecated and we recommend checking out Pivot Table V2 instead!`),
-  name: t('Pivot Table (Deprecated)'),
+  name: t('Pivot Table'),
   tags: [t('Legacy')],
   thumbnail,
   useLegacyApi: true,

--- a/plugins/legacy-plugin-chart-treemap/src/index.js
+++ b/plugins/legacy-plugin-chart-treemap/src/index.js
@@ -32,7 +32,7 @@ const metadata = new ChartMetadata({
     'Shows the composition of a dataset by segmenting a given rectangle as smaller rectangles with areas proportional to their value or contribution to the whole. Those rectangles may also, in turn, be further segmented hierarchically.',
   ),
   exampleGallery: [{ url: example1 }, { url: example2 }, { url: example3 }, { url: example4 }],
-  name: t('Treemap (Deprecated)'),
+  name: t('Treemap'),
   tags: [t('Categorical'), t('Legacy'), t('Multi-Levels'), t('Percentages'), t('Proportional')],
   thumbnail,
   useLegacyApi: true,

--- a/plugins/plugin-chart-echarts/src/Treemap/index.ts
+++ b/plugins/plugin-chart-echarts/src/Treemap/index.ts
@@ -53,7 +53,7 @@ export default class EchartsTreemapChartPlugin extends ChartPlugin<
           'Show hierarchical relationships of data, with with the value represented by area, showing proportion and contribution to the whole.',
         ),
         exampleGallery: [{ url: example1 }, { url: example2 }],
-        name: t('Treemap'),
+        name: t('Treemap v2'),
         tags: [
           t('Aesthetic'),
           t('Categorical'),

--- a/plugins/plugin-chart-pivot-table/src/plugin/index.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/index.ts
@@ -51,7 +51,7 @@ export default class PivotTableChartPlugin extends ChartPlugin<
       description: t(
         'Used to summarize a set of data by grouping together multiple statistics along two axes. Examples: Sales numbers by region and month, tasks by status and assignee, active users by age and location. Not the most visually stunning visualization, but highly informative and versatile.',
       ),
-      name: t('Pivot Table'),
+      name: t('Pivot Table v2'),
       tags: [t('Additive'), t('Report'), t('Tabular'), t('Highly-used')],
       thumbnail,
     });


### PR DESCRIPTION
As noted by Airbnb, the V2 pivot table has not yet achieved feature parity with the original. Changing the names was too eager of a move. We should consult with the community before making this kind of change.