### PR TITLE
feat(plugin-chart-echarts): implement cross filter in mixd-timeseries chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
@@ -32,16 +32,21 @@ export default function EchartsMixedTimeseries({
   groupbyB,
   selectedValues,
   formData,
+  seriesBreakdown,
 }: EchartsMixedTimeseriesChartTransformedProps) {
+  const isFirstQuery = useCallback((seriesIndex: number) => seriesIndex < seriesBreakdown, [
+    seriesBreakdown,
+  ]);
+
   const handleChange = useCallback(
     (values: string[], seriesIndex: number) => {
-      const emitFilter = seriesIndex === 0 ? formData.emitFilter : formData.emitFilterB;
+      const emitFilter = isFirstQuery(seriesIndex) ? formData.emitFilter : formData.emitFilterB;
       if (!emitFilter) {
         return;
       }
 
-      const currentGroupBy = seriesIndex === 0 ? groupby : groupbyB;
-      const currentLabelMap = seriesIndex === 0 ? labelMap : labelMapB;
+      const currentGroupBy = isFirstQuery(seriesIndex) ? groupby : groupbyB;
+      const currentLabelMap = isFirstQuery(seriesIndex) ? labelMap : labelMapB;
       const groupbyValues = values.map(value => currentLabelMap[value]).filter(value => !!value);
 
       setDataMask({
@@ -72,7 +77,7 @@ export default function EchartsMixedTimeseries({
         },
       });
     },
-    [groupby, labelMap, setDataMask, selectedValues],
+    [groupby, groupbyB, labelMap, labelMapB, setDataMask, selectedValues],
   );
 
   const eventHandlers: EventHandlers = {

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -17,11 +17,12 @@
  * under the License.
  */
 import React from 'react';
-import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelSectionConfig,
   ControlSetRow,
+  emitFilterControl,
   sections,
   sharedControls,
 } from '@superset-ui/chart-controls';
@@ -47,7 +48,6 @@ const {
   zoomable,
   xAxisLabelRotation,
   yAxisIndex,
-  emitFilter,
 } = DEFAULT_FORM_DATA;
 
 function createQuerySection(label: string, controlSuffix: string): ControlPanelSectionConfig {
@@ -73,6 +73,14 @@ function createQuerySection(label: string, controlSuffix: string): ControlPanelS
           config: sharedControls.adhoc_filters,
         },
       ],
+      emitFilterControl.length > 0
+        ? [
+            {
+              ...emitFilterControl[0],
+              name: `emit_filter${controlSuffix}`,
+            },
+          ]
+        : [],
       [
         {
           name: `limit${controlSuffix}`,
@@ -244,20 +252,6 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['color_scheme', 'label_colors'],
-        isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
-          ? [
-              {
-                name: 'emit_filter',
-                config: {
-                  type: 'CheckboxControl',
-                  label: t('Enable emitting filters'),
-                  default: emitFilter,
-                  renderTrigger: true,
-                  description: t('Enable emmiting filters.'),
-                },
-              },
-            ]
-          : [],
         ...createCustomizeSection(t('Query A'), ''),
         ...createCustomizeSection(t('Query B'), 'B'),
         [

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { t } from '@superset-ui/core';
+import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelSectionConfig,
@@ -47,6 +47,7 @@ const {
   zoomable,
   xAxisLabelRotation,
   yAxisIndex,
+  emitFilter,
 } = DEFAULT_FORM_DATA;
 
 function createQuerySection(label: string, controlSuffix: string): ControlPanelSectionConfig {
@@ -243,6 +244,20 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['color_scheme', 'label_colors'],
+        isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
+          ? [
+              {
+                name: 'emit_filter',
+                config: {
+                  type: 'CheckboxControl',
+                  label: t('Enable emitting filters'),
+                  default: emitFilter,
+                  renderTrigger: true,
+                  description: t('Enable emmiting filters.'),
+                },
+              },
+            ]
+          : [],
         ...createCustomizeSection(t('Query A'), ''),
         ...createCustomizeSection(t('Query B'), 'B'),
         [

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin, AnnotationType } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
 import buildQuery from './buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from './transformProps';
@@ -43,6 +43,7 @@ export default class EchartsTimeseriesChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsMixedTimeseries'),
       metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
         category: t('Evolution'),
         credits: ['https://echarts.apache.org'],
         description: t(

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
@@ -21,8 +21,12 @@ import buildQuery from './buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
+import { EchartsMixedTimeseriesProps, EchartsMixedTimeseriesFormData } from './types';
 
-export default class EchartsTimeseriesChartPlugin extends ChartPlugin {
+export default class EchartsTimeseriesChartPlugin extends ChartPlugin<
+  EchartsMixedTimeseriesFormData,
+  EchartsMixedTimeseriesProps
+> {
   /**
    * The constructor is used to pass relevant metadata and callbacks that get
    * registered in respective registries that are used throughout the library
@@ -64,6 +68,7 @@ export default class EchartsTimeseriesChartPlugin extends ChartPlugin {
           t('Transformable'),
         ],
       }),
+      // @ts-ignore
       transformProps,
     });
   }

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -106,6 +106,7 @@ export default function transformProps(
     groupby,
     groupbyB,
     emitFilter,
+    emitFilterB,
   }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
@@ -141,20 +142,9 @@ export default function transformProps(
       seriesType,
       stack,
       yAxisIndex,
+      filterState,
     });
-    if (transformedSeries) {
-      series.push(transformedSeries);
-      const opacity =
-        filterState.selectedValues && !filterState.selectedValues.includes(transformedSeries.name)
-          ? OpacityEnum.SemiTransparent
-          : OpacityEnum.NonTransparent;
-      // @ts-ignore
-      transformedSeries.itemStyle.opacity = opacity;
-      // @ts-ignore
-      transformedSeries.lineStyle.opacity = opacity;
-      // @ts-ignore
-      transformedSeries.areaStyle.opacity = opacity;
-    }
+    if (transformedSeries) series.push(transformedSeries);
   });
   rawSeriesB.forEach(entry => {
     const transformedSeries = transformSeries(entry, colorScale, {
@@ -165,20 +155,9 @@ export default function transformProps(
       seriesType: seriesTypeB,
       stack: stackB,
       yAxisIndex: yAxisIndexB,
+      filterState,
     });
-    if (transformedSeries) {
-      series.push(transformedSeries);
-      const opacity =
-        filterState.selectedValues && !filterState.selectedValues.includes(transformedSeries.name)
-          ? OpacityEnum.SemiTransparent
-          : OpacityEnum.NonTransparent;
-      // @ts-ignore
-      transformedSeries.itemStyle.opacity = opacity;
-      // @ts-ignore
-      transformedSeries.lineStyle.opacity = opacity;
-      // @ts-ignore
-      transformedSeries.areaStyle.opacity = opacity;
-    }
+    if (transformedSeries) series.push(transformedSeries);
   });
 
   annotationLayers
@@ -210,7 +189,7 @@ export default function transformProps(
   const addYAxisLabelOffset = !!(yAxisTitle || yAxisTitleSecondary);
   const chartPadding = getPadding(showLegend, legendOrientation, addYAxisLabelOffset, zoomable);
 
-  const labelMapA = rawSeriesA.reduce((acc, datum) => {
+  const labelMap = rawSeriesA.reduce((acc, datum) => {
     const label = datum.name as string;
     return {
       ...acc,
@@ -225,33 +204,6 @@ export default function transformProps(
       [label]: label.split(', '),
     };
   }, {}) as Record<string, DataRecordValue[]>;
-
-  const selectedValuesA = (filterState.selectedValues || []).reduce(
-    (acc: Record<string, number>, selectedValue: string) => {
-      const index = rawSeriesA.findIndex(({ name }) => name === selectedValue);
-      if (index === -1) {
-        return { ...acc };
-      }
-      return {
-        ...acc,
-        [index]: selectedValue,
-      };
-    },
-    {},
-  );
-  const selectedValuesB = (filterState.selectedValues || []).reduce(
-    (acc: Record<string, number>, selectedValue: string) => {
-      const index = rawSeriesB.findIndex(({ name }) => name === selectedValue);
-      if (index === -1) {
-        return { ...acc };
-      }
-      return {
-        ...acc,
-        [index]: selectedValue,
-      };
-    },
-    {},
-  );
 
   const { setDataMask = () => {} } = hooks;
 
@@ -367,10 +319,11 @@ export default function transformProps(
     echartOptions,
     setDataMask,
     emitFilter,
-    labelMap: labelMapA,
+    emitFilterB,
+    labelMap,
     labelMapB,
     groupby,
     groupbyB,
-    selectedValues: { ...selectedValuesA, ...selectedValuesB },
+    selectedValues: filterState.selectedValues || [],
   };
 }

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -115,7 +115,6 @@ export default function transformProps(
   const rawSeriesB = extractTimeseriesSeries(rebaseTimeseriesDatum(data2), {
     fillNeighborValue: stackB ? 0 : undefined,
   });
-  debugger;
 
   const series: SeriesOption[] = [];
   const formatter = getNumberFormatter(contributionMode ? ',.0%' : yAxisFormat);

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -55,7 +55,7 @@ import {
   transformSeries,
   transformTimeseriesAnnotation,
 } from '../Timeseries/transformers';
-import { TIMESERIES_CONSTANTS, OpacityEnum } from '../constants';
+import { TIMESERIES_CONSTANTS } from '../constants';
 
 export default function transformProps(
   chartProps: EchartsMixedTimeseriesFormData,
@@ -324,6 +324,7 @@ export default function transformProps(
     labelMapB,
     groupby,
     groupbyB,
+    seriesBreakdown: rawSeriesA.length,
     selectedValues: filterState.selectedValues || [],
   };
 }

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -124,7 +124,6 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   zoomable: TIMESERIES_DEFAULTS.zoomable,
   richTooltip: TIMESERIES_DEFAULTS.richTooltip,
   xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,
-  emitFilter: false,
 };
 
 export interface EchartsMixedTimeseriesProps extends ChartProps {
@@ -138,6 +137,7 @@ export type EchartsMixedTimeseriesChartTransformedProps = {
   width: number;
   echartOptions: EChartsOption;
   emitFilter: boolean;
+  emitFilterB: boolean;
   setDataMask: SetDataMaskHook;
   groupby: string[];
   groupbyB: string[];

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -144,4 +144,5 @@ export type EchartsMixedTimeseriesChartTransformedProps = {
   labelMap: Record<string, DataRecordValue[]>;
   labelMapB: Record<string, DataRecordValue[]>;
   selectedValues: Record<number, string>;
+  seriesBreakdown: number;
 };

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -16,7 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { AnnotationLayer, TimeGranularity } from '@superset-ui/core';
+import { EChartsOption } from 'echarts';
+import {
+  AnnotationLayer,
+  TimeGranularity,
+  DataRecordValue,
+  SetDataMaskHook,
+  QueryFormData,
+  ChartProps,
+  ChartDataResponseResult,
+} from '@superset-ui/core';
 import { DEFAULT_LEGEND_FORM_DATA, EchartsLegendFormData } from '../types';
 import {
   DEFAULT_FORM_DATA as TIMESERIES_DEFAULTS,
@@ -24,7 +33,7 @@ import {
   EchartsTimeseriesSeriesType,
 } from '../Timeseries/types';
 
-export type EchartsMixedTimeseriesFormData = {
+export type EchartsMixedTimeseriesFormData = QueryFormData & {
   annotationLayers: AnnotationLayer[];
   // shared properties
   minorSplitLine: boolean;
@@ -68,8 +77,12 @@ export type EchartsMixedTimeseriesFormData = {
   stackB: boolean;
   yAxisIndex?: number;
   yAxisIndexB?: number;
+  groupby: string[];
+  groupbyB: string[];
+  emitFilter: boolean;
 } & EchartsLegendFormData;
 
+// @ts-ignore
 export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   ...DEFAULT_LEGEND_FORM_DATA,
   annotationLayers: [],
@@ -104,9 +117,31 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   stackB: TIMESERIES_DEFAULTS.stack,
   yAxisIndex: 0,
   yAxisIndexB: 0,
+  groupby: [],
+  groupbyB: [],
   xAxisShowMinLabel: TIMESERIES_DEFAULTS.xAxisShowMinLabel,
   xAxisShowMaxLabel: TIMESERIES_DEFAULTS.xAxisShowMaxLabel,
   zoomable: TIMESERIES_DEFAULTS.zoomable,
   richTooltip: TIMESERIES_DEFAULTS.richTooltip,
   xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,
+  emitFilter: false,
+};
+
+export interface EchartsMixedTimeseriesProps extends ChartProps {
+  formData: EchartsMixedTimeseriesFormData;
+  queriesData: ChartDataResponseResult[];
+}
+
+export type EchartsMixedTimeseriesChartTransformedProps = {
+  formData: EchartsMixedTimeseriesFormData;
+  height: number;
+  width: number;
+  echartOptions: EChartsOption;
+  emitFilter: boolean;
+  setDataMask: SetDataMaskHook;
+  groupby: string[];
+  groupbyB: string[];
+  labelMap: Record<string, DataRecordValue[]>;
+  labelMapB: Record<string, DataRecordValue[]>;
+  selectedValues: Record<number, string>;
 };


### PR DESCRIPTION
🏆 Enhancements
Add cross filter highlighting to MixdTimeSeries chart.

Both series support setting cross filter separately.
![image](https://user-images.githubusercontent.com/11830681/127746028-aed2529c-3e80-44f6-bc58-588f4fd12ba0.png)


https://user-images.githubusercontent.com/11830681/127747100-889620ec-7ece-43f8-b9c1-6577a6e1ccf1.mov



