### PR TITLE
fix(legacy-preset-chart-nvd3): dual line dnd control missing

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -102,6 +102,12 @@ export const dnd_adhoc_metric: SharedControlConfig<'DndMetricSelect'> = {
   description: t('Metric'),
 };
 
+export const dnd_adhoc_metric_2: SharedControlConfig<'DndMetricSelect'> = {
+  ...dnd_adhoc_metric,
+  label: t('Right Axis Metric'),
+  description: t('Choose a metric for right axis'),
+};
+
 export const dnd_sort_by: SharedControlConfig<'DndMetricSelect'> = {
   type: 'DndMetricSelect',
   label: t('Sort by'),

--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -78,6 +78,7 @@ import {
   dndEntity,
   dndGroupByControl,
   dndSeries,
+  dnd_adhoc_metric_2,
 } from './dndControls';
 
 const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
@@ -470,7 +471,7 @@ const sharedControls = {
   datasource: datasourceControl,
   viz_type,
   color_picker,
-  metric_2,
+  metric_2: enableExploreDnd ? dnd_adhoc_metric_2 : metric_2,
   linear_color_scheme,
   secondary_metric: enableExploreDnd ? dnd_secondary_metric : secondary_metric,
   groupby: enableExploreDnd ? dndGroupByControl : groupByControl,

--- a/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/DualLine/controlPanel.ts
@@ -39,12 +39,12 @@ const config: ControlPanelConfig = {
     {
       label: t('Y Axis 1'),
       expanded: true,
-      controlSetRows: [['metric', 'y_axis_format'], [yAxisShowMinmax], [yAxisBounds]],
+      controlSetRows: [['metric'], ['y_axis_format'], [yAxisShowMinmax], [yAxisBounds]],
     },
     {
       label: t('Y Axis 2'),
       expanded: true,
-      controlSetRows: [['metric_2', yAxis2Format], [yAxis2ShowMinmax], [yAxis2Bounds]],
+      controlSetRows: [['metric_2'], [yAxis2Format], [yAxis2ShowMinmax], [yAxis2Bounds]],
     },
     {
       label: t('Query'),


### PR DESCRIPTION
1 of the controls in Dual Line chart was still using the old UI, even with DND feature flag on. This PR fixes it.
I also moved some controls to separate rows to avoid ugly overflow.

Before: https://github.com/apache/superset/issues/16018
After:
![image](https://user-images.githubusercontent.com/15073128/127853132-5f277d28-f113-4fe7-b8a5-0e5e5d872236.png)

CC: @jinghua-qa @junlincc 