### PR TITLE
fix(plugin-chart-echarts): missing dnd control in tree chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Tree/controlPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { t } from '@superset-ui/core';
+import { FeatureFlag, isFeatureEnabled, t } from '@superset-ui/core';
 import { ControlPanelConfig, sections, sharedControls } from '@superset-ui/chart-controls';
 import { DEFAULT_FORM_DATA } from './types';
 
@@ -85,7 +85,9 @@ const controlPanel: ControlPanelConfig = {
             name: 'metric',
             config: {
               ...optionalEntity,
-              type: 'MetricsControl',
+              type: isFeatureEnabled(FeatureFlag.ENABLE_EXPLORE_DRAG_AND_DROP)
+                ? 'DndMetricSelect'
+                : 'MetricsControl',
               label: t('Metric'),
               description: t('Metric for node values'),
             },


### PR DESCRIPTION
Metric control in Tree chart was using the old UI even with DnD flag enabled. This PR fixes it.

Before: https://github.com/apache/superset/issues/16021
After:
![image](https://user-images.githubusercontent.com/15073128/127866791-e1a2319c-2657-4754-ac6e-23a832825481.png)

CC @jinghua-qa @junlincc 