### PR TITLE
fix(plugin-chart-pivot-table): make date formatting clearable

### DIFF
--- a/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
@@ -217,7 +217,6 @@ const config: ControlPanelConfig = {
               label: t('Date format'),
               default: smartDateFormatter.id,
               renderTrigger: true,
-              clearable: false,
               choices: D3_TIME_FORMAT_OPTIONS,
               description: t('D3 time format for datetime columns'),
             },


### PR DESCRIPTION
Before there was no way to disable date formatting to see the original value of temporal column in pivot table. This PR enables clearing the select button value.

https://user-images.githubusercontent.com/15073128/127890757-204a2287-be36-4b89-9815-5b2d7479108b.mov

Fixes https://github.com/apache/superset/issues/15947

CC @junlincc @jinghua-qa