### PR TITLE
fix(legacy-plugin-chart-sunburst): move color scheme controls to own row

### DIFF
--- a/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
+++ b/plugins/legacy-plugin-chart-sunburst/src/controlPanel.ts
@@ -46,7 +46,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Chart Options'),
       expanded: true,
-      controlSetRows: [['color_scheme', 'linear_color_scheme']],
+      controlSetRows: [['color_scheme'], ['linear_color_scheme']],
     },
   ],
   controlOverrides: {


### PR DESCRIPTION
🐛 Bug Fix

Move Sunburst chart color scheme controls to separate rows.

### AFTER

![image](https://user-images.githubusercontent.com/33317356/127975776-e6cb9cbc-a94f-4ee3-8132-2474ef49d987.png)

### BEFORE

![image](https://user-images.githubusercontent.com/33317356/127975849-2563f67c-b5d9-49d0-b28b-d48cc750fe01.png)
