### PR TITLE
fix(plugin-chart-pivot-table): dont display nulls as 0

### DIFF
--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -54,7 +54,7 @@ const iconStyle = { stroke: 'black', strokeWidth: '16px' };
 const aggregatorsFactory = (formatter: NumberFormatter) => ({
   Count: aggregatorTemplates.count(formatter),
   'Count Unique Values': aggregatorTemplates.countUnique(formatter),
-  'List Unique Values': aggregatorTemplates.listUnique(', '),
+  'List Unique Values': aggregatorTemplates.listUnique(', ', formatter),
   Sum: aggregatorTemplates.sum(formatter),
   Average: aggregatorTemplates.average(formatter),
   Median: aggregatorTemplates.median(formatter),
@@ -62,7 +62,7 @@ const aggregatorsFactory = (formatter: NumberFormatter) => ({
   'Sample Standard Deviation': aggregatorTemplates.stdev(1, formatter),
   Minimum: aggregatorTemplates.min(formatter),
   Maximum: aggregatorTemplates.max(formatter),
-  First: aggregatorTemplates.first(),
+  First: aggregatorTemplates.first(formatter),
   Last: aggregatorTemplates.last(formatter),
   'Sum as Fraction of Total': aggregatorTemplates.fractionOf(
     aggregatorTemplates.sum(),
@@ -147,11 +147,13 @@ export default function PivotTableChart(props: PivotTableProps) {
       data.reduce(
         (acc: Record<string, any>[], record: Record<string, any>) => [
           ...acc,
-          ...metricNames.map((name: string) => ({
-            ...record,
-            [METRIC_KEY]: name,
-            value: record[name],
-          })),
+          ...metricNames
+            .map((name: string) => ({
+              ...record,
+              [METRIC_KEY]: name,
+              value: record[name],
+            }))
+            .filter(record => record.value !== null),
         ],
         [],
       ),


### PR DESCRIPTION
Before, we were displaying nulls as zeros when using "Sum" aggregate function. Now we filter out the nulls before passing them to the pivot table, so they are not included in the calculations.

Before: see https://github.com/apache/superset/issues/15938
After:
![image](https://user-images.githubusercontent.com/15073128/128018851-9fc84f45-7a47-44f9-bd6c-ceee35e73a67.png)

CC @junlincc @jinghua-qa