### PR TITLE
fix(plugin-chart-pivot-table): dont apply colors to subtotals

### DIFF
--- a/plugins/plugin-chart-pivot-table/package.json
+++ b/plugins/plugin-chart-pivot-table/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@superset-ui/chart-controls": "0.17.77",
     "@superset-ui/core": "0.17.75",
-    "@superset-ui/react-pivottable": "^0.12.10"
+    "@superset-ui/react-pivottable": "^0.12.11"
   },
   "peerDependencies": {
     "@ant-design/icons": "^4.2.2",

--- a/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
@@ -300,7 +300,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'ConditionalFormattingControl',
               renderTrigger: true,
-              label: t('Customize metrics'),
+              label: t('Conditional formatting'),
               description: t('Apply conditional color formatting to metrics'),
               mapStateToProps(explore) {
                 const values = (explore?.controls?.metrics?.value as QueryFormMetric[]) ?? [];


### PR DESCRIPTION
This PR excludes subtotals from conditional formatting coloring to match the old Heatmap table feature

![image](https://user-images.githubusercontent.com/15073128/128141972-de6bdcad-1022-4d84-b842-1c00656d5caa.png)

