### PR TITLE
fix(plugin-chart-echarts): fix null labels on pie and funnel charts

### DIFF
--- a/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -50,13 +50,15 @@ export function formatFunnelLabel({
   params,
   labelType,
   numberFormatter,
+  sanitizeName = false,
 }: {
-  params: CallbackDataParams;
+  params: Pick<CallbackDataParams, 'name' | 'value' | 'percent'>;
   labelType: EchartsFunnelLabelTypeType;
   numberFormatter: NumberFormatter;
+  sanitizeName?: boolean;
 }): string {
   const { name: rawName = '', value, percent } = params;
-  const name = sanitizeHtml(rawName);
+  const name = sanitizeName ? sanitizeHtml(rawName) : rawName;
   const formattedValue = numberFormatter(value as number);
   const formattedPercent = percentFormatter((percent as number) / 100);
   switch (labelType) {

--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -51,13 +51,15 @@ export function formatPieLabel({
   params,
   labelType,
   numberFormatter,
+  sanitizeName = false,
 }: {
-  params: CallbackDataParams;
+  params: Pick<CallbackDataParams, 'name' | 'value' | 'percent'>;
   labelType: EchartsPieLabelType;
   numberFormatter: NumberFormatter;
+  sanitizeName?: boolean;
 }): string {
   const { name: rawName = '', value, percent } = params;
-  const name = sanitizeHtml(rawName);
+  const name = sanitizeName ? sanitizeHtml(rawName) : rawName;
   const formattedValue = numberFormatter(value as number);
   const formattedPercent = percentFormatter((percent as number) / 100);
 
@@ -221,6 +223,7 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
           params,
           numberFormatter,
           labelType: EchartsPieLabelType.KeyValuePercent,
+          sanitizeName: true,
         }),
     },
     legend: {

--- a/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
+++ b/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
@@ -102,5 +102,20 @@ describe('formatFunnelLabel', () => {
         labelType: EchartsFunnelLabelTypeType.KeyValuePercent,
       }),
     ).toEqual('My Label: 1.23k (12.34%)');
+    expect(
+      formatFunnelLabel({
+        params: { ...params, name: '<NULL>' },
+        numberFormatter,
+        labelType: EchartsFunnelLabelTypeType.Key,
+      }),
+    ).toEqual('<NULL>');
+    expect(
+      formatFunnelLabel({
+        params: { ...params, name: '<NULL>' },
+        numberFormatter,
+        labelType: EchartsFunnelLabelTypeType.Key,
+        sanitizeName: true,
+      }),
+    ).toEqual('&lt;NULL&gt;');
   });
 });

--- a/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
+++ b/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
@@ -16,17 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChartProps, getNumberFormatter } from '@superset-ui/core';
+import { ChartProps, getNumberFormatter, SqlaFormData } from '@superset-ui/core';
 import transformProps, { formatPieLabel } from '../../src/Pie/transformProps';
 import { EchartsPieLabelType } from '../../src/Pie/types';
 
 describe('Pie tranformProps', () => {
-  const formData = {
+  const formData: SqlaFormData = {
     colorScheme: 'bnbColors',
     datasource: '3__table',
     granularity_sqla: 'ds',
     metric: 'sum__num',
     groupby: ['foo', 'bar'],
+    viz_type: 'my_viz',
   };
   const chartProps = new ChartProps({
     formData,
@@ -91,5 +92,20 @@ describe('formatPieLabel', () => {
     expect(
       formatPieLabel({ params, numberFormatter, labelType: EchartsPieLabelType.KeyValuePercent }),
     ).toEqual('My Label: 1.23k (12.34%)');
+    expect(
+      formatPieLabel({
+        params: { ...params, name: '<NULL>' },
+        numberFormatter,
+        labelType: EchartsPieLabelType.Key,
+      }),
+    ).toEqual('<NULL>');
+    expect(
+      formatPieLabel({
+        params: { ...params, name: '<NULL>' },
+        numberFormatter,
+        labelType: EchartsPieLabelType.Key,
+        sanitizeName: true,
+      }),
+    ).toEqual('&lt;NULL&gt;');
   });
 });


### PR DESCRIPTION
🐛 Bug Fix

Remove label escaping in Pie and Funnel charts that were causing hml escaping where it wasn't needed. Closes https://github.com/apache/superset/issues/16057

### AFTER
![image](https://user-images.githubusercontent.com/33317356/128184454-cabdd4c8-e4ab-4ab0-b513-f75d0ecf02cb.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/128184521-ae5c7441-32c7-49cf-80cd-dfb4c90cc597.png)
