### PR TITLE
fix(legacy-preset-chart-nvd3): bar chart unexpected error

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
@@ -16,8 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, validateNonEmpty } from '@superset-ui/core';
-import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
+import { ensureIsArray, t, validateNonEmpty } from '@superset-ui/core';
+import {
+  ColumnMeta,
+  ControlPanelConfig,
+  sections,
+  sharedControls,
+} from '@superset-ui/chart-controls';
 import {
   showLegend,
   showControls,
@@ -107,10 +112,24 @@ const config: ControlPanelConfig = {
     groupby: {
       label: t('Series'),
       validators: [validateNonEmpty],
+      mapStateToProps: (state, controlState) => {
+        const groupbyProps = sharedControls.groupby.mapStateToProps?.(state, controlState) || {};
+        groupbyProps.canDropValue = (column: ColumnMeta) =>
+          !ensureIsArray(state.controls.columns.value).includes(column.column_name);
+        return groupbyProps;
+      },
+      rerender: ['columns'],
     },
     columns: {
       label: t('Breakdowns'),
       description: t('Defines how each series is broken down'),
+      mapStateToProps: (state, controlState) => {
+        const columnsProps = sharedControls.columns.mapStateToProps?.(state, controlState) || {};
+        columnsProps.canDropValue = (column: ColumnMeta) =>
+          !ensureIsArray(state.controls.groupby.value).includes(column.column_name);
+        return columnsProps;
+      },
+      rerender: ['groupby'],
     },
   },
 };

--- a/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
+++ b/plugins/legacy-preset-chart-nvd3/src/DistBar/controlPanel.ts
@@ -115,7 +115,7 @@ const config: ControlPanelConfig = {
       mapStateToProps: (state, controlState) => {
         const groupbyProps = sharedControls.groupby.mapStateToProps?.(state, controlState) || {};
         groupbyProps.canDropValue = (column: ColumnMeta) =>
-          !ensureIsArray(state.controls.columns.value).includes(column.column_name);
+          !ensureIsArray(state.controls?.columns?.value).includes(column.column_name);
         return groupbyProps;
       },
       rerender: ['columns'],
@@ -126,7 +126,7 @@ const config: ControlPanelConfig = {
       mapStateToProps: (state, controlState) => {
         const columnsProps = sharedControls.columns.mapStateToProps?.(state, controlState) || {};
         columnsProps.canDropValue = (column: ColumnMeta) =>
-          !ensureIsArray(state.controls.groupby.value).includes(column.column_name);
+          !ensureIsArray(state.controls?.groupby?.value).includes(column.column_name);
         return columnsProps;
       },
       rerender: ['groupby'],


### PR DESCRIPTION
Bar chart doesn't allow "Series" and "Breakdown" controls to overlap. If user adds the same column to those controls, we get "Unexpected error". This PR disallows adding a column to "Breakdown" if it's already in "Series" (and the other way around too) when drag and drop is enabled.

Requires https://github.com/apache/superset/pull/16090 to work

Fixes https://github.com/apache/superset/issues/16071

https://user-images.githubusercontent.com/15073128/128378703-bbebd2ae-a948-4fce-a0bf-bd61cf7c8b1a.mov

CC @junlincc @jinghua-qa