### PR TITLE
fix: Match Pivot Table V2 style with Pivot Table

### DIFF
--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -40,11 +40,32 @@ import {
 } from './types';
 
 const Styles = styled.div<PivotTableStylesProps>`
-  ${({ height, width, margin }) => `
+  ${({ height, width, margin, borderColor }) => `
       margin: ${margin}px;
       height: ${height - margin * 2}px;
       width: ${width - margin * 2}px;
       overflow-y: scroll;
+
+      table.pvtTable thead tr th,
+      table.pvtTable tbody tr th {
+        border-top: 1px solid ${borderColor};
+        border-left: 1px solid ${borderColor};
+      }
+      table.pvtTable tbody tr td {
+        border-left: 1px solid ${borderColor};
+      }
+      table.pvtTable tbody tr td:last-child,
+      table.pvtTable thead tr th:last-child:not(.pvtSubtotalLabel) {
+        border-right: 1px solid ${borderColor};
+      }
+      table.pvtTable thead tr:last-child th,
+      table.pvtTable thead tr:first-child th.pvtTotalLabel,
+      table.pvtTable thead tr:nth-last-child(2) th.pvtColLabel,
+      table.pvtTable thead th.pvtSubtotalLabel,
+      table.pvtTable tbody tr:last-child th,
+      table.pvtTable tbody tr:last-child td {
+        border-bottom: 1px solid ${borderColor};
+      }
  `}
 `;
 
@@ -249,7 +270,12 @@ export default function PivotTableChart(props: PivotTableProps) {
   );
 
   return (
-    <Styles height={height} width={width} margin={theme.gridUnit * 4}>
+    <Styles
+      height={height}
+      width={width}
+      margin={theme.gridUnit * 4}
+      borderColor={theme.colors.grayscale.light2}
+    >
       <PivotTable
         data={unpivotedData}
         rows={rows}

--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -40,11 +40,18 @@ import {
 } from './types';
 
 const Styles = styled.div<PivotTableStylesProps>`
-  ${({ height, width, margin, borderColor }) => `
+  ${({ borderColor, fontFamily, fontSize, height, margin, width }) => `
       margin: ${margin}px;
       height: ${height - margin * 2}px;
       width: ${width - margin * 2}px;
       overflow-y: scroll;
+
+      table.pvtTable th,
+      table.pvtTable td {
+        font-family: ${fontFamily};
+        font-size: ${fontSize}px;
+        line-height: 1.4;
+      }
 
       table.pvtTable thead tr th,
       table.pvtTable tbody tr th {
@@ -275,6 +282,8 @@ export default function PivotTableChart(props: PivotTableProps) {
       width={width}
       margin={theme.gridUnit * 4}
       borderColor={theme.colors.grayscale.light2}
+      fontFamily={theme.typography.families.sansSerif}
+      fontSize={theme.typography.sizes.s}
     >
       <PivotTable
         data={unpivotedData}

--- a/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/plugins/plugin-chart-pivot-table/src/types.ts
@@ -34,6 +34,8 @@ export interface PivotTableStylesProps {
   width: number;
   margin: number;
   borderColor: string;
+  fontFamily: string;
+  fontSize: number;
 }
 
 export type FilterType = Record<string, DataRecordValue>;

--- a/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/plugins/plugin-chart-pivot-table/src/types.ts
@@ -33,6 +33,7 @@ export interface PivotTableStylesProps {
   height: number;
   width: number;
   margin: number;
+  borderColor: string;
 }
 
 export type FilterType = Record<string, DataRecordValue>;


### PR DESCRIPTION
### SUMMARY

This PR changes the border color, font family and font size of the Pivot Table V2 to match those of the original Pivot Table

Fixes: https://github.com/apache/superset/issues/15826

### BEFORE
<img width="1117" alt="Screen Shot 2021-07-21 at 2 16 20 PM" src="https://user-images.githubusercontent.com/81597121/126561769-61352469-491a-4599-a7ae-3df70ef58730.png">

### AFTER

![Screen Shot 2021-08-09 at 17 36 32](https://user-images.githubusercontent.com/60598000/128733359-207b61af-883f-4fe1-a08b-3113c9be4651.png)

