### PR TITLE
feat(plugin-chart-table): add support for temporal x-filter

### DIFF
--- a/packages/superset-ui-core/src/query/types/Filter.ts
+++ b/packages/superset-ui-core/src/query/types/Filter.ts
@@ -6,11 +6,14 @@ import {
   isBinaryOperator,
   isSetOperator,
 } from './Operator';
+import { TimeGranularity } from '../../time-format';
 
 interface BaseSimpleAdhocFilter {
   expressionType: 'SIMPLE';
   clause: 'WHERE' | 'HAVING';
   subject: string;
+  timeGrain?: TimeGranularity;
+  isExtra?: boolean;
 }
 
 export type UnaryAdhocFilter = BaseSimpleAdhocFilter & {

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -29,6 +29,8 @@ import { TimeGranularity } from '../../time-format';
 
 export type QueryObjectFilterClause = {
   col: string;
+  grain?: TimeGranularity;
+  isExtra?: boolean;
 } & (
   | {
       op: BinaryOperator;

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -206,6 +206,7 @@ const transformProps = (chartProps: TableChartProps): TableChartTransformedProps
     show_totals: showTotals,
     conditional_formatting: conditionalFormatting,
   } = formData;
+  const timeGrain = extractTimegrain(formData);
 
   const [metrics, percentMetrics, columns] = processColumns(chartProps);
 
@@ -249,6 +250,7 @@ const transformProps = (chartProps: TableChartProps): TableChartTransformedProps
     emitFilter,
     onChangeFilter,
     columnColorFormatters,
+    timeGrain,
   };
 };
 

--- a/plugins/plugin-chart-table/src/types.ts
+++ b/plugins/plugin-chart-table/src/types.ts
@@ -83,6 +83,7 @@ export interface TableChartProps extends ChartProps {
 }
 
 export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
+  timeGrain?: TimeGranularity;
   height: number;
   width: number;
   rowCount?: number;

--- a/plugins/plugin-chart-table/src/utils/DateWithFormatter.ts
+++ b/plugins/plugin-chart-table/src/utils/DateWithFormatter.ts
@@ -31,7 +31,10 @@ export default class DateWithFormatter extends Date {
 
   constructor(
     input: DataRecordValue,
-    { formatter = String, forceUTC = true }: { formatter?: TimeFormatFunction; forceUTC?: boolean },
+    {
+      formatter = String,
+      forceUTC = true,
+    }: { formatter?: TimeFormatFunction; forceUTC?: boolean } = {},
   ) {
     let value = input;
     // assuming timestamps without a timezone is in UTC time


### PR DESCRIPTION
🏆 Enhancements
🐛 Bug Fix

Add support for emitting temporal time filters with time grain. Also add missing `isExtra` property to `BaseSimpleAdhocFilter` and `QueryObjectFilterClause` signatures.

### AFTER
https://user-images.githubusercontent.com/33317356/128667009-3999c26b-5e9a-466e-96af-616f2f39fb87.mp4

### BEFORE
https://user-images.githubusercontent.com/33317356/128667541-475dfdab-b86b-4deb-a891-46096b0341ad.mp4
