### PR TITLE
fix: 0 indicator on radar viz

### DIFF
--- a/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
@@ -19,6 +19,7 @@
 import {
   CategoricalColorNamespace,
   DataRecordValue,
+  ensureIsInt,
   getMetricLabel,
   getNumberFormatter,
   getTimeFormatter,
@@ -100,6 +101,7 @@ export default function transformProps(
 
   const metricsLabel = metrics.map(metric => getMetricLabel(metric));
 
+  const metricLabelAndMaxValueMap = new Map<string, number>();
   const columnsLabelMap = new Map<string, DataRecordValue[]>();
   const transformedData: RadarSeriesDataItemOption[] = [];
   data.forEach(datum => {
@@ -114,6 +116,21 @@ export default function transformProps(
       joinedName,
       groupby.map(col => datum[col]),
     );
+
+    // put max value of series into metricLabelAndMaxValueMap
+    for (const [metricLabel, value] of Object.entries(datum)) {
+      if (metricLabelAndMaxValueMap.has(metricLabel)) {
+        metricLabelAndMaxValueMap.set(
+          metricLabel,
+          Math.max(
+            value as number,
+            ensureIsInt(metricLabelAndMaxValueMap.get(metricLabel), Number.MIN_SAFE_INTEGER),
+          ),
+        );
+      } else {
+        metricLabelAndMaxValueMap.set(metricLabel, value as number);
+      }
+    }
 
     const isFiltered =
       filterState.selectedValues && !filterState.selectedValues.includes(joinedName);
@@ -148,10 +165,19 @@ export default function transformProps(
     {},
   );
 
-  const indicator = metricsLabel.map(metricLabel => ({
-    name: metricLabel,
-    max: columnConfig?.[metricLabel]?.radarMetricMaxValue,
-  }));
+  const indicator = metricsLabel.map(metricLabel => {
+    const maxValueInControl = columnConfig?.[metricLabel]?.radarMetricMaxValue;
+    // Ensure that 0 is at the center of the polar coordinates
+    const metricValueAsMax =
+      metricLabelAndMaxValueMap.get(metricLabel) === 0
+        ? Number.MAX_SAFE_INTEGER
+        : metricLabelAndMaxValueMap.get(metricLabel);
+    const max = maxValueInControl === null ? metricValueAsMax : maxValueInControl;
+    return {
+      name: metricLabel,
+      max,
+    };
+  });
 
   const series: RadarSeriesOption[] = [
     {

--- a/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
@@ -118,6 +118,7 @@ export default function transformProps(
     );
 
     // put max value of series into metricLabelAndMaxValueMap
+    // eslint-disable-next-line no-restricted-syntax
     for (const [metricLabel, value] of Object.entries(datum)) {
       if (metricLabelAndMaxValueMap.has(metricLabel)) {
         metricLabelAndMaxValueMap.set(


### PR DESCRIPTION
🐛 Bug Fix
closes: https://github.com/apache/superset/issues/16120

### before
![image](https://user-images.githubusercontent.com/67837651/128543887-8cafce57-9378-48f2-9f41-0381aeda9b63.png)


### after
![image](https://user-images.githubusercontent.com/2016594/128692880-18cf7711-6d6a-45f3-a179-4d70abc30a23.png)

### Test instructions
- Select `cleaned_sales_data` dataset
- Open explore page and switch to Radar Chart
- Add sum(sales), avg(sales) and sum(0) metrics into Chart
- Run query, the sum(0) metric at the center of polar coordinates.