### PR TITLE
fix: Hide Safari default tooltip

### DIFF
--- a/packages/superset-ui-chart-controls/package.json
+++ b/packages/superset-ui-chart-controls/package.json
@@ -26,6 +26,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@emotion/react": "^11.4.1",
     "@react-icons/all-files": "^4.1.0",
     "@superset-ui/core": "0.17.75",
     "lodash": "^4.17.15",

--- a/packages/superset-ui-chart-controls/package.json
+++ b/packages/superset-ui-chart-controls/package.json
@@ -26,13 +26,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@emotion/react": "^11.4.1",
     "@react-icons/all-files": "^4.1.0",
     "@superset-ui/core": "0.17.75",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
+    "@emotion/react": "^11.1.5",
     "@types/react": "*",
     "antd": "^4.9.4",
     "react": "^16.13.1"

--- a/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
+++ b/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
@@ -23,10 +23,10 @@ export const Tooltip = ({ overlayStyle, color, ...props }: TooltipProps) => {
           }
         `}
       />
-    <BaseTooltip
-      overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6', ...overlayStyle }}
-      color={defaultColor || color}
-      {...props}
+      <BaseTooltip
+        overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6', ...overlayStyle }}
+        color={defaultColor || color}
+        {...props}
       />
     </>
   );

--- a/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
+++ b/packages/superset-ui-chart-controls/src/components/Tooltip.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { useTheme } from '@superset-ui/core';
+import { useTheme, css } from '@superset-ui/core';
 import { Tooltip as BaseTooltip } from 'antd';
 import { TooltipProps } from 'antd/lib/tooltip';
+import { Global } from '@emotion/react';
 
 export { TooltipProps } from 'antd/lib/tooltip';
 
@@ -9,11 +10,25 @@ export const Tooltip = ({ overlayStyle, color, ...props }: TooltipProps) => {
   const theme = useTheme();
   const defaultColor = `${theme.colors.grayscale.dark2}e6`;
   return (
+    <>
+      {/* Safari hack to hide browser default tooltips */}
+      <Global
+        styles={css`
+          .ant-tooltip-open {
+            display: inline-block;
+            &::after {
+              content: '';
+              display: block;
+            }
+          }
+        `}
+      />
     <BaseTooltip
       overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6', ...overlayStyle }}
       color={defaultColor || color}
       {...props}
-    />
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
### SUMMARY
This PR implements a small hack to prevent Safari from showing its default tooltip when a text is truncated and a custom Antdesign tooltip is already present.

### RELATED PR ON SUPERSET
https://github.com/apache/superset/pull/16145

### BEFORE
![Screen Shot 2021-08-09 at 16 50 59](https://user-images.githubusercontent.com/60598000/128726808-419d5aa7-d15a-4a51-89d8-cf98abe19d14.png)

### AFTER
![Screen Shot 2021-08-09 at 16 48 47](https://user-images.githubusercontent.com/60598000/128726836-de53e31b-87fc-4a98-bfc5-89b902c20c51.png)
