### PR TITLE
fix(chart-controls): lower minOpacity in conditional formatting

### DIFF
--- a/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -83,7 +83,7 @@ export const getColorFunction = (
   }
   switch (operator) {
     case COMPARATOR.NONE:
-      minOpacity = 0.05;
+      minOpacity = 0;
       comparatorFunction = (value: number, allValues: number[]) => {
         const cutoffValue = Math.min(...allValues);
         const extremeValue = Math.max(...allValues);

--- a/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -30,19 +30,23 @@ export const round = (num: number, precision = 0) =>
 export const rgbToRgba = (rgb: string, alpha: number) =>
   rgb.replace(/rgb/i, 'rgba').replace(/\)/i, `,${alpha})`);
 
-export const getOpacity = (value: number, cutoffPoint: number, extremeValue: number) => {
-  const MIN_OPACITY = 0.3;
-  const MAX_OPACITY = 1;
-
-  return extremeValue === cutoffPoint
-    ? MAX_OPACITY
+const MIN_OPACITY = 0.05;
+const MAX_OPACITY = 1;
+export const getOpacity = (
+  value: number,
+  cutoffPoint: number,
+  extremeValue: number,
+  minOpacity = MIN_OPACITY,
+  maxOpacity = MAX_OPACITY,
+) =>
+  extremeValue === cutoffPoint
+    ? maxOpacity
     : round(
         Math.abs(
-          ((MAX_OPACITY - MIN_OPACITY) / (extremeValue - cutoffPoint)) * (value - cutoffPoint),
-        ) + MIN_OPACITY,
+          ((maxOpacity - minOpacity) / (extremeValue - cutoffPoint)) * (value - cutoffPoint),
+        ) + minOpacity,
         2,
       );
-};
 
 export const getColorFunction = (
   {
@@ -54,6 +58,9 @@ export const getColorFunction = (
   }: ConditionalFormattingConfig,
   columnValues: number[],
 ) => {
+  let minOpacity = MIN_OPACITY;
+  const maxOpacity = MAX_OPACITY;
+
   let comparatorFunction: (
     value: number,
     allValues: number[],
@@ -76,6 +83,7 @@ export const getColorFunction = (
   }
   switch (operator) {
     case COMPARATOR.NONE:
+      minOpacity = 0.05;
       comparatorFunction = (value: number, allValues: number[]) => {
         const cutoffValue = Math.min(...allValues);
         const extremeValue = Math.max(...allValues);
@@ -158,7 +166,10 @@ export const getColorFunction = (
     const compareResult = comparatorFunction(value, columnValues);
     if (compareResult === false) return undefined;
     const { cutoffValue, extremeValue } = compareResult;
-    return rgbToRgba(colorScheme, getOpacity(value, cutoffValue, extremeValue));
+    return rgbToRgba(
+      colorScheme,
+      getOpacity(value, cutoffValue, extremeValue, minOpacity, maxOpacity),
+    );
   };
 };
 

--- a/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -30,13 +30,14 @@ export const round = (num: number, precision = 0) =>
 export const rgbToRgba = (rgb: string, alpha: number) =>
   rgb.replace(/rgb/i, 'rgba').replace(/\)/i, `,${alpha})`);
 
-const MIN_OPACITY = 0.05;
+const MIN_OPACITY_BOUNDED = 0.05;
+const MIN_OPACITY_UNBOUNDED = 0;
 const MAX_OPACITY = 1;
 export const getOpacity = (
   value: number,
   cutoffPoint: number,
   extremeValue: number,
-  minOpacity = MIN_OPACITY,
+  minOpacity = MIN_OPACITY_BOUNDED,
   maxOpacity = MAX_OPACITY,
 ) =>
   extremeValue === cutoffPoint
@@ -58,7 +59,7 @@ export const getColorFunction = (
   }: ConditionalFormattingConfig,
   columnValues: number[],
 ) => {
-  let minOpacity = MIN_OPACITY;
+  let minOpacity = MIN_OPACITY_BOUNDED;
   const maxOpacity = MAX_OPACITY;
 
   let comparatorFunction: (
@@ -83,7 +84,7 @@ export const getColorFunction = (
   }
   switch (operator) {
     case COMPARATOR.NONE:
-      minOpacity = 0;
+      minOpacity = MIN_OPACITY_UNBOUNDED;
       comparatorFunction = (value: number, allValues: number[]) => {
         const cutoffValue = Math.min(...allValues);
         const extremeValue = Math.max(...allValues);

--- a/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -46,9 +46,11 @@ describe('round', () => {
 describe('getOpacity', () => {
   it('getOpacity', () => {
     expect(getOpacity(100, 100, 100)).toEqual(1);
-    expect(getOpacity(75, 50, 100)).toEqual(0.65);
-    expect(getOpacity(75, 100, 50)).toEqual(0.65);
-    expect(getOpacity(100, 100, 50)).toEqual(0.3);
+    expect(getOpacity(75, 50, 100)).toEqual(0.53);
+    expect(getOpacity(75, 100, 50)).toEqual(0.53);
+    expect(getOpacity(100, 100, 50)).toEqual(0.05);
+    expect(getOpacity(100, 100, 100, 0, 0.8)).toEqual(0.8);
+    expect(getOpacity(100, 100, 50, 0, 1)).toEqual(0);
   });
 });
 
@@ -97,7 +99,7 @@ describe('getColorFunction()', () => {
       },
       countValues,
     );
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.3)');
+    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.05)');
     expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
     expect(colorFunction(0)).toBeUndefined();
   });
@@ -113,7 +115,7 @@ describe('getColorFunction()', () => {
       countValues,
     );
     expect(colorFunction(50)).toEqual('rgba(255,0,0,1)');
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,0.3)');
+    expect(colorFunction(100)).toEqual('rgba(255,0,0,0.05)');
     expect(colorFunction(150)).toBeUndefined();
   });
 
@@ -143,7 +145,7 @@ describe('getColorFunction()', () => {
     );
     expect(colorFunction(60)).toBeUndefined();
     expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.48)');
+    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.29)');
 
     colorFunction = getColorFunction(
       {
@@ -155,7 +157,7 @@ describe('getColorFunction()', () => {
       countValues,
     );
     expect(colorFunction(90)).toBeUndefined();
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,0.48)');
+    expect(colorFunction(100)).toEqual('rgba(255,0,0,0.29)');
     expect(colorFunction(50)).toEqual('rgba(255,0,0,1)');
   });
 
@@ -171,7 +173,7 @@ describe('getColorFunction()', () => {
       countValues,
     );
     expect(colorFunction(50)).toBeUndefined();
-    expect(colorFunction(100)).toEqual('rgba(255,0,0,0.65)');
+    expect(colorFunction(100)).toEqual('rgba(255,0,0,0.53)');
   });
 
   it('getColorFunction BETWEEN_OR_EQUAL', () => {
@@ -185,7 +187,7 @@ describe('getColorFunction()', () => {
       },
       countValues,
     );
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.3)');
+    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.05)');
     expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
     expect(colorFunction(150)).toBeUndefined();
   });
@@ -201,7 +203,7 @@ describe('getColorFunction()', () => {
       },
       countValues,
     );
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.3)');
+    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.05)');
     expect(colorFunction(100)).toBeUndefined();
   });
 
@@ -289,8 +291,8 @@ describe('getColorFunction()', () => {
       countValues,
     );
     expect(colorFunction(20)).toEqual(undefined);
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.3)');
-    expect(colorFunction(75)).toEqual('rgba(255,0,0,0.65)');
+    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.05)');
+    expect(colorFunction(75)).toEqual('rgba(255,0,0,0.53)');
     expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
     expect(colorFunction(120)).toEqual(undefined);
   });
@@ -364,7 +366,7 @@ describe('getColorFormatters()', () => {
     expect(colorFormatters[1].getColorFromValue(400)).toBeUndefined();
 
     expect(colorFormatters[2].column).toEqual('count');
-    expect(colorFormatters[2].getColorFromValue(100)).toEqual('rgba(255,0,0,0.65)');
+    expect(colorFormatters[2].getColorFromValue(100)).toEqual('rgba(255,0,0,0.53)');
   });
 
   it('undefined column config', () => {

--- a/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -291,8 +291,8 @@ describe('getColorFunction()', () => {
       countValues,
     );
     expect(colorFunction(20)).toEqual(undefined);
-    expect(colorFunction(50)).toEqual('rgba(255,0,0,0.05)');
-    expect(colorFunction(75)).toEqual('rgba(255,0,0,0.53)');
+    expect(colorFunction(50)).toEqual('rgba(255,0,0,0)');
+    expect(colorFunction(75)).toEqual('rgba(255,0,0,0.5)');
     expect(colorFunction(100)).toEqual('rgba(255,0,0,1)');
     expect(colorFunction(120)).toEqual(undefined);
   });


### PR DESCRIPTION
Before, the minimal opacity for values coloured with conditional formatting was 0.3. That value turned out to be too large, as the low values were not contrasting with the high values. This PR changes minimal opacity to 0 for "None" operator and 0.05 for other operators

Before:
<img width="1792" alt="Screenshot 2021-08-09 at 17 24 05" src="https://user-images.githubusercontent.com/15073128/128734120-181c12a0-3818-4e02-b146-ea0e9aef5cc3.png">

After:
<img width="1792" alt="Screenshot 2021-08-09 at 17 22 32" src="https://user-images.githubusercontent.com/15073128/128734148-69f6a4c3-c6a8-4bce-abcf-ad89fbe852f1.png">

Fixes https://github.com/apache/superset/issues/16099

CC @graceguo-supercat @junlincc 