### PR TITLE
chore: change Highly-used back to Popular

### DIFF
--- a/plugins/legacy-plugin-chart-world-map/src/index.js
+++ b/plugins/legacy-plugin-chart-world-map/src/index.js
@@ -39,7 +39,7 @@ const metadata = new ChartMetadata({
     t('Multi-Layers'),
     t('Multi-Variables'),
     t('Scatter'),
-    t('Highly-used'),
+    t('Popular'),
   ],
   thumbnail,
   useLegacyApi: true,

--- a/plugins/legacy-preset-chart-big-number/src/BigNumber/index.ts
+++ b/plugins/legacy-preset-chart-big-number/src/BigNumber/index.ts
@@ -34,7 +34,7 @@ const metadata = new ChartMetadata({
     t('Formattable'),
     t('Line'),
     t('Percentages'),
-    t('Highly-used'),
+    t('Popular'),
     t('Report'),
     t('Description'),
     t('Trend'),

--- a/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/index.ts
+++ b/plugins/legacy-preset-chart-big-number/src/BigNumberTotal/index.ts
@@ -42,7 +42,7 @@ const metadata = new ChartMetadata({
     t('Formattable'),
     t('Legacy'),
     t('Percentages'),
-    t('Highly-used'),
+    t('Popular'),
     t('Report'),
     t('Description'),
   ],

--- a/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -43,7 +43,7 @@ const metadata = new ChartMetadata({
     t('Discrete'),
     t('Legacy'),
     t('Percentages'),
-    t('Highly-used'),
+    t('Popular'),
     t('Stacked'),
     t('Vertical'),
     t('nvd3'),

--- a/plugins/plugin-chart-echarts/src/Pie/index.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/index.ts
@@ -66,7 +66,7 @@ export default class EchartsPieChartPlugin extends ChartPlugin<
           t('Circular'),
           t('Comparison'),
           t('Percentages'),
-          t('Highly-used'),
+          t('Popular'),
           t('Proportional'),
           t('ECharts'),
         ],

--- a/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts
@@ -73,7 +73,7 @@ export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
           t('Line'),
           t('Transformable'),
           t('Stacked'),
-          t('Highly-used'),
+          t('Popular'),
         ],
         thumbnail,
       }),

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
@@ -70,7 +70,7 @@ export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
           t('Stacked'),
           t('Vertical'),
           t('Bar'),
-          t('Highly-used'),
+          t('Popular'),
         ],
         thumbnail,
       }),

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
@@ -65,7 +65,7 @@ export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
           t('Advanced-Analytics'),
           t('Aesthetic'),
           t('Line'),
-          t('Highly-used'),
+          t('Popular'),
         ],
         thumbnail,
       }),

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
@@ -66,7 +66,7 @@ export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
           t('Time'),
           t('Transformable'),
           t('Scatter'),
-          t('Highly-used'),
+          t('Popular'),
         ],
         thumbnail,
       }),

--- a/plugins/plugin-chart-pivot-table/src/plugin/index.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/index.ts
@@ -52,7 +52,7 @@ export default class PivotTableChartPlugin extends ChartPlugin<
         'Used to summarize a set of data by grouping together multiple statistics along two axes. Examples: Sales numbers by region and month, tasks by status and assignee, active users by age and location. Not the most visually stunning visualization, but highly informative and versatile.',
       ),
       name: t('Pivot Table v2'),
-      tags: [t('Additive'), t('Report'), t('Tabular'), t('Highly-used')],
+      tags: [t('Additive'), t('Report'), t('Tabular'), t('Popular')],
       thumbnail,
     });
 


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

Addressing requests to change "Highly Used" tag to "Popular" as was originally implemented. The version bump for these packages will need to coincide with a similar change on the Superset side.

🐛 Bug Fix

🏠 Internal
