### PR TITLE
chore(plugin-chart-pivot-table): change fontsize and border colors

### DIFF
--- a/plugins/plugin-chart-pivot-table/package.json
+++ b/plugins/plugin-chart-pivot-table/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@superset-ui/chart-controls": "0.17.80",
     "@superset-ui/core": "0.17.80",
-    "@superset-ui/react-pivottable": "^0.12.11"
+    "@superset-ui/react-pivottable": "^0.12.12"
   },
   "peerDependencies": {
     "@ant-design/icons": "^4.2.2",


### PR DESCRIPTION
Bump react-pivottable version.
Changes:
font size (12px), border colors (#e0e0e0) and line height (1.4) matching Table chart.

![image](https://user-images.githubusercontent.com/15073128/128855628-6e65ff26-b90b-41a0-90e6-97ea2b0b63d9.png)

This PR replaces https://github.com/apache-superset/superset-ui/pull/1277