### PR TITLE
fix(plugin-chart-echarts): fix Time-series line x-filtering not working when not rich tooltip

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -145,6 +145,7 @@ export default function transformProps(
       showValue,
       totalStackedValues,
       showValueIndexes,
+      richTooltip,
     });
     if (transformedSeries) series.push(transformedSeries);
   });

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -130,6 +130,11 @@ export function transformSeries(
   } else {
     plotType = seriesType === 'bar' ? 'bar' : 'line';
   }
+  const itemStyle = {
+    color: colorScale(forecastSeries.name),
+    opacity,
+  };
+  let emphasis = {};
   let showSymbol = false;
   let symbolSize = markerSize;
   if (!isConfidenceBand) {
@@ -143,7 +148,13 @@ export function transformSeries(
       // this is hack to make timeseries line chart clickable when tooltip trigger way is 'item'
       // so that the chart can emit cross-filtering
       showSymbol = true;
-      symbolSize = 0.1;
+      symbolSize = 10;
+      itemStyle.opacity = 0;
+      emphasis = {
+        itemStyle: {
+          opacity: 1,
+        },
+      };
     } else if (markerEnabled) {
       showSymbol = true;
     }
@@ -153,10 +164,7 @@ export function transformSeries(
     ...series,
     yAxisIndex,
     name: forecastSeries.name,
-    itemStyle: {
-      color: colorScale(forecastSeries.name),
-      opacity,
-    },
+    itemStyle,
     // @ts-ignore
     type: plotType,
     smooth: seriesType === 'smooth',
@@ -170,6 +178,7 @@ export function transformSeries(
           ? opacity * areaOpacity
           : 0,
     },
+    emphasis,
     showSymbol,
     symbolSize,
     label: {

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -136,7 +136,6 @@ export function transformSeries(
   };
   let emphasis = {};
   let showSymbol = false;
-  let symbolSize = markerSize;
   if (!isConfidenceBand) {
     if (plotType === 'scatter') {
       showSymbol = true;
@@ -145,10 +144,9 @@ export function transformSeries(
     } else if (plotType === 'line' && showValue) {
       showSymbol = true;
     } else if (plotType === 'line' && !richTooltip && !markerEnabled) {
-      // this is hack to make timeseries line chart clickable when tooltip trigger way is 'item'
+      // this is hack to make timeseries line chart clickable when tooltip trigger is 'item'
       // so that the chart can emit cross-filtering
       showSymbol = true;
-      symbolSize = 10;
       itemStyle.opacity = 0;
       emphasis = {
         itemStyle: {
@@ -180,7 +178,7 @@ export function transformSeries(
     },
     emphasis,
     showSymbol,
-    symbolSize,
+    symbolSize: markerSize,
     label: {
       show: !!showValue,
       position: 'top',

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -78,6 +78,7 @@ export function transformSeries(
     formatter?: NumberFormatter;
     totalStackedValues?: number[];
     showValueIndexes?: number[];
+    richTooltip?: boolean;
   },
 ): SeriesOption | undefined {
   const { name } = series;
@@ -95,6 +96,7 @@ export function transformSeries(
     formatter,
     totalStackedValues = [],
     showValueIndexes = [],
+    richTooltip,
   } = opts;
 
   const forecastSeries = extractForecastSeriesContext(name || '');
@@ -129,6 +131,7 @@ export function transformSeries(
     plotType = seriesType === 'bar' ? 'bar' : 'line';
   }
   let showSymbol = false;
+  let symbolSize = markerSize;
   if (!isConfidenceBand) {
     if (plotType === 'scatter') {
       showSymbol = true;
@@ -136,6 +139,11 @@ export function transformSeries(
       showSymbol = true;
     } else if (plotType === 'line' && showValue) {
       showSymbol = true;
+    } else if (plotType === 'line' && !richTooltip && !markerEnabled) {
+      // this is hack to make timeseries line chart clickable when tooltip trigger way is 'item'
+      // so that the chart can emit cross-filtering
+      showSymbol = true;
+      symbolSize = 0.1;
     } else if (markerEnabled) {
       showSymbol = true;
     }
@@ -163,7 +171,7 @@ export function transformSeries(
           : 0,
     },
     showSymbol,
-    symbolSize: markerSize,
+    symbolSize,
     label: {
       show: !!showValue,
       position: 'top',


### PR DESCRIPTION
🐛 Bug Fix
https://github.com/apache/superset/issues/16070

this is hack to make timeseries line chart clickable when tooltip trigger is 'item' (see https://echarts.apache.org/en/option.html#tooltip.trigger),  so that the chart can emit cross-filtering.

### after

https://user-images.githubusercontent.com/11830681/129067504-1ef36ba3-2a2e-49bf-b2a7-05e6b95ee4cd.mov

