### PR TITLE
fix(plugin-chart-echarts): fix temporary filters

### DIFF
--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -73,7 +73,7 @@ function createQuerySection(label: string, controlSuffix: string): ControlPanelS
           config: {
             ...sharedControls.adhoc_filters,
             mapStateToProps: (state, controlState) => ({
-              ...(sharedControls?.adhoc_filters?.mapStateToProps?.(state, controlState) || {}),
+              ...(sharedControls.adhoc_filters?.mapStateToProps?.(state, controlState) || {}),
               value: [
                 ...((state?.controls?.adhoc_filters?.value as any[]) || []).filter(
                   filter => filter.isExtra,

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -72,17 +72,15 @@ function createQuerySection(label: string, controlSuffix: string): ControlPanelS
           name: `adhoc_filters${controlSuffix}`,
           config: {
             ...sharedControls.adhoc_filters,
-            mapStateToProps: (state, controlState) => {
-              return {
-                ...(sharedControls?.adhoc_filters?.mapStateToProps?.(state, controlState) || {}),
-                value: [
-                  ...((state?.controls?.adhoc_filters?.value as any[]) || []).filter(
-                    filter => filter.isExtra,
-                  ),
-                  ...((state?.controls?.adhoc_filters_2?.value as any[]) || []),
-                ],
-              };
-            },
+            mapStateToProps: (state, controlState) => ({
+              ...(sharedControls?.adhoc_filters?.mapStateToProps?.(state, controlState) || {}),
+              value: [
+                ...((state?.controls?.adhoc_filters?.value as any[]) || []).filter(
+                  filter => filter.isExtra,
+                ),
+                ...((state?.controls?.adhoc_filters_2?.value as any[]) || []),
+              ],
+            }),
           },
         },
       ],

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -70,7 +70,20 @@ function createQuerySection(label: string, controlSuffix: string): ControlPanelS
       [
         {
           name: `adhoc_filters${controlSuffix}`,
-          config: sharedControls.adhoc_filters,
+          config: {
+            ...sharedControls.adhoc_filters,
+            mapStateToProps: (state, controlState) => {
+              return {
+                ...(sharedControls?.adhoc_filters?.mapStateToProps?.(state, controlState) || {}),
+                value: [
+                  ...((state?.controls?.adhoc_filters?.value as any[]) || []).filter(
+                    filter => filter.isExtra,
+                  ),
+                  ...((state?.controls?.adhoc_filters_2?.value as any[]) || []),
+                ],
+              };
+            },
+          },
         },
       ],
       emitFilterControl.length > 0
@@ -269,30 +282,6 @@ const config: ControlPanelConfig = {
         ...legendSection,
         [<h1 className="section-header">{t('X Axis')}</h1>],
         ['x_axis_time_format'],
-        [
-          {
-            name: 'xAxisShowMinLabel',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Show Min Label'),
-              default: true,
-              renderTrigger: true,
-              description: t('Show Min Label'),
-            },
-          },
-        ],
-        [
-          {
-            name: 'xAxisShowMaxLabel',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Show Max Label'),
-              default: true,
-              renderTrigger: true,
-              description: t('Show Max Label'),
-            },
-          },
-        ],
         [
           {
             name: 'xAxisLabelRotation',

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -92,8 +92,6 @@ export default function transformProps(
     tooltipTimeFormat,
     yAxisFormat,
     yAxisFormatSecondary,
-    xAxisShowMinLabel,
-    xAxisShowMaxLabel,
     xAxisTimeFormat,
     yAxisBounds,
     yAxisIndex,
@@ -216,8 +214,6 @@ export default function transformProps(
     xAxis: {
       type: 'time',
       axisLabel: {
-        showMinLabel: xAxisShowMinLabel,
-        showMaxLabel: xAxisShowMaxLabel,
         formatter: xAxisFormatter,
         rotate: xAxisLabelRotation,
       },

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -53,8 +53,6 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   zoomable: boolean;
   richTooltip: boolean;
   xAxisLabelRotation: number;
-  xAxisShowMinLabel?: boolean;
-  xAxisShowMaxLabel?: boolean;
   colorScheme?: string;
   // types specific to Query A and Query B
   area: boolean;
@@ -119,8 +117,6 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   yAxisIndexB: 0,
   groupby: [],
   groupbyB: [],
-  xAxisShowMinLabel: TIMESERIES_DEFAULTS.xAxisShowMinLabel,
-  xAxisShowMaxLabel: TIMESERIES_DEFAULTS.xAxisShowMaxLabel,
   zoomable: TIMESERIES_DEFAULTS.zoomable,
   richTooltip: TIMESERIES_DEFAULTS.richTooltip,
   xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -64,8 +64,6 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   truncateYAxis: boolean;
   yAxisFormat?: string;
   yAxisTitle: string;
-  xAxisShowMinLabel?: boolean;
-  xAxisShowMaxLabel?: boolean;
   xAxisTimeFormat?: string;
   timeGrainSqla?: TimeGranularity;
   yAxisBounds: [number | undefined | null, number | undefined | null];


### PR DESCRIPTION
🐛 Bug Fix

When going from the dashboard to Explore view with extra filters (native filters or filter box), the filters are only appended to the first query. In this PR we add the first query's adhoc filters that have `isExtra` set to true. In addition, the `showMinLabel` and `showMaxLabel` contrls are removed, as they're no longer used in the main Timeseries chart.

Tested to work both with native filters and filter box.

Closes https://github.com/apache/superset/issues/15858

### AFTER 
Notice how the same temporary filter is available in both Query A and Query B
![image](https://user-images.githubusercontent.com/33317356/129183040-40f62814-3f34-4467-ae03-e53726327f2d.png)

### BEFORE
Notice how the temporary filter is missing from Query B:
![image](https://user-images.githubusercontent.com/33317356/129183339-dcc2a167-d317-4987-9558-42f61de5b8e1.png)
