### PR TITLE
chore: removing errant label from two charts that don't have AA (but should)

### DIFF
--- a/plugins/legacy-plugin-chart-time-table/src/index.ts
+++ b/plugins/legacy-plugin-chart-time-table/src/index.ts
@@ -28,7 +28,6 @@ const metadata = new ChartMetadata({
     'Compare multiple time series charts (as sparklines) and related metrics quickly. ',
   ),
   tags: [
-    t('Advanced-Analytics'),
     t('Multi-Variables'),
     t('Comparison'),
     t('Legacy'),

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
@@ -58,7 +58,6 @@ export default class EchartsTimeseriesChartPlugin extends ChartPlugin<
         name: t('Mixed Time-Series'),
         thumbnail,
         tags: [
-          t('Advanced-Analytics'),
           t('Aesthetic'),
           t('ECharts'),
           t('Experimental'),


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation
Removing the `Advanced Analytics` label from these charts since... well... they don't have Advanced Analytics.

🐛 Bug Fix

🏠 Internal
