### PR TITLE
fix(plugin-chart-echarts): default to use node name for color category

### DIFF
--- a/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Graph/controlPanel.tsx
@@ -66,10 +66,12 @@ const controlPanel: ControlPanelConfig = {
             name: 'source_category',
             config: {
               ...optionalEntity,
-              label: t('Source category'),
+              label: t('Source color category'),
               description: t(
-                'The category of source nodes used to assign colors. ' +
-                  'If a node is associated with more than one category, only the first will be used.',
+                'The column used to determine the color of the source node and ' +
+                  'line. Leave blank to use the source column value to determine ' +
+                  'the color. If a node is associated with more than one category, ' +
+                  'only the first will be used.',
               ),
             },
           },
@@ -79,8 +81,12 @@ const controlPanel: ControlPanelConfig = {
             name: 'target_category',
             config: {
               ...optionalEntity,
-              label: t('Target category'),
-              description: t('Category of target nodes'),
+              label: t('Target color category'),
+              description: t(
+                'The column used to detrmine the color of the target ' +
+                  'node. Leave blank to use the target column value to determine ' +
+                  'the color.',
+              ),
             },
           },
         ],

--- a/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
@@ -195,6 +195,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
         category,
         select: DEFAULT_GRAPH_SERIES_OPTION.select,
         tooltip: DEFAULT_GRAPH_SERIES_OPTION.tooltip,
+        itemStyle: category ? {} : { color: colorFn(name) },
       });
     }
     const node = echartNodes[nodes[name]];
@@ -232,7 +233,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
       source: sourceNode.id,
       target: targetNode.id,
       value,
-      lineStyle: {},
+      lineStyle: sourceCategory ? {} : { color: colorFn(sourceName!) },
       emphasis: {},
       select: {},
     });


### PR DESCRIPTION
🐛 Bug Fix

When a source or target color hasn't been chosen, the color scheme isn't used. This changes the behavior so that the node name will be used to determine the color when a category hasn't been chosen. This matches how colors are usually picked by other charts. When a the source or target color column has been chosen the behavior is unchanged. In addition, the control name and descriptions are updated to be more explanatory.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/129349222-8df84fee-0bf5-43fc-a0b9-657e948ae849.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/129349389-26ed8ad1-cde0-4d2f-92df-3fbb9a632719.png)
