### PR TITLE
fix: Make the scrollbar appear inside the table  

### DIFF
--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -49,8 +49,9 @@ const Styles = styled.div<PivotTableStylesProps>`
 
 const PivotTableWrapper = styled.div`
   height: 100%;
+  max-width: 100%;
+  overflow: auto;
   width: min-content;
-  overflow-y: auto;
 `;
 
 const METRIC_KEY = 'metric';

--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -49,9 +49,8 @@ const Styles = styled.div<PivotTableStylesProps>`
 
 const PivotTableWrapper = styled.div`
   height: 100%;
-  max-width: 100%;
+  max-width: fit-content;
   overflow: auto;
-  width: min-content;
 `;
 
 const METRIC_KEY = 'metric';

--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -44,8 +44,13 @@ const Styles = styled.div<PivotTableStylesProps>`
       margin: ${margin}px;
       height: ${height - margin * 2}px;
       width: ${width - margin * 2}px;
-      overflow-y: scroll;
  `}
+`;
+
+const PivotTableWrapper = styled.div`
+  height: 100%;
+  width: min-content;
+  overflow-y: auto;
 `;
 
 const METRIC_KEY = 'metric';
@@ -250,42 +255,44 @@ export default function PivotTableChart(props: PivotTableProps) {
 
   return (
     <Styles height={height} width={width} margin={theme.gridUnit * 4}>
-      <PivotTable
-        data={unpivotedData}
-        rows={rows}
-        cols={cols}
-        aggregatorsFactory={aggregatorsFactory}
-        defaultFormatter={defaultFormatter}
-        customFormatters={
-          hasCustomMetricFormatters ? { [METRIC_KEY]: metricFormatters } : undefined
-        }
-        aggregatorName={aggregateFunction}
-        vals={['value']}
-        rendererName="Table With Subtotal"
-        colOrder={colOrder}
-        rowOrder={rowOrder}
-        sorters={{
-          metric: sortAs(metricNames),
-        }}
-        tableOptions={{
-          clickRowHeaderCallback: toggleFilter,
-          clickColumnHeaderCallback: toggleFilter,
-          colTotals,
-          rowTotals,
-          highlightHeaderCellsOnHover: emitFilter,
-          highlightedHeaderCells: selectedFilters,
-          omittedHighlightHeaderGroups: [METRIC_KEY],
-          cellColorFormatters: { [METRIC_KEY]: metricColorFormatters },
-          dateFormatters,
-        }}
-        subtotalOptions={{
-          colSubtotalDisplay: { displayOnTop: colSubtotalPosition },
-          rowSubtotalDisplay: { displayOnTop: rowSubtotalPosition },
-          arrowCollapsed: <PlusSquareOutlined style={iconStyle} />,
-          arrowExpanded: <MinusSquareOutlined style={iconStyle} />,
-        }}
-        namesMapping={verboseMap}
-      />
+      <PivotTableWrapper>
+        <PivotTable
+          data={unpivotedData}
+          rows={rows}
+          cols={cols}
+          aggregatorsFactory={aggregatorsFactory}
+          defaultFormatter={defaultFormatter}
+          customFormatters={
+            hasCustomMetricFormatters ? { [METRIC_KEY]: metricFormatters } : undefined
+          }
+          aggregatorName={aggregateFunction}
+          vals={['value']}
+          rendererName="Table With Subtotal"
+          colOrder={colOrder}
+          rowOrder={rowOrder}
+          sorters={{
+            metric: sortAs(metricNames),
+          }}
+          tableOptions={{
+            clickRowHeaderCallback: toggleFilter,
+            clickColumnHeaderCallback: toggleFilter,
+            colTotals,
+            rowTotals,
+            highlightHeaderCellsOnHover: emitFilter,
+            highlightedHeaderCells: selectedFilters,
+            omittedHighlightHeaderGroups: [METRIC_KEY],
+            cellColorFormatters: { [METRIC_KEY]: metricColorFormatters },
+            dateFormatters,
+          }}
+          subtotalOptions={{
+            colSubtotalDisplay: { displayOnTop: colSubtotalPosition },
+            rowSubtotalDisplay: { displayOnTop: rowSubtotalPosition },
+            arrowCollapsed: <PlusSquareOutlined style={iconStyle} />,
+            arrowExpanded: <MinusSquareOutlined style={iconStyle} />,
+          }}
+          namesMapping={verboseMap}
+        />
+      </PivotTableWrapper>
     </Styles>
   );
 }


### PR DESCRIPTION
### SUMMARY

This PR only solves an issue with the scrollbar not appearing in the table container but at the far right. Read [this comment](https://github.com/apache/superset/issues/15935#issuecomment-897699534) for context 

### BEFORE

https://user-images.githubusercontent.com/60598000/129375411-4e61d037-2a27-4762-a6f7-13848813e763.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/129585796-2fe468b7-1dfa-4367-9459-34a3f3fb5c5b.mp4


### TESTING INSTRUCTIONS

1. Open Explore with a Pivot Table V2 viz
2. Observe the table and scroll
3. Make sure the scrollbar appears within the table container

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/15935
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
