### PR TITLE
feat(plugin-chart-echarts): add only_total control to ts chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -32,7 +32,7 @@ import {
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
 } from '../types';
-import { legendSection, showValueControl } from '../../controls';
+import { legendSection, showValueSection } from '../../controls';
 
 const {
   contributionMode,
@@ -135,7 +135,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [showValueControl],
+        ...showValueSection,
         [
           {
             name: 'stack',

--- a/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -138,18 +138,6 @@ const config: ControlPanelConfig = {
         ...showValueSection,
         [
           {
-            name: 'stack',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Stack series'),
-              renderTrigger: true,
-              default: stack,
-              description: t('Stack series on top of each other'),
-            },
-          },
-        ],
-        [
-          {
             name: 'markerEnabled',
             config: {
               type: 'CheckboxControl',

--- a/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -43,7 +43,6 @@ const {
   opacity,
   rowLimit,
   seriesType,
-  stack,
   tooltipTimeFormat,
   truncateYAxis,
   yAxisBounds,

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -98,18 +98,6 @@ const config: ControlPanelConfig = {
         ...showValueSection,
         [
           {
-            name: 'stack',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Stack series'),
-              renderTrigger: true,
-              default: stack,
-              description: t('Stack series on top of each other'),
-            },
-          },
-        ],
-        [
-          {
             name: 'markerEnabled',
             config: {
               type: 'CheckboxControl',

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -37,7 +37,6 @@ const {
   markerSize,
   minorSplitLine,
   rowLimit,
-  stack,
   tooltipTimeFormat,
   truncateYAxis,
   yAxisBounds,

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -28,7 +28,7 @@ import {
 } from '@superset-ui/chart-controls';
 
 import { DEFAULT_FORM_DATA, EchartsTimeseriesContributionType } from '../types';
-import { legendSection, showValueControl } from '../../controls';
+import { legendSection, showValueSection } from '../../controls';
 
 const {
   contributionMode,
@@ -95,7 +95,7 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['color_scheme', 'label_colors'],
-        [showValueControl],
+        ...showValueSection,
         [
           {
             name: 'stack',

--- a/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -43,7 +43,6 @@ const {
   minorSplitLine,
   opacity,
   rowLimit,
-  stack,
   tooltipTimeFormat,
   truncateYAxis,
   yAxisBounds,

--- a/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -32,7 +32,7 @@ import {
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
 } from '../types';
-import { legendSection, showValueControl } from '../../controls';
+import { legendSection, showValueSection } from '../../controls';
 
 const {
   area,
@@ -120,7 +120,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [showValueControl],
+        ...showValueSection,
         [
           {
             name: 'stack',

--- a/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -123,18 +123,6 @@ const config: ControlPanelConfig = {
         ...showValueSection,
         [
           {
-            name: 'stack',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Stack series'),
-              renderTrigger: true,
-              default: stack,
-              description: t('Stack series on top of each other'),
-            },
-          },
-        ],
-        [
-          {
             name: 'area',
             config: {
               type: 'CheckboxControl',

--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -44,7 +44,6 @@ const {
   opacity,
   rowLimit,
   seriesType,
-  stack,
   tooltipTimeFormat,
   truncateYAxis,
   yAxisBounds,

--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -126,18 +126,6 @@ const config: ControlPanelConfig = {
         ...showValueSection,
         [
           {
-            name: 'stack',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Stack series'),
-              renderTrigger: true,
-              default: stack,
-              description: t('Stack series on top of each other'),
-            },
-          },
-        ],
-        [
-          {
             name: 'area',
             config: {
               type: 'CheckboxControl',

--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -32,7 +32,7 @@ import {
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
 } from './types';
-import { legendSection, showValueControl } from '../controls';
+import { legendSection, showValueSection } from '../controls';
 
 const {
   area,
@@ -123,7 +123,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [showValueControl],
+        ...showValueSection,
         [
           {
             name: 'stack',

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -96,6 +96,7 @@ export default function transformProps(
     emitFilter,
     groupby,
     showValue,
+    onlyTotal,
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
@@ -109,18 +110,18 @@ export default function transformProps(
   const totalStackedValues: number[] = [];
   const showValueIndexes: number[] = [];
 
-  if (stack) {
-    rebasedData.forEach(data => {
-      const values = Object.keys(data).reduce((prev, curr) => {
-        if (curr === '__timestamp') {
-          return prev;
-        }
-        const value = data[curr] || 0;
-        return prev + (value as number);
-      }, 0);
-      totalStackedValues.push(values);
-    });
+  rebasedData.forEach(data => {
+    const values = Object.keys(data).reduce((prev, curr) => {
+      if (curr === '__timestamp') {
+        return prev;
+      }
+      const value = data[curr] || 0;
+      return prev + (value as number);
+    }, 0);
+    totalStackedValues.push(values);
+  });
 
+  if (stack) {
     rawSeries.forEach((entry, seriesIndex) => {
       const { data = [] } = entry;
       (data as [Date, number][]).forEach((datum, dataIndex) => {
@@ -143,6 +144,7 @@ export default function transformProps(
       stack,
       formatter,
       showValue,
+      onlyTotal,
       totalStackedValues,
       showValueIndexes,
       richTooltip,

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -191,10 +191,7 @@ export function transformSeries(
           seriesIndex,
         } = params;
         if (!formatter) return numericValue;
-        if (!stack) {
-          if (onlyTotal) {
-            return formatter(totalStackedValues[dataIndex]);
-          }
+        if (!stack || !onlyTotal) {
           return formatter(numericValue);
         }
         if (seriesIndex === showValueIndexes[dataIndex]) {

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -75,6 +75,7 @@ export function transformSeries(
     stack?: boolean;
     yAxisIndex?: number;
     showValue?: boolean;
+    onlyTotal?: boolean;
     formatter?: NumberFormatter;
     totalStackedValues?: number[];
     showValueIndexes?: number[];
@@ -93,6 +94,7 @@ export function transformSeries(
     stack,
     yAxisIndex = 0,
     showValue,
+    onlyTotal,
     formatter,
     totalStackedValues = [],
     showValueIndexes = [],
@@ -188,16 +190,17 @@ export function transformSeries(
           dataIndex,
           seriesIndex,
         } = params;
-        if (formatter) {
-          if (!stack) {
-            return formatter(numericValue);
-          }
-          if (seriesIndex === showValueIndexes[dataIndex]) {
+        if (!formatter) return numericValue;
+        if (!stack) {
+          if (onlyTotal) {
             return formatter(totalStackedValues[dataIndex]);
           }
-          return '';
+          return formatter(numericValue);
         }
-        return numericValue;
+        if (seriesIndex === showValueIndexes[dataIndex]) {
+          return formatter(totalStackedValues[dataIndex]);
+        }
+        return '';
       },
     },
   };

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -76,6 +76,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   emitFilter: boolean;
   groupby: string[];
   showValue: boolean;
+  onlyTotal: boolean;
 } & EchartsLegendFormData;
 
 // @ts-ignore
@@ -108,6 +109,7 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   groupby: [],
   yAxisTitle: '',
   showValue: false,
+  onlyTotal: false,
 };
 
 export interface EchartsTimeseriesChartProps extends ChartProps {

--- a/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/plugins/plugin-chart-echarts/src/controls.tsx
@@ -94,7 +94,7 @@ export const legendSection = [
   [legendMarginControl],
 ];
 
-export const showValueControl = {
+const showValueControl = {
   name: 'show_value',
   config: {
     type: 'CheckboxControl',
@@ -104,3 +104,17 @@ export const showValueControl = {
     description: t('Show series values on the chart'),
   },
 };
+
+const onlyTotalControl = {
+  name: 'only_total',
+  config: {
+    type: 'CheckboxControl',
+    label: t('Only Total'),
+    default: false,
+    renderTrigger: true,
+    description: t('Only show the total value on the chart'),
+    visibility: ({ controls }: ControlPanelsContainerProps) => Boolean(controls?.show_value?.value),
+  },
+};
+
+export const showValueSection = [[showValueControl], [onlyTotalControl]];

--- a/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/plugins/plugin-chart-echarts/src/controls.tsx
@@ -105,16 +105,28 @@ const showValueControl = {
   },
 };
 
+const stackControl = {
+  name: 'stack',
+  config: {
+    type: 'CheckboxControl',
+    label: t('Stack series'),
+    renderTrigger: true,
+    default: false,
+    description: t('Stack series on top of each other'),
+  },
+};
+
 const onlyTotalControl = {
   name: 'only_total',
   config: {
     type: 'CheckboxControl',
     label: t('Only Total'),
-    default: false,
+    default: true,
     renderTrigger: true,
-    description: t('Only show the total value on the chart'),
-    visibility: ({ controls }: ControlPanelsContainerProps) => Boolean(controls?.show_value?.value),
+    description: t('Only show the total value on the stacked chart'),
+    visibility: ({ controls }: ControlPanelsContainerProps) =>
+      Boolean(controls?.show_value?.value) && Boolean(controls?.stack?.value),
   },
 };
 
-export const showValueSection = [[showValueControl], [onlyTotalControl]];
+export const showValueSection = [[showValueControl], [stackControl], [onlyTotalControl]];


### PR DESCRIPTION
🏆 Enhancements
releated to https://github.com/apache-superset/superset-ui/pull/1279
closes https://github.com/apache/superset/issues/16063

#### individual values
![image](https://user-images.githubusercontent.com/11830681/129914823-b3885207-e2d8-4af4-8ed8-7c72a7125e6a.png)

#### total values
![image](https://user-images.githubusercontent.com/11830681/129914795-98aa3593-be49-49d4-8d21-e5c7e6aa71a9.png)
