### PR TITLE
feat(core): hide chart when all metrics values are null

### DIFF
--- a/packages/superset-ui-core/src/chart/components/NoResultsComponent.tsx
+++ b/packages/superset-ui-core/src/chart/components/NoResultsComponent.tsx
@@ -25,17 +25,21 @@ type Props = {
   height: number | string;
   id?: string;
   width: number | string;
+  title?: string;
+  message?: string;
 };
 
-const NoResultsComponent = ({ className, height, id, width }: Props) => {
+const NoResultsComponent = ({ className, height, id, width, title, message }: Props) => {
   const containerStyles = useMemo(() => generateContainerStyles(height, width), [height, width]);
 
   // render the body if the width is auto/100% or greater than 250 pixels
   const shouldRenderBody = typeof width === 'string' || width > MIN_WIDTH_FOR_BODY;
 
-  const BODY_STRING = t(
-    'No results were returned for this query. If you expected results to be returned, ensure any filters are configured properly and the datasource contains data for the selected time range.',
-  );
+  const BODY_STRING =
+    message ||
+    t(
+      'No results were returned for this query. If you expected results to be returned, ensure any filters are configured properly and the datasource contains data for the selected time range.',
+    );
 
   return (
     <div
@@ -45,7 +49,7 @@ const NoResultsComponent = ({ className, height, id, width }: Props) => {
       title={shouldRenderBody ? undefined : BODY_STRING}
     >
       <div style={MESSAGE_STYLES}>
-        <div style={TITLE_STYLES}>{t('No Results')}</div>
+        <div style={TITLE_STYLES}>{title || t('No Results')}</div>
         {shouldRenderBody && <div style={BODY_STYLES}>{BODY_STRING}</div>}
       </div>
     </div>

--- a/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -135,16 +135,21 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
       enableNoResults &&
       (!queriesData ||
         queriesData.every(({ data }) => !data || (Array.isArray(data) && data.length === 0)));
-    const metricLabels = ensureIsArray(chartProps.formData?.metrics || chartProps.formData?.metric)
-      .map((metric: AdhocMetric | string) => (typeof metric === 'string' ? metric : metric.label))
-      .filter(Boolean);
-    const hasNullMetrics =
-      metricLabels.length > 0 &&
-      metricLabels.every(label =>
-        queriesData?.every(({ data }) =>
-          ensureIsArray(data).every(record => record[label!] === null),
-        ),
-      );
+    let hasNullMetrics = false;
+    if (chartProps.formData?.disallowNullMetrics) {
+      const metricLabels = ensureIsArray(
+        chartProps.formData?.metrics || chartProps.formData?.metric,
+      )
+        .map((metric: AdhocMetric | string) => (typeof metric === 'string' ? metric : metric.label))
+        .filter(Boolean);
+      hasNullMetrics =
+        metricLabels.length > 0 &&
+        metricLabels.every(label =>
+          queriesData?.every(({ data }) =>
+            ensureIsArray(data).every(record => record[label!] === null),
+          ),
+        );
+    }
     if (noResultQueries) {
       chart = <NoResultsComponent id={id} className={className} height={height} width={width} />;
     } else if (hasNullMetrics) {

--- a/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -7,6 +7,9 @@ import SuperChartCore, { Props as SuperChartCoreProps } from './SuperChartCore';
 import DefaultFallbackComponent from './FallbackComponent';
 import ChartProps, { ChartPropsConfig } from '../models/ChartProps';
 import NoResultsComponent from './NoResultsComponent';
+import { ensureIsArray } from '../../utils';
+import { AdhocMetric } from '../../query';
+import { t } from '../../translation';
 
 const defaultProps = {
   FallbackComponent: DefaultFallbackComponent,
@@ -132,8 +135,28 @@ export default class SuperChart extends React.PureComponent<Props, {}> {
       enableNoResults &&
       (!queriesData ||
         queriesData.every(({ data }) => !data || (Array.isArray(data) && data.length === 0)));
+    const metricLabels = ensureIsArray(chartProps.formData?.metrics || chartProps.formData?.metric)
+      .map((metric: AdhocMetric | string) => (typeof metric === 'string' ? metric : metric.label))
+      .filter(Boolean);
+    const hasNullMetrics =
+      metricLabels.length > 0 &&
+      metricLabels.every(label =>
+        queriesData?.every(({ data }) =>
+          ensureIsArray(data).every(record => record[label!] === null),
+        ),
+      );
     if (noResultQueries) {
       chart = <NoResultsComponent id={id} className={className} height={height} width={width} />;
+    } else if (hasNullMetrics) {
+      chart = (
+        <NoResultsComponent
+          id={id}
+          className={className}
+          height={height}
+          width={width}
+          message={t('All metrics values are null for this query')}
+        />
+      );
     } else {
       const chartWithoutWrapper = (
         <SuperChartCore

--- a/packages/superset-ui-core/test/chart/components/NoResultsComponent.test.tsx
+++ b/packages/superset-ui-core/test/chart/components/NoResultsComponent.test.tsx
@@ -13,4 +13,12 @@ describe('NoResultsComponent', () => {
       'No ResultsNo results were returned for this query. If you expected results to be returned, ensure any filters are configured properly and the datasource contains data for the selected time range.',
     );
   });
+
+  it('renders with custom message', () => {
+    const wrapper = shallow(
+      <NoResultsComponent height="400" width="300" message="test message" title="Test title" />,
+    );
+
+    expect(wrapper.text()).toEqual('Test titletest message');
+  });
 });

--- a/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
@@ -196,6 +196,17 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [
+          {
+            name: 'disallowNullMetrics',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Disallow null metrics'),
+              default: true,
+              visibility: () => false,
+            },
+          },
+        ],
       ],
     },
     {

--- a/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -335,6 +335,17 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [
+          {
+            name: 'disallowNullMetrics',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Disallow null metrics'),
+              default: true,
+              visibility: () => false,
+            },
+          },
+        ],
         ['adhoc_filters'],
         emitFilterControl,
       ],


### PR DESCRIPTION
For some charts, when all metrics have only null values it doesn't make much sense to display the chart. Instead, we want to show a message that says "All metrics values are null for this query". 
This PR introduces that behaviour in Pivot Table v2 and Table charts.


https://user-images.githubusercontent.com/15073128/129589847-a221bd46-6f44-40a2-994a-a3870671d7f1.mov


@junlincc @jinghua-qa @adam-stasiak