### PR TITLE
fix(plugin-chart-table): apply correct date formatting for time grain

### DIFF
--- a/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -31,7 +31,6 @@ import { getColorFormatters } from '@superset-ui/chart-controls';
 import { DateFormatter } from '../types';
 
 const { DATABASE_DATETIME } = TimeFormats;
-const TIME_COLUMN = '__timestamp';
 
 function isNumeric(key: string, data: DataRecord[] = []) {
   return data.every(
@@ -108,7 +107,7 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
     .reduce((acc: Record<string, DateFormatter | undefined>, temporalColname: string) => {
       let formatter: DateFormatter | undefined;
       if (dateFormat === smartDateFormatter.id) {
-        if (temporalColname === TIME_COLUMN) {
+        if (granularity) {
           // time column use formats based on granularity
           formatter = getTimeFormatterForGranularity(granularity);
         } else if (isNumeric(temporalColname, data)) {

--- a/plugins/plugin-chart-table/src/transformProps.ts
+++ b/plugins/plugin-chart-table/src/transformProps.ts
@@ -39,11 +39,6 @@ import { DataColumnMeta, TableChartProps, TableChartTransformedProps } from './t
 
 const { PERCENT_3_POINT } = NumberFormats;
 const { DATABASE_DATETIME } = TimeFormats;
-const TIME_COLUMN = '__timestamp';
-
-function isTimeColumn(key: string) {
-  return key === TIME_COLUMN;
-}
 
 function isNumeric(key: string, data: DataRecord[] = []) {
   return data.every(x => x[key] === null || x[key] === undefined || typeof x[key] === 'number');
@@ -122,7 +117,7 @@ const processColumns = memoizeOne(function processColumns(props: TableChartProps
         const timeFormat = customFormat || tableTimestampFormat;
         // When format is "Adaptive Formatting" (smart_date)
         if (timeFormat === smartDateFormatter.id) {
-          if (isTimeColumn(key)) {
+          if (granularity) {
             // time column use formats based on granularity
             formatter = getTimeFormatterForGranularity(granularity);
           } else if (customFormat) {


### PR DESCRIPTION
Before, proper date formatting based on selected timegrain was applied only when column's name was `__timestamp`. This PR changes that behaviour in Table and Pivot Table v2 charts so that if granularity and adaptive formatting are selected, the date formatter proper for the time grain is used.

Before: see https://github.com/apache/superset/issues/16283
After: 
![image](https://user-images.githubusercontent.com/15073128/129733801-72a73167-394f-4724-b875-e99e2c25dd07.png)

Fixes https://github.com/apache/superset/issues/16283

A PR with the change on backend is in progress (made by @villebro)

CC: @junlincc 