### PR TITLE
fix(chart-controls): temporal col placeholder for hybrid dnd

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -17,7 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, validateNonEmpty } from '@superset-ui/core';
+import { FeatureFlag, isFeatureEnabled, t, validateNonEmpty } from '@superset-ui/core';
 import { ExtraControlProps, SharedControlConfig } from '../types';
 import { TIME_COLUMN_OPTION, TIME_FILTER_LABELS } from '../constants';
 
@@ -156,7 +156,11 @@ export const dnd_granularity_sqla: typeof dndGroupByControl = {
       'expression',
   ),
   canDelete: false,
-  ghostButtonText: t('Drop temporal column here'),
+  ghostButtonText: t(
+    isFeatureEnabled(FeatureFlag.ENABLE_DND_WITH_CLICK_UX)
+      ? 'Drop a temporal column here or click'
+      : 'Drop temporal column here',
+  ),
   mapStateToProps: ({ datasource }) => {
     const temporalColumns = datasource?.columns.filter(c => c.is_dttm) ?? [];
     const options = Object.fromEntries(temporalColumns.map(option => [option.column_name, option]));


### PR DESCRIPTION
If `ENABLE_DND_WITH_CLICK_UX` feature flag is enabled, change the Time Column placeholder from "Drop temporal column here" to "Drop a temporal column here or click"
Fixes https://github.com/apache/superset/issues/16307