### PR TITLE
fix: Improve big number time format UX

### DIFF
--- a/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx
+++ b/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx
@@ -71,7 +71,6 @@ const config: ControlPanelConfig = {
               label: t('Timestamp format'),
               renderTrigger: true,
               choices: D3_TIME_FORMAT_OPTIONS,
-              default: '%Y-%m-%d %H:%M:%S',
               description: D3_FORMAT_DOCS,
             },
           },

--- a/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx
+++ b/plugins/legacy-preset-chart-big-number/src/BigNumber/controlPanel.tsx
@@ -64,18 +64,6 @@ const config: ControlPanelConfig = {
         ['y_axis_format'],
         [
           {
-            name: 'show_timestamp',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Show Timestamp'),
-              renderTrigger: true,
-              default: false,
-              description: t('Whether to display the timestamp'),
-            },
-          },
-        ],
-        [
-          {
             name: 'time_format',
             config: {
               type: 'SelectControl',
@@ -83,12 +71,20 @@ const config: ControlPanelConfig = {
               label: t('Timestamp format'),
               renderTrigger: true,
               choices: D3_TIME_FORMAT_OPTIONS,
-              default: '%d-%m-%Y %H:%M:%S',
+              default: '%Y-%m-%d %H:%M:%S',
               description: D3_FORMAT_DOCS,
-              visibility(props) {
-                const { show_timestamp } = props.form_data;
-                return !!show_timestamp;
-              },
+            },
+          },
+        ],
+        [
+          {
+            name: 'show_timestamp',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show Timestamp'),
+              renderTrigger: true,
+              default: false,
+              description: t('Whether to display the timestamp'),
             },
           },
         ],


### PR DESCRIPTION
🐛 Bug Fix
https://github.com/apache-superset/superset-ui/pull/1278 introduced the ability to show a timestamp for the value of big number, but as a result it overrode the default time format for the tooltip in big number trendline charts to a somewhat obscure (for americans) `%d-%m-%Y %H:%M:%S` format. This PR:
- makes the time formatter always visible (so that the big number trendline chart can always set it)
- Defaults to a format that's used globally, `'%Y-%m-%d %H:%M:%S'`

to: @krsnik93 @villebro @ktmud