### PR TITLE
fix(plugin-chart-echarts): improve marksize range

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -155,7 +155,7 @@ const config: ControlPanelConfig = {
               label: t('Marker Size'),
               renderTrigger: true,
               min: 0,
-              max: 100,
+              max: 20,
               default: markerSize,
               description: t('Size of marker. Also applies to forecast observations.'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -115,7 +115,7 @@ const config: ControlPanelConfig = {
               label: t('Marker Size'),
               renderTrigger: true,
               min: 0,
-              max: 100,
+              max: 20,
               default: markerSize,
               description: t('Size of marker. Also applies to forecast observations.'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>

--- a/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -169,7 +169,7 @@ const config: ControlPanelConfig = {
               label: t('Marker Size'),
               renderTrigger: true,
               min: 0,
-              max: 100,
+              max: 20,
               default: markerSize,
               description: t('Size of marker. Also applies to forecast observations.'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>

--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -172,7 +172,7 @@ const config: ControlPanelConfig = {
               label: t('Marker Size'),
               renderTrigger: true,
               min: 0,
-              max: 100,
+              max: 20,
               default: markerSize,
               description: t('Size of marker. Also applies to forecast observations.'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>


### PR DESCRIPTION
🏆 Enhancements

related to https://github.com/apache/superset/issues/16343#event-5184581121

set marker size to 0-20 for time-series echart.

![image](https://user-images.githubusercontent.com/11830681/130318538-4500d077-d1cf-448a-8f06-7902b4735ab4.png)

