### PR TITLE
feat(plugin-chart-echarts): [feature-parity] support double clicking legend and series to view single selected series

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -92,17 +92,18 @@ export default function EchartsTimeseries({
     },
     legendselectchanged: payload => {
       const currentTime = Date.now();
+      const echartInstance = echartRef.current?.getEchartInstance();
       // 300 is the interval between two legendselectchanged event
       if (currentTime - lastTimeRef.current < 300 && lastSelectedLegend.current === payload.name) {
         // execute dbclick
         legendData.forEach(datum => {
           if (datum === payload.name) {
-            echartRef.current?.dispatchAction({
+            echartInstance?.dispatchAction({
               type: 'legendSelect',
               name: datum,
             });
           } else {
-            echartRef.current?.dispatchAction({
+            echartInstance?.dispatchAction({
               type: 'legendUnSelect',
               name: datum,
             });
@@ -115,7 +116,7 @@ export default function EchartsTimeseries({
       }
       // if all legend is unselected, we keep all selected
       if (Object.values(payload.selected).every(i => !i)) {
-        echartRef.current?.dispatchAction({
+        echartInstance?.dispatchAction({
           type: 'legendAllSelect',
         });
       }

--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -166,7 +166,6 @@ export default function EchartsTimeseries({
       if (clickTimer.current) {
         clearTimeout(clickTimer.current);
       }
-      // only for the stacked line/area/step/smooth chart
       const pointInPixel = [params.offsetX, params.offsetY];
       const echartInstance = echartRef.current?.getEchartInstance();
       if (echartInstance?.containPixel('grid', pointInPixel)) {

--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -19,6 +19,7 @@
 import React, { useCallback, useRef } from 'react';
 import { ViewRootGroup } from 'echarts/types/src/util/types';
 import GlobalModel from 'echarts/types/src/model/Global';
+import ComponentModel from 'echarts/types/src/model/Component';
 import { EchartsHandler, EventHandlers } from '../types';
 import Echart from '../components/Echart';
 import { TimeseriesChartTransformedProps } from './types';
@@ -68,7 +69,7 @@ export default function EchartsTimeseries({
 
   const getModelInfo = (target: ViewRootGroup, globalModel: GlobalModel) => {
     let el = target;
-    let model = null;
+    let model: ComponentModel | null = null;
     while (el) {
       // eslint-disable-next-line no-underscore-dangle
       const modelInfo = el.__ecComponentInfo;

--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -36,7 +36,7 @@ export default function EchartsTimeseries({
   setDataMask,
   legendData = [],
 }: TimeseriesChartTransformedProps) {
-  const { emitFilter, stack, area } = formData;
+  const { emitFilter, stack } = formData;
   const echartRef = useRef<EchartsHandler | null>(null);
   const lastTimeRef = useRef(Date.now());
   const lastSelectedLegend = useRef('');

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -221,6 +221,15 @@ export default function transformProps(
     yAxisTitleMargin,
     xAxisTitleMargin,
   );
+
+  const legendData = rawSeries
+    .filter(
+      entry =>
+        extractForecastSeriesContext(entry.name || '').type === ForecastSeriesEnum.Observation,
+    )
+    .map(entry => entry.name || '')
+    .concat(extractAnnotationLabels(annotationLayers, annotationData));
+
   const echartOptions: EChartsCoreOption = {
     useUTC: true,
     grid: {
@@ -282,14 +291,7 @@ export default function transformProps(
     },
     legend: {
       ...getLegendProps(legendType, legendOrientation, showLegend, zoomable),
-      // @ts-ignore
-      data: rawSeries
-        .filter(
-          entry =>
-            extractForecastSeriesContext(entry.name || '').type === ForecastSeriesEnum.Observation,
-        )
-        .map(entry => entry.name || '')
-        .concat(extractAnnotationLabels(annotationLayers, annotationData)),
+      data: legendData as string[],
     },
     series: dedupSeries(series),
     toolbox: {
@@ -328,5 +330,6 @@ export default function transformProps(
     selectedValues,
     setDataMask,
     width,
+    legendData,
   };
 }

--- a/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
 import { styled } from '@superset-ui/core';
-import { ECharts, init, Payload } from 'echarts';
+import { ECharts, init } from 'echarts';
 import { EchartsHandler, EchartsProps, EchartsStylesProps } from '../types';
 
 const Styles = styled.div<EchartsStylesProps>`
@@ -36,11 +36,7 @@ function Echart(
   const previousSelection = useRef<string[]>([]);
 
   useImperativeHandle(ref, () => ({
-    dispatchAction: (payload: Payload) => {
-      if (chartRef.current) {
-        chartRef.current.dispatchAction(payload);
-      }
-    },
+    getEchartInstance: () => chartRef.current,
   }));
 
   useEffect(() => {

--- a/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -16,27 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
 import { styled } from '@superset-ui/core';
-import { ECharts, init } from 'echarts';
-import { EchartsProps, EchartsStylesProps } from '../types';
+import { ECharts, init, Payload } from 'echarts';
+import { EchartsHandler, EchartsProps, EchartsStylesProps } from '../types';
 
 const Styles = styled.div<EchartsStylesProps>`
   height: ${({ height }) => height};
   width: ${({ width }) => width};
 `;
 
-export default function Echart({
-  width,
-  height,
-  echartOptions,
-  eventHandlers,
-  selectedValues = {},
-}: EchartsProps) {
+function Echart(
+  { width, height, echartOptions, eventHandlers, selectedValues = {} }: EchartsProps,
+  ref: React.Ref<EchartsHandler>,
+) {
   const divRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<ECharts>();
   const currentSelection = Object.keys(selectedValues) || [];
   const previousSelection = useRef<string[]>([]);
+
+  useImperativeHandle(ref, () => ({
+    dispatchAction: (payload: Payload) => {
+      if (chartRef.current) {
+        chartRef.current.dispatchAction(payload);
+      }
+    },
+  }));
 
   useEffect(() => {
     if (!divRef.current) return;
@@ -72,3 +77,5 @@ export default function Echart({
 
   return <Styles ref={divRef} height={height} width={width} />;
 }
+
+export default forwardRef(Echart);

--- a/plugins/plugin-chart-echarts/src/types.ts
+++ b/plugins/plugin-chart-echarts/src/types.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { DataRecordValue, SetDataMaskHook } from '@superset-ui/core';
-import { EChartsCoreOption, Payload } from 'echarts';
+import { EChartsCoreOption, ECharts } from 'echarts';
 import { TooltipMarker } from 'echarts/types/src/util/format';
 import { OptionName } from 'echarts/types/src/util/types';
 
@@ -36,7 +36,7 @@ export interface EchartsProps {
 }
 
 export interface EchartsHandler {
-  dispatchAction: (paload: Payload) => void;
+  getEchartInstance: () => ECharts | undefined;
 }
 
 export enum ForecastSeriesEnum {

--- a/plugins/plugin-chart-echarts/src/types.ts
+++ b/plugins/plugin-chart-echarts/src/types.ts
@@ -31,6 +31,7 @@ export interface EchartsProps {
   width: number;
   echartOptions: EChartsCoreOption;
   eventHandlers?: EventHandlers;
+  zrEventHandlers?: EventHandlers;
   selectedValues?: Record<number, string>;
   forceClear?: boolean;
 }

--- a/plugins/plugin-chart-echarts/src/types.ts
+++ b/plugins/plugin-chart-echarts/src/types.ts
@@ -17,8 +17,9 @@
  * under the License.
  */
 import { DataRecordValue, SetDataMaskHook } from '@superset-ui/core';
-import { EChartsCoreOption } from 'echarts';
+import { EChartsCoreOption, Payload } from 'echarts';
 import { TooltipMarker } from 'echarts/types/src/util/format';
+import { OptionName } from 'echarts/types/src/util/types';
 
 export type EchartsStylesProps = {
   height: number;
@@ -32,6 +33,10 @@ export interface EchartsProps {
   eventHandlers?: EventHandlers;
   selectedValues?: Record<number, string>;
   forceClear?: boolean;
+}
+
+export interface EchartsHandler {
+  dispatchAction: (paload: Payload) => void;
 }
 
 export enum ForecastSeriesEnum {
@@ -108,6 +113,7 @@ export interface EChartTransformedProps<F> {
   labelMap: Record<string, DataRecordValue[]>;
   groupby: string[];
   selectedValues: Record<number, string>;
+  legendData?: OptionName[];
 }
 
 export interface EchartsTitleFormData {


### PR DESCRIPTION
🏆 Enhancements
This PR supports two features: 
1. when user double click on the legend-> select single series, no change on ad hoc filter field -> click again to show all series.
2. when user double click on a single series(in place filtering) -> display the correlative legend only -> no change on ad hoc filter field -> double click again to show all series

related to: 
- https://github.com/apache/superset/issues/16354. 
- https://github.com/apache/superset/issues/16364


### Line related chart (area, line, smooth, step)

#### Stacked

https://user-images.githubusercontent.com/11830681/132133087-c5e573af-bd15-462f-b2e3-291237f167b7.mov



#### Unstacked

https://user-images.githubusercontent.com/11830681/132133090-129bd28c-3b02-466b-8e23-8e678196a870.mov


### Bar chart
#### Stacked

https://user-images.githubusercontent.com/11830681/132132829-e5970dc6-6860-4765-8a58-26de9f0b63f2.mov



#### Unstacked


https://user-images.githubusercontent.com/11830681/132132845-ac14739e-5ca1-428c-af5d-428ac06dd46c.mov

### Scatter Plot


https://user-images.githubusercontent.com/11830681/132133165-d3f58dbd-da02-4873-84fe-b9c4cb357852.mov

