### PR TITLE
fix(plugin-chart-echarts): [gauge chart] filter indicator not be shown

### DIFF
--- a/plugins/plugin-chart-echarts/src/Gauge/index.ts
+++ b/plugins/plugin-chart-echarts/src/Gauge/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, Behavior } from '@superset-ui/core';
 import controlPanel from './controlPanel';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
@@ -33,6 +33,7 @@ export default class EchartsGaugeChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsGauge'),
       metadata: new ChartMetadata({
+        behaviors: [Behavior.INTERACTIVE_CHART],
         category: t('KPI'),
         credits: ['https://echarts.apache.org'],
         description: t(


### PR DESCRIPTION
🐛 Bug Fix
refer to https://github.com/apache/superset/issues/16255

### after

https://user-images.githubusercontent.com/11830681/130360633-85e8284b-ba5a-435e-a5f3-e3a9e612ebbf.mov



