### PR TITLE
feat(plugin-chart-echarts): [feature-parity] support Extra Control on the time-series area chart

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/components/RadioButtonControl.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/components/RadioButtonControl.tsx
@@ -28,7 +28,7 @@ export interface RadioButtonControlProps {
   description?: string;
   options: RadioButtonOption[];
   hovered?: boolean;
-  value?: string;
+  value?: JsonValue;
   onChange: (opt: RadioButtonOption[0]) => void;
 }
 
@@ -38,7 +38,7 @@ export default function RadioButtonControl({
   onChange,
   ...props
 }: RadioButtonControlProps) {
-  const currentValue = initialValue || options[0][0];
+  const currentValue = initialValue === null ? options[0][0] : initialValue;
   const theme = useTheme();
   return (
     <div

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -149,7 +149,7 @@ export default function transformProps(
       markerSize,
       areaOpacity: opacity,
       seriesType,
-      stack,
+      stack: Boolean(stack),
       yAxisIndex,
       filterState,
     });
@@ -162,7 +162,7 @@ export default function transformProps(
       markerSize: markerSizeB,
       areaOpacity: opacityB,
       seriesType: seriesTypeB,
-      stack: stackB,
+      stack: Boolean(stackB),
       yAxisIndex: yAxisIndexB,
       filterState,
     });

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -37,6 +37,7 @@ import {
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
 } from '../Timeseries/types';
+import { AreaChartExtraControlsValue } from '../constants';
 
 export type EchartsMixedTimeseriesFormData = QueryFormData & {
   annotationLayers: AnnotationLayer[];
@@ -77,8 +78,8 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   rowLimitB: number;
   seriesType: EchartsTimeseriesSeriesType;
   seriesTypeB: EchartsTimeseriesSeriesType;
-  stack: boolean;
-  stackB: boolean;
+  stack: boolean | Partial<AreaChartExtraControlsValue> | null;
+  stackB: boolean | Partial<AreaChartExtraControlsValue> | null;
   yAxisIndex?: number;
   yAxisIndexB?: number;
   groupby: string[];

--- a/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -136,6 +136,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [showValueControl],
         [
           {
             name: 'stack',
@@ -152,7 +153,6 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [showValueControl],
         [onlyTotalControl],
         [
           {

--- a/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -32,7 +32,8 @@ import {
   EchartsTimeseriesContributionType,
   EchartsTimeseriesSeriesType,
 } from '../types';
-import { legendSection, showValueSection } from '../../controls';
+import { legendSection, onlyTotalControl, showValueControl } from '../../controls';
+import { AreaChartExtraControlsValue } from '../../constants';
 
 const {
   contributionMode,
@@ -135,7 +136,40 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ...showValueSection,
+        [
+          {
+            name: 'stack',
+            config: {
+              type: 'SelectControl',
+              label: t('Stacked Style'),
+              renderTrigger: true,
+              choices: [
+                [AreaChartExtraControlsValue.Stacked, 'stack'],
+                [AreaChartExtraControlsValue.Expanded, 'expand'],
+              ],
+              default: 'stack',
+              description: t('Stack series on top of each other'),
+            },
+          },
+        ],
+        [showValueControl],
+        [onlyTotalControl],
+        [
+          {
+            name: 'extra_controls',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Extra Controls'),
+              renderTrigger: true,
+              default: false,
+              description: t(
+                'Whether to show extra controls or not. Extra controls ' +
+                  'include things like making mulitBar charts stacked ' +
+                  'or side by side.',
+              ),
+            },
+          },
+        ],
         [
           {
             name: 'markerEnabled',

--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -26,7 +26,7 @@ import { EchartsHandler, EventHandlers } from '../types';
 import Echart from '../components/Echart';
 import { EchartsTimeseriesFormData, TimeseriesChartTransformedProps } from './types';
 import { currentSeries } from '../utils/series';
-import { AreaChartExtraControlsOptions, TIMESERIES_CONSTANTS } from '../constants';
+import { AreaChartExtraControlsOptions } from '../constants';
 
 const { RadioButtonControl } = sharedControlComponents;
 
@@ -86,7 +86,7 @@ export default function EchartsTimeseries({
   selectedValues,
   setDataMask,
   legendData = [],
-  setControlValue
+  setControlValue,
 }: TimeseriesChartTransformedProps) {
   const { emitFilter, stack, extraControls } = formData;
   const echartRef = useRef<EchartsHandler | null>(null);
@@ -256,10 +256,12 @@ export default function EchartsTimeseries({
         </ExtraControlsWrapper>
       )}
       <Echart
-        height={extraControls ? height - TIMESERIES_CONSTANTS.extraControlsOffset : height}
+        ref={echartRef}
+        height={height}
         width={width}
         echartOptions={echartOptions}
         eventHandlers={eventHandlers}
+        zrEventHandlers={zrEventHandlers}
         selectedValues={selectedValues}
       />
     </>

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -197,7 +197,7 @@ export function transformSeries(
         } = params;
         if (!formatter) return numericValue;
         if (!stack || !onlyTotal) {
-          return formatter(numericValue);
+          return numericValue ? formatter(numericValue) : '';
         }
         if (seriesIndex === showValueIndexes[dataIndex]) {
           return formatter(totalStackedValues[dataIndex]);

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -31,6 +31,7 @@ import {
   EchartsTitleFormData,
   DEFAULT_TITLE_FORM_DATA,
 } from '../types';
+import { AreaChartExtraControlsValue } from '../constants';
 
 export enum EchartsTimeseriesContributionType {
   Row = 'row',
@@ -66,7 +67,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   orderDesc: boolean;
   rowLimit: number;
   seriesType: EchartsTimeseriesSeriesType;
-  stack: boolean;
+  stack: boolean | null | Partial<AreaChartExtraControlsValue>;
   tooltipTimeFormat?: string;
   truncateYAxis: boolean;
   yAxisFormat?: string;
@@ -82,6 +83,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   groupby: string[];
   showValue: boolean;
   onlyTotal: boolean;
+  extraControls: boolean;
 } & EchartsLegendFormData &
   EchartsTitleFormData;
 

--- a/plugins/plugin-chart-echarts/src/constants.ts
+++ b/plugins/plugin-chart-echarts/src/constants.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import { JsonValue, t } from '@superset-ui/core';
+import { ReactNode } from 'react';
 import { LabelPositionEnum } from './types';
 
 // eslint-disable-next-line import/prefer-default-export
@@ -36,6 +38,7 @@ export const TIMESERIES_CONSTANTS = {
   dataZoomStart: 0,
   dataZoomEnd: 100,
   yAxisLabelTopOffset: 20,
+  extraControlsOffset: 22,
 };
 
 export const LABEL_POSITION: [LabelPositionEnum, string][] = [
@@ -59,3 +62,16 @@ export enum OpacityEnum {
   SemiTransparent = 0.3,
   NonTransparent = 1,
 }
+
+export enum AreaChartExtraControlsValue {
+  Stacked = 'Stacked',
+  Expanded = 'Expanded',
+}
+
+export const AreaChartExtraControlsOptions: [
+  JsonValue,
+  Exclude<ReactNode, null | undefined | boolean>,
+][] = [
+  [AreaChartExtraControlsValue.Stacked, t('Stacked')],
+  [AreaChartExtraControlsValue.Expanded, t('Expanded')],
+];

--- a/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/plugins/plugin-chart-echarts/src/controls.tsx
@@ -129,4 +129,4 @@ export const onlyTotalControl = {
   },
 };
 
-export const showValueSection = [[stackControl], [showValueControl], [onlyTotalControl]];
+export const showValueSection = [[showValueControl], [stackControl], [onlyTotalControl]];

--- a/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/plugins/plugin-chart-echarts/src/controls.tsx
@@ -94,7 +94,7 @@ export const legendSection = [
   [legendMarginControl],
 ];
 
-const showValueControl = {
+export const showValueControl = {
   name: 'show_value',
   config: {
     type: 'CheckboxControl',
@@ -105,7 +105,7 @@ const showValueControl = {
   },
 };
 
-const stackControl = {
+export const stackControl = {
   name: 'stack',
   config: {
     type: 'CheckboxControl',
@@ -116,7 +116,7 @@ const stackControl = {
   },
 };
 
-const onlyTotalControl = {
+export const onlyTotalControl = {
   name: 'only_total',
   config: {
     type: 'CheckboxControl',
@@ -129,4 +129,4 @@ const onlyTotalControl = {
   },
 };
 
-export const showValueSection = [[showValueControl], [stackControl], [onlyTotalControl]];
+export const showValueSection = [[stackControl], [showValueControl], [onlyTotalControl]];

--- a/plugins/plugin-chart-echarts/src/types.ts
+++ b/plugins/plugin-chart-echarts/src/types.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DataRecordValue, SetDataMaskHook } from '@superset-ui/core';
+import { DataRecordValue, HandlerFunction, SetDataMaskHook } from '@superset-ui/core';
 import { EChartsCoreOption, ECharts } from 'echarts';
 import { TooltipMarker } from 'echarts/types/src/util/format';
 import { OptionName } from 'echarts/types/src/util/types';
@@ -111,6 +111,7 @@ export interface EChartTransformedProps<F> {
   echartOptions: EChartsCoreOption;
   emitFilter: boolean;
   setDataMask: SetDataMaskHook;
+  setControlValue?: HandlerFunction;
   labelMap: Record<string, DataRecordValue[]>;
   groupby: string[];
   selectedValues: Record<number, string>;

--- a/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -35,11 +35,26 @@ function isDefined<T>(value: T | undefined | null): boolean {
   return value !== undefined && value !== null;
 }
 
+export function extractTotalValues(data: TimeseriesDataRecord[]) {
+  return data.map(datum =>
+    Object.keys(datum)
+      .filter(key => key !== '__timestamp')
+      .reduce((sum, key) => {
+        const value = datum[key] || 0;
+        return sum + (value as number);
+      }, 0),
+  );
+}
+
 export function extractTimeseriesSeries(
   data: TimeseriesDataRecord[],
-  opts: { fillNeighborValue?: number } = {},
+  opts: {
+    fillNeighborValue?: number;
+    isExpended?: boolean;
+    totalValues?: number[];
+  } = {},
 ): SeriesOption[] {
-  const { fillNeighborValue } = opts;
+  const { fillNeighborValue, isExpended, totalValues = [] } = opts;
   if (data.length === 0) return [];
   const rows: TimeseriesDataRecord[] = data.map(datum => ({
     ...datum,
@@ -54,12 +69,16 @@ export function extractTimeseriesSeries(
       data: rows.map((row, idx) => {
         const isNextToDefinedValue =
           isDefined(rows[idx - 1]?.[key]) || isDefined(rows[idx + 1]?.[key]);
-        return [
-          row.__timestamp,
-          !isDefined(row[key]) && isNextToDefinedValue && fillNeighborValue !== undefined
-            ? fillNeighborValue
-            : row[key],
-        ];
+        const isFillNeighborValue =
+          !isDefined(row[key]) && isNextToDefinedValue && fillNeighborValue !== undefined;
+
+        let value: DataRecordValue | undefined = row[key];
+        if (isFillNeighborValue) {
+          value = fillNeighborValue;
+        } else if (isExpended) {
+          value = ((value || 0) as number) / totalValues[idx];
+        }
+        return [row.__timestamp, value];
       }),
     }));
 }


### PR DESCRIPTION
🏆 Enhancements

This PR implements `Extra Control` on the time-series area chart, and the chart's update mechanism is using `setControlValue` hook. In addition, I changed the stack checkbox control to select control. When `Extra Control` is updated, the control panel will be updated as well, and vice versa. (this is different from NVD3, where updating extra control does not update the control panel). Since 'Stacked' and 'Expended' seem to be used more often, I only keep these two options.
Another UI difference is that the button is used instead of the radio to maintain consistency with the control panel.

Refers to :
- https://github.com/apache/superset/issues/16298.
- https://github.com/apache/superset/pull/16493

cc @villebro @zhaoyongjie @junlincc 

## explore

### before

https://user-images.githubusercontent.com/11830681/131250907-de75f67e-f414-4cc9-b261-37cc4360f37b.mov

### after

https://user-images.githubusercontent.com/11830681/131250972-8c7f5e9a-4530-41dd-86c5-59193c3b915c.mov



## dashboard

### before

https://user-images.githubusercontent.com/11830681/131251068-74cb6aab-6156-41cc-886c-1718bf58d300.mov


### after
https://user-images.githubusercontent.com/11830681/131251071-6a578b9b-26d8-4c05-9e42-b7097bb1c293.mov

