### PR TITLE
chore: isolate the one actual jquery dependency

### DIFF
--- a/plugins/legacy-plugin-chart-pivot-table/package.json
+++ b/plugins/legacy-plugin-chart-pivot-table/package.json
@@ -32,6 +32,7 @@
     "@superset-ui/core": "0.18.0",
     "d3": "^3.5.17",
     "datatables.net-bs": "^1.10.15",
+    "jquery": "^3.6.0",
     "prop-types": "^15.6.2"
   }
 }

--- a/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
@@ -19,6 +19,7 @@
 /* eslint-disable react/sort-prop-types */
 import dt from 'datatables.net-bs';
 import PropTypes from 'prop-types';
+import $ from 'jquery';
 import {
   getTimeFormatter,
   getTimeFormatterForGranularity,
@@ -28,10 +29,7 @@ import { formatCellValue, formatDateCellValue } from './utils/formatCells';
 import fixTableHeight from './utils/fixTableHeight';
 import 'datatables.net-bs/css/dataTables.bootstrap.css';
 
-if (window.$) {
-  dt(window, window.$);
-}
-const $ = window.$ || dt.$;
+dt(window, $);
 
 const propTypes = {
   data: PropTypes.shape({


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix

🏠 Internal

It uses the Data Tables jquery plugin and is deprecated, so don't want to try to remove jquery from it. Instead will make it an explicit dependency so that jquery can be removed from the rest of superset.