### PR TITLE
chore(plugin-chart-echarts): bump to ECharts 5.2.0

### DIFF
--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -30,7 +30,7 @@
     "@superset-ui/core": "0.17.81",
     "@types/mathjs": "^6.0.7",
     "d3-array": "^1.2.0",
-    "echarts": "^5.1.2",
+    "echarts": "^5.2.0",
     "lodash": "^4.17.15",
     "mathjs": "^8.0.1"
   },

--- a/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
@@ -223,11 +223,13 @@ export default function transformProps(
     axisLine.lineStyle.color = intervalBoundsAndColors;
     pointer = {
       show: showPointer,
+      showAbove: false,
       itemStyle: INTERVAL_GAUGE_SERIES_OPTION.pointer?.itemStyle,
     };
   } else {
     pointer = {
       show: showPointer,
+      showAbove: false,
     };
   }
 


### PR DESCRIPTION
🏆 Enhancements

Upgrade to latest version of ECharts. Includes many new features and bugfixes, and addresses one cosmetic issue related to gauge chart.

### AFTER
Now Gauge chart defaults to showing the pointer below the text:
![image](https://user-images.githubusercontent.com/33317356/131621948-c05e0a7c-5ee6-4ab1-9173-33276013090f.png)

### BEFORE
Previously the text fell below the pointer:
![image](https://user-images.githubusercontent.com/33317356/131621963-1d6ca20d-d64e-40ef-8411-16337245cf78.png)
