### PR TITLE
feat(plugin-chart-echarts): add x and y label support for timeseries

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/controlPanel.tsx
@@ -42,6 +42,11 @@ const {
   yAxisBounds,
   zoomable,
   xAxisLabelRotation,
+  xAxisLabel,
+  yAxisLabel,
+  xAxisLabelBottomMargin,
+  yAxisLabelMargin,
+  yAxisLabelPosition,
 } = DEFAULT_FORM_DATA;
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -139,6 +144,42 @@ const config: ControlPanelConfig = {
         [<h1 className="section-header">{t('X Axis')}</h1>],
         [
           {
+            name: 'x_axis_label',
+            config: {
+              type: 'TextControl',
+              label: t('X AXIS LABEL'),
+              renderTrigger: true,
+              default: xAxisLabel,
+              description: t('Changing this control takes effect instantly'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'xAxisLabelBottomMargin',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              clearable: false,
+              label: t('BOTTOM MARGIN'),
+              choices: [
+                [15, 15],
+                [30, 30],
+                [50, 50],
+                [75, 75],
+                [100, 100],
+                [125, 125],
+                [150, 150],
+                [200, 200],
+              ],
+              default: xAxisLabelBottomMargin,
+              renderTrigger: true,
+              description: t('Changing this control takes effect instantly'),
+            },
+          },
+        ],
+        [
+          {
             name: 'x_axis_time_format',
             config: {
               ...sharedControls.x_axis_time_format,
@@ -194,6 +235,60 @@ const config: ControlPanelConfig = {
         ],
         // eslint-disable-next-line react/jsx-key
         [<h1 className="section-header">{t('Y Axis')}</h1>],
+        [
+          {
+            name: 'y_axis_label',
+            config: {
+              type: 'TextControl',
+              label: t('Y Axis Label'),
+              renderTrigger: true,
+              default: yAxisLabel,
+              description: t('Changing this control takes effect instantly'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'yAxisLabelPosition',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              clearable: false,
+              label: t('Left/TOP MARGIN'),
+              choices: [
+                ['Left', 'Left'],
+                ['Top', 'Top'],
+              ],
+              default: yAxisLabelPosition,
+              renderTrigger: true,
+              description: t('Changing this control takes effect instantly'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'yAxisLabelMargin',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              clearable: false,
+              label: t('Left/TOP MARGIN'),
+              choices: [
+                [15, 15],
+                [30, 30],
+                [50, 50],
+                [75, 75],
+                [100, 100],
+                [125, 125],
+                [150, 150],
+                [200, 200],
+              ],
+              default: yAxisLabelMargin,
+              renderTrigger: true,
+              description: t('Changing this control takes effect instantly'),
+            },
+          },
+        ],
         ['y_axis_format'],
         [
           {
@@ -216,18 +311,6 @@ const config: ControlPanelConfig = {
               renderTrigger: true,
               default: minorSplitLine,
               description: t('Draw split lines for minor y-axis ticks'),
-            },
-          },
-        ],
-        [
-          {
-            name: 'yAxisTitle',
-            config: {
-              type: 'TextControl',
-              label: t('Primary y-axis title'),
-              renderTrigger: true,
-              default: '',
-              description: t('Title for y-axis'),
             },
           },
         ],

--- a/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/controlPanel.tsx
@@ -278,18 +278,6 @@ const config: ControlPanelConfig = {
         ],
         [
           {
-            name: 'yAxisTitle',
-            config: {
-              type: 'TextControl',
-              label: t('Primary y-axis title'),
-              renderTrigger: true,
-              default: '',
-              description: t('Title for y-axis'),
-            },
-          },
-        ],
-        [
-          {
             name: 'truncateYAxis',
             config: {
               type: 'CheckboxControl',

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -94,7 +94,6 @@ export default function transformProps(
     yAxisFormat,
     xAxisTimeFormat,
     yAxisBounds,
-    yAxisTitle,
     tooltipTimeFormat,
     zoomable,
     richTooltip,
@@ -103,6 +102,11 @@ export default function transformProps(
     groupby,
     showValue,
     onlyTotal,
+    xAxisLabel,
+    yAxisLabel,
+    xAxisLabelBottomMargin = 0,
+    yAxisLabelMargin = 0,
+    yAxisLabelPosition = 'Top',
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
@@ -205,9 +209,19 @@ export default function transformProps(
 
   const { setDataMask = () => {} } = hooks;
 
-  const addYAxisLabelOffset = !!yAxisTitle;
-  const padding = getPadding(showLegend, legendOrientation, addYAxisLabelOffset, zoomable);
-
+  const addYAxisLabelOffset = !!yAxisLabel;
+  const addXAxisLabelOffset = !!xAxisLabel;
+  const padding = getPadding(
+    showLegend,
+    legendOrientation,
+    addYAxisLabelOffset,
+    zoomable,
+    null,
+    addXAxisLabelOffset,
+    yAxisLabelPosition,
+    yAxisLabelMargin,
+    xAxisLabelBottomMargin,
+  );
   const echartOptions: EChartsOption = {
     useUTC: true,
     grid: {
@@ -216,6 +230,9 @@ export default function transformProps(
     },
     xAxis: {
       type: 'time',
+      name: xAxisLabel,
+      nameGap: xAxisLabelBottomMargin,
+      nameLocation: 'middle',
       axisLabel: {
         formatter: xAxisFormatter,
         rotate: xAxisLabelRotation,
@@ -230,7 +247,9 @@ export default function transformProps(
       minorSplitLine: { show: minorSplitLine },
       axisLabel: { formatter },
       scale: truncateYAxis,
-      name: yAxisTitle,
+      name: yAxisLabel,
+      nameGap: yAxisLabelMargin,
+      nameLocation: yAxisLabelPosition === 'Left' ? 'middle' : 'end',
     },
     tooltip: {
       ...defaultTooltip,

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -375,6 +375,10 @@ export function getPadding(
   addYAxisLabelOffset: boolean,
   zoomable: boolean,
   margin?: string | number | null,
+  addXAxisLabelOffset?: boolean,
+  yAxisLabelPosition?: string,
+  yAxisLabelMargin?: number,
+  xAxisLabelBottomMargin?: number,
 ): {
   bottom: number;
   left: number;
@@ -382,12 +386,19 @@ export function getPadding(
   top: number;
 } {
   const yAxisOffset = addYAxisLabelOffset ? TIMESERIES_CONSTANTS.yAxisLabelTopOffset : 0;
+  const xAxisOffset = addXAxisLabelOffset ? xAxisLabelBottomMargin || 0 : 0;
   return getChartPadding(showLegend, legendOrientation, margin, {
-    top: TIMESERIES_CONSTANTS.gridOffsetTop + yAxisOffset,
+    top:
+      yAxisLabelPosition && yAxisLabelPosition === 'Top'
+        ? TIMESERIES_CONSTANTS.gridOffsetTop + (yAxisLabelMargin || 0)
+        : TIMESERIES_CONSTANTS.gridOffsetTop + yAxisOffset,
     bottom: zoomable
-      ? TIMESERIES_CONSTANTS.gridOffsetBottomZoomable
-      : TIMESERIES_CONSTANTS.gridOffsetBottom,
-    left: TIMESERIES_CONSTANTS.gridOffsetLeft,
+      ? TIMESERIES_CONSTANTS.gridOffsetBottomZoomable + xAxisOffset
+      : TIMESERIES_CONSTANTS.gridOffsetBottom + xAxisOffset,
+    left:
+      yAxisLabelPosition === 'Left'
+        ? TIMESERIES_CONSTANTS.gridOffsetLeft + (yAxisLabelMargin || 0)
+        : TIMESERIES_CONSTANTS.gridOffsetLeft,
     right:
       showLegend && legendOrientation === LegendOrientation.Right
         ? 0


### PR DESCRIPTION
fix #16512

🏆 Enhancements
This PR supports two features:
1 User can add X/Y axis label in timeseries line chart. 
2 Changed previews default top Y axis position to dynamic left/top choice.
related to:
https://github.com/apache/superset/issues/16512

After:


https://user-images.githubusercontent.com/51693396/132231973-6fcae913-95c9-496a-a102-e63290c9b815.mov


