### PR TITLE
fix: Pivot table now at 100% width

### DIFF
--- a/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
+++ b/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
@@ -110,6 +110,10 @@ function PivotTable(element, props) {
       });
   });
 
+  $container.find('table').each(function fullWidth() {
+    this.style = 'width: 100%';
+  });
+
   if (numGroups === 1) {
     // When there is only 1 group by column,
     // we use the DataTable plugin to make the header fixed.

--- a/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -43,7 +43,7 @@ const Styles = styled.div<PivotTableStylesProps>`
   ${({ height, width, margin }) => `
       margin: ${margin}px;
       height: ${height - margin * 2}px;
-      width: ${width - margin * 2}px;
+      width: ${typeof width === 'string' ? parseInt(width, 10) : width - margin * 2}px;
  `}
 `;
 

--- a/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/plugins/plugin-chart-pivot-table/src/types.ts
@@ -31,7 +31,7 @@ import { ColorFormatters } from '@superset-ui/chart-controls';
 
 export interface PivotTableStylesProps {
   height: number;
-  width: number;
+  width: number | string;
   margin: number;
 }
 


### PR DESCRIPTION
💔 Breaking Changes: None

🏆 Enhancements: Pivot table now at 100% width

📜 Documentation: N/A

🐛 Bug Fix: Reports screenshots are too small for charts

🏠 Internal: N/A

📸 Screenshots of the fix:
<img width="1792" alt="Screen Shot 2021-09-14 at 10 40 25 PM" src="https://user-images.githubusercontent.com/55605634/133367113-fc1af5cd-0f16-4a7d-aff4-b3f8da3657d1.png">
<img width="1792" alt="Screen Shot 2021-09-14 at 10 40 07 PM" src="https://user-images.githubusercontent.com/55605634/133367117-5046230f-3f02-4d3f-8d59-fb61553ec68e.png">
