### PR TITLE
chore: replace mathjs with mexp

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/package.json
+++ b/plugins/legacy-preset-chart-nvd3/package.json
@@ -36,7 +36,7 @@
     "dompurify": "^2.0.6",
     "fast-safe-stringify": "^2.0.6",
     "lodash": "^4.17.11",
-    "mathjs": "^8.0.1",
+    "math-expression-evaluator": "^1.3.8",
     "moment": "^2.20.1",
     "nvd3-fork": "^2.0.5",
     "prop-types": "^15.6.2",

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -995,7 +995,6 @@ function nvd3Vis(element, props) {
               classed: `${fo.opacity} ${fo.style}`,
             };
           });
-          console.log(formulaData);
           data.push(...formulaData);
         }
         const xAxis = chart.xAxis1 ? chart.xAxis1 : chart.xAxis;

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -19,9 +19,9 @@
  */
 import { kebabCase, throttle } from 'lodash';
 import d3 from 'd3';
-import nv from 'nvd3-fork';
-import { parse as mathjsParse } from 'mathjs';
 import moment from 'moment';
+import mexp from 'math-expression-evaluator';
+import nv from 'nvd3-fork';
 import PropTypes from 'prop-types';
 import {
   t,
@@ -919,9 +919,9 @@ function nvd3Vis(element, props) {
       // The below code should be run AFTER rendering because chart is updated in call()
       if (isTimeSeries && activeAnnotationLayers.length > 0) {
         // Formula annotations
-        const formulas = activeAnnotationLayers
-          .filter(a => a.annotationType === ANNOTATION_TYPES.FORMULA)
-          .map(a => ({ ...a, formula: mathjsParse(a.value) }));
+        const formulas = activeAnnotationLayers.filter(
+          a => a.annotationType === ANNOTATION_TYPES.FORMULA,
+        );
 
         let xMax;
         let xMin;
@@ -946,6 +946,13 @@ function nvd3Vis(element, props) {
         }
 
         if (formulas.length > 0) {
+          const token = {
+            type: 3,
+            token: 'x',
+            show: 'x',
+            value: 'x',
+          };
+
           const xValues = [];
           if (vizType === 'bar') {
             // For bar-charts we want one data point evaluated for every
@@ -973,13 +980,22 @@ function nvd3Vis(element, props) {
             }
             xValues.push(xMax);
           }
-          const formulaData = formulas.map(fo => ({
-            key: fo.name,
-            values: xValues.map(x => ({ y: fo.formula.evaluate({ x }), x })),
-            color: fo.color,
-            strokeWidth: fo.width,
-            classed: `${fo.opacity} ${fo.style}`,
-          }));
+          const formulaData = formulas.map(fo => {
+            const { value: expression } = fo;
+            const subExpressions = String(expression).split('=');
+
+            return {
+              key: fo.name,
+              values: xValues.map(x => ({
+                x,
+                y: mexp.eval(subExpressions[1] ?? subExpressions[0], [token], { x }),
+              })),
+              color: fo.color,
+              strokeWidth: fo.width,
+              classed: `${fo.opacity} ${fo.style}`,
+            };
+          });
+          console.log(formulaData);
           data.push(...formulaData);
         }
         const xAxis = chart.xAxis1 ? chart.xAxis1 : chart.xAxis;

--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -28,11 +28,10 @@
   "dependencies": {
     "@superset-ui/chart-controls": "0.18.4",
     "@superset-ui/core": "0.18.4",
-    "@types/mathjs": "^6.0.7",
     "d3-array": "^1.2.0",
     "echarts": "^5.2.0",
     "lodash": "^4.17.15",
-    "mathjs": "^8.0.1"
+    "math-expression-evaluator": "^1.3.8"
   },
   "peerDependencies": {
     "react": "^16.13.1"

--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@superset-ui/chart-controls": "0.18.4",
     "@superset-ui/core": "0.18.4",
+    "@types/math-expression-evaluator": "^1.2.1",
     "d3-array": "^1.2.0",
     "echarts": "^5.2.0",
     "lodash": "^4.17.15",

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -224,7 +224,6 @@ export function transformFormulaAnnotation(
     smooth: true,
     data: evalFormula(layer, data),
     symbolSize: 0,
-    z: 0,
   };
 }
 

--- a/plugins/plugin-chart-echarts/src/utils/annotation.ts
+++ b/plugins/plugin-chart-echarts/src/utils/annotation.ts
@@ -28,18 +28,24 @@ import {
   isTimeseriesAnnotationResult,
   TimeseriesDataRecord,
 } from '@superset-ui/core';
-import { parse as mathjsParse } from 'mathjs';
+import mexp from 'math-expression-evaluator';
 
 export function evalFormula(
   formula: AnnotationLayer,
   data: TimeseriesDataRecord[],
 ): [Date, number][] {
-  const { value } = formula;
-  const node = mathjsParse(value as string);
-  const func = node.compile();
+  const token = {
+    type: 3,
+    token: 'x',
+    show: 'x',
+    value: 'x',
+  };
+  const { value: expression } = formula;
+  const subExpressions = String(expression).split('=');
+
   return data.map(row => [
     new Date(Number(row.__timestamp)),
-    func.evaluate({ x: row.__timestamp }) as number,
+    mexp.eval(subExpressions[1] ?? subExpressions[0], [token], { x: row.__timestamp }),
   ]);
 }
 

--- a/plugins/plugin-chart-echarts/src/utils/annotation.ts
+++ b/plugins/plugin-chart-echarts/src/utils/annotation.ts
@@ -45,7 +45,7 @@ export function evalFormula(
 
   return data.map(row => [
     new Date(Number(row.__timestamp)),
-    mexp.eval(subExpressions[1] ?? subExpressions[0], [token], { x: row.__timestamp }),
+    Number(mexp.eval(subExpressions[1] ?? subExpressions[0], [token], { x: row.__timestamp })),
   ]);
 }
 

--- a/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
+++ b/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
@@ -16,8 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { AnnotationLayer, AnnotationResult } from '@superset-ui/core';
 import {
+  AnnotationLayer,
+  AnnotationOpacity,
+  AnnotationResult,
+  AnnotationSourceType,
+  AnnotationStyle,
+  AnnotationType,
+  FormulaAnnotationLayer,
+  TimeseriesDataRecord,
+} from '@superset-ui/core';
+import {
+  evalFormula,
   extractAnnotationLabels,
   formatAnnotationLabel,
   parseAnnotationOpacity,
@@ -53,10 +63,10 @@ describe('formatAnnotationLabel', () => {
 
 describe('extractForecastSeriesContext', () => {
   it('should extract the correct series name and type', () => {
-    expect(parseAnnotationOpacity('opacityLow')).toEqual(0.2);
-    expect(parseAnnotationOpacity('opacityMedium')).toEqual(0.5);
-    expect(parseAnnotationOpacity('opacityHigh')).toEqual(0.8);
-    expect(parseAnnotationOpacity('')).toEqual(1);
+    expect(parseAnnotationOpacity(AnnotationOpacity.Low)).toEqual(0.2);
+    expect(parseAnnotationOpacity(AnnotationOpacity.Medium)).toEqual(0.5);
+    expect(parseAnnotationOpacity(AnnotationOpacity.High)).toEqual(0.8);
+    expect(parseAnnotationOpacity(AnnotationOpacity.Undefined)).toEqual(1);
     expect(parseAnnotationOpacity(undefined)).toEqual(1);
   });
 });
@@ -65,41 +75,41 @@ describe('extractAnnotationLabels', () => {
   it('should extract all annotations that can be added to the legend', () => {
     const layers: AnnotationLayer[] = [
       {
-        annotationType: 'FORMULA',
+        annotationType: AnnotationType.Formula,
         name: 'My Formula',
         show: true,
-        style: 'solid',
+        style: AnnotationStyle.Solid,
         value: 'sin(x)',
       },
       {
-        annotationType: 'FORMULA',
+        annotationType: AnnotationType.Formula,
         name: 'My Hidden Formula',
         show: false,
-        style: 'solid',
+        style: AnnotationStyle.Solid,
         value: 'sin(2x)',
       },
       {
-        annotationType: 'INTERVAL',
+        annotationType: AnnotationType.Interval,
         name: 'My Interval',
-        sourceType: 'table',
+        sourceType: AnnotationSourceType.Table,
         show: true,
-        style: 'solid',
+        style: AnnotationStyle.Solid,
         value: 1,
       },
       {
-        annotationType: 'TIME_SERIES',
+        annotationType: AnnotationType.Timeseries,
         name: 'My Line',
         show: true,
-        style: 'dashed',
-        sourceType: 'line',
+        style: AnnotationStyle.Dashed,
+        sourceType: AnnotationSourceType.Line,
         value: 1,
       },
       {
-        annotationType: 'TIME_SERIES',
+        annotationType: AnnotationType.Timeseries,
         name: 'My Hidden Line',
         show: false,
-        style: 'dashed',
-        sourceType: 'line',
+        style: AnnotationStyle.Dashed,
+        sourceType: AnnotationSourceType.Line,
         value: 1,
       },
     ];
@@ -115,5 +125,32 @@ describe('extractAnnotationLabels', () => {
     };
 
     expect(extractAnnotationLabels(layers, results)).toEqual(['My Formula', 'Line 1', 'Line 2']);
+  });
+});
+
+describe('evalFormula', () => {
+  const layer: FormulaAnnotationLayer = {
+    annotationType: AnnotationType.Formula,
+    name: 'My Formula',
+    show: true,
+    style: AnnotationStyle.Solid,
+    value: 'x+1',
+  };
+  it('Should evaluate a regular formula', () => {
+    const data: TimeseriesDataRecord[] = [{ __timestamp: 0 }, { __timestamp: 10 }];
+
+    expect(evalFormula(layer, data)).toEqual([
+      [new Date(0), 1],
+      [new Date(10), 11],
+    ]);
+  });
+
+  it('Should evaluate a formula starting with redundant characters', () => {
+    const data: TimeseriesDataRecord[] = [{ __timestamp: 0 }, { __timestamp: 10 }];
+
+    expect(evalFormula({ ...layer, value: 'y  = x* 2   -1' }, data)).toEqual([
+      [new Date(0), -1],
+      [new Date(10), 19],
+    ]);
   });
 });

--- a/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
+++ b/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
@@ -145,7 +145,7 @@ describe('evalFormula', () => {
     ]);
   });
 
-  it('Should evaluate a formula starting with redundant characters', () => {
+  it('Should evaluate a formula containing redundant characters', () => {
     const data: TimeseriesDataRecord[] = [{ __timestamp: 0 }, { __timestamp: 10 }];
 
     expect(evalFormula({ ...layer, value: 'y  = x* 2   -1' }, data)).toEqual([

--- a/yarn.lock
+++ b/yarn.lock
@@ -4802,13 +4802,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/mathjs@^6.0.7":
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/@types/mathjs/-/mathjs-6.0.11.tgz#bf24c1ed875252274008d2c373bad07e0348adfb"
-  integrity sha512-q9B8ZreO41L38iTY76bCZEtAqzeRs4mNIOZpZ1sLSlcYgvgfFrnf8y8qfmas0tVWrsODjmQbQJFD6RJJJCqJbQ==
-  dependencies:
-    decimal.js "^10.0.0"
-
 "@types/micromatch@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.1.tgz#9381449dd659fc3823fd2a4190ceacc985083bc7"
@@ -8336,11 +8329,6 @@ compare-versions@^3.6.0:
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
   integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
 
-complex.js@^2.0.11:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/complex.js/-/complex.js-2.0.12.tgz#fa4df97d8928e5f7b6a86b35bdeecc3a3eda8a22"
-  integrity sha512-oQX99fwL6LrTVg82gDY1dIWXy6qZRnRL35N+YhIX0N7tSwsa0KFy6IEMHTNuCW4mP7FS7MEqZ/2I/afzYwPldw==
-
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -9472,7 +9460,7 @@ decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-decimal.js@^10.0.0, decimal.js@^10.2.1:
+decimal.js@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
   integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
@@ -10046,13 +10034,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.1.2.tgz#aa1ab0cef5b74fa2f7c620261a5f286893d30fd1"
-  integrity sha512-okUhO4sw22vwZp+rTPNjd/bvTdpug4K4sHNHyrV8NdAncIX9/AarlolFqtJCAYKGFYhUBNjIWu1EznFrSWTFxg==
+echarts@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.2.0.tgz#9f1fbfbf048c15ab630bf0a74525c4c534d6cebc"
+  integrity sha512-7CrCKGRjFdpLIJ/Yt1gpHeqs5PiCem2GHPdWZPwKl7WSYeZu0Qzm1bcCFe9/b4dfVaL1zlY4JmdzaVwKksVeqg==
   dependencies:
-    tslib "2.0.3"
-    zrender "5.1.1"
+    tslib "2.3.0"
+    zrender "5.2.0"
 
 editions@^2.2.0:
   version "2.3.1"
@@ -10476,11 +10464,6 @@ escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
-
-escape-latex@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/escape-latex/-/escape-latex-1.2.0.tgz#07c03818cf7dac250cce517f4fda1b001ef2bca1"
-  integrity sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -11657,11 +11640,6 @@ forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
-
-fraction.js@^4.0.13:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.0.13.tgz#3c1c315fa16b35c85fffa95725a36fa729c69dfe"
-  integrity sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -13907,11 +13885,6 @@ java-properties@^1.0.0:
   resolved "https://registry.yarnpkg.com/java-properties/-/java-properties-1.0.2.tgz#ccd1fa73907438a5b5c38982269d0e771fe78211"
   integrity sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==
 
-javascript-natural-sort@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
-  integrity sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=
-
 jed@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/jed/-/jed-1.1.1.tgz#7a549bbd9ffe1585b0cd0a191e203055bee574b4"
@@ -15899,24 +15872,15 @@ math-expression-evaluator@^1.2.14:
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.3.7.tgz#1b62225db86af06f7ea1fd9576a34af605a5b253"
   integrity sha512-nrbaifCl42w37hYd6oRLvoymFK42tWB+WQTMFtksDGQMi5GvlJwnz/CsS30FFAISFLtX+A0csJ0xLiuuyyec7w==
 
+math-expression-evaluator@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.3.8.tgz#320da3b2bc1512f4f50fc3020b2b1cd5c8e9d577"
+  integrity sha512-9FbRY3i6U+CbHgrdNbAUaisjWTozkm1ZfupYQJiZ87NtYHk2Zh9DvxMgp/fifxVhqTLpd5fCCLossUbpZxGeKw==
+
 mathfn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mathfn/-/mathfn-1.2.0.tgz#0e952bd7a8b66e39f490ace4642e675b5837c83e"
   integrity sha512-QBcepxkFxuGk12q4G0KuNbuU3UCXhDROxWZllaNZSpBivkHl2z8qNvi7UGE/WLJt+c7GTC4jigYtur+JDL+40A==
-
-mathjs@^8.0.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-8.1.1.tgz#89d6f2fc4a90e9038db3690678a9e1ce563e15ea"
-  integrity sha512-b3TX3EgiZObujjwb8lZnTDLUuivC2jar4ZBjmGJ4stFYCDXx/DNwx5yry5t/z65p9mvejyZel1qoeR05KtChcQ==
-  dependencies:
-    complex.js "^2.0.11"
-    decimal.js "^10.2.1"
-    escape-latex "^1.2.0"
-    fraction.js "^4.0.13"
-    javascript-natural-sort "^0.7.1"
-    seedrandom "^3.0.5"
-    tiny-emitter "^2.1.0"
-    typed-function "^2.0.0"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -21665,7 +21629,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-emitter@^2.0.0, tiny-emitter@^2.1.0:
+tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
@@ -21969,10 +21933,10 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+tslib@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
@@ -22069,11 +22033,6 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
-
-typed-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-2.0.0.tgz#15ab3825845138a8b1113bd89e60cd6a435739e8"
-  integrity sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA==
 
 typed-styles@^0.0.7:
   version "0.0.7"
@@ -23474,9 +23433,9 @@ yosay@^2.0.2:
     taketalk "^1.0.0"
     wrap-ansi "^2.0.0"
 
-zrender@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.1.1.tgz#0515f4f8cc0f4742f02a6b8819550a6d13d64c5c"
-  integrity sha512-oeWlmUZPQdS9f5hK4pV21tHPqA3wgQ7CkKkw7l0CCBgWlJ/FP+lRgLFtUBW6yam4JX8y9CdHJo1o587VVrbcoQ==
+zrender@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.2.0.tgz#f8abc484ac4a8a51b04c3ccd37beabe1def342cd"
+  integrity sha512-87v3gvB0lcWy48ObA/DwrhQ95ADMMRhECVrXmHDFCBNvbxHFfEDZtrZh4VmVjLAeFAjimY4PyZ65rbLCivdszA==
   dependencies:
-    tslib "2.0.3"
+    tslib "2.3.0"


### PR DESCRIPTION
🏠 Internal
Replace `mathjs` (11 Mb bundle) with `math-expression-evaluator` (71 kb) as done on https://github.com/apache/superset/pull/16701.

Checklist:
- added unit tests to `plugins-chart-echart` for formula evaluation
- ensure formula annotations work on both NVD3 and ECharts plugin:

NVD3 plugin after migration:
![image](https://user-images.githubusercontent.com/33317356/133620150-b236656a-fdbb-4b6f-bbf2-217604261c1a.png)

ECharts plugin after migration:
![image](https://user-images.githubusercontent.com/33317356/133620241-70a45516-0863-46ed-8913-9d7756fac809.png)

Also fix z-index of formula to make sure it is displayed above other charts:

### AFTER
![image](https://user-images.githubusercontent.com/33317356/133621130-541e7d11-c8a5-4bbc-b802-f622d9d909d4.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/133621266-c9d4a6be-40e8-44c7-b7c3-d6d25437c564.png)
