### PR TITLE
refactor: migrate timeseries_limit_metric to legacy_order_by

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -512,6 +512,7 @@ const sharedControls = {
   series_columns: enableExploreDnd ? dndColumnsControl : columnsControl,
   series_limit,
   series_limit_metric: enableExploreDnd ? dnd_sort_by : sort_by,
+  legacy_order_by: enableExploreDnd ? dnd_sort_by : sort_by,
 };
 
 export default sharedControls;

--- a/packages/superset-ui-chart-controls/src/shared-controls/legacySortBy.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/legacySortBy.tsx
@@ -16,24 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import * as sectionsModule from './sections';
+import { t } from '@superset-ui/core';
+import { ControlSetRow } from '../types';
 
-export * from './utils';
-export * from './constants';
-export * from './operators';
-
-// can't do `export * as sections from './sections'`, babel-transformer will fail
-export const sections = sectionsModule;
-
-export * from './components/InfoTooltipWithTrigger';
-export * from './components/ColumnOption';
-export * from './components/ColumnTypeLabel';
-export * from './components/MetricOption';
-
-// React control components
-export { default as sharedControls } from './shared-controls';
-export { default as sharedControlComponents } from './shared-controls/components';
-export { legacySortBy } from './shared-controls/legacySortBy';
-export * from './shared-controls/emitFilterControl';
-export * from './shared-controls/components';
-export * from './types';
+export const legacySortBy: ControlSetRow[] = [
+  ['legacy_order_by'],
+  [
+    {
+      name: 'order_desc',
+      config: {
+        type: 'CheckboxControl',
+        label: t('Sort descending'),
+        default: true,
+        description: t(
+          'Whether to sort descending or ascending. Takes effect only when "Sort by" is set',
+        ),
+      },
+    },
+  ],
+];

--- a/packages/superset-ui-core/src/query/normalizeOrderBy.ts
+++ b/packages/superset-ui-core/src/query/normalizeOrderBy.ts
@@ -38,6 +38,7 @@ export default function normalizeOrderBy(queryObject: QueryObject): QueryObject 
   // ensure that remove invalid orderby clause
   const cloneQueryObject = { ...queryObject };
   delete cloneQueryObject.timeseries_limit_metric;
+  delete cloneQueryObject.legacy_order_by;
   delete cloneQueryObject.order_desc;
   delete cloneQueryObject.orderby;
 

--- a/packages/superset-ui-core/src/query/normalizeOrderBy.ts
+++ b/packages/superset-ui-core/src/query/normalizeOrderBy.ts
@@ -53,6 +53,19 @@ export default function normalizeOrderBy(queryObject: QueryObject): QueryObject 
     };
   }
 
+  // todo: Removed `legacy_ordery_by` after refactoring
+  if (
+    queryObject.legacy_order_by !== undefined &&
+    queryObject.legacy_order_by !== null &&
+    !isEmpty(queryObject.legacy_order_by)
+  ) {
+    return {
+      ...cloneQueryObject,
+      // @ts-ignore
+      orderby: [[queryObject.legacy_order_by, isAsc]],
+    };
+  }
+
   if (Array.isArray(queryObject.metrics) && queryObject.metrics.length > 0) {
     return {
       ...cloneQueryObject,

--- a/packages/superset-ui-core/test/query/normalizeOrderBy.test.ts
+++ b/packages/superset-ui-core/test/query/normalizeOrderBy.test.ts
@@ -69,6 +69,46 @@ describe('normalizeOrderBy', () => {
     });
   });
 
+  it('should transform legacy_order_by in queryObject', () => {
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      metrics: ['count(*)'],
+      legacy_order_by: {
+        expressionType: 'SIMPLE',
+        column: {
+          id: 1,
+          column_name: 'sales',
+        },
+        aggregate: 'SUM',
+      },
+      order_desc: true,
+    };
+    const expectedQueryObject = normalizeOrderBy(query);
+    expect(expectedQueryObject).not.toHaveProperty('legacy_order_by');
+    expect(expectedQueryObject).not.toHaveProperty('order_desc');
+    expect(expectedQueryObject).toEqual({
+      datasource: '5__table',
+      viz_type: 'table',
+      time_range: '1 year ago : 2013',
+      metrics: ['count(*)'],
+      orderby: [
+        [
+          {
+            expressionType: 'SIMPLE',
+            column: {
+              id: 1,
+              column_name: 'sales',
+            },
+            aggregate: 'SUM',
+          },
+          false,
+        ],
+      ],
+    });
+  });
+
   it('has metrics in queryObject', () => {
     const query: QueryObject = {
       datasource: '5__table',

--- a/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -25,20 +25,15 @@ import {
 import { PivotTableQueryFormData } from '../types';
 
 export default function buildQuery(formData: PivotTableQueryFormData) {
-  const {
-    groupbyColumns = [],
-    groupbyRows = [],
-    order_desc = true,
-    timeseries_limit_metric,
-  } = formData;
+  const { groupbyColumns = [], groupbyRows = [], order_desc = true, legacy_order_by } = formData;
   const groupbySet = new Set([
     ...ensureIsArray<string>(groupbyColumns),
     ...ensureIsArray<string>(groupbyRows),
   ]);
   return buildQueryContext(formData, baseQueryObject => {
-    const queryObject = normalizeOrderBy({ ...baseQueryObject, order_desc });
+    const queryObject = normalizeOrderBy({ ...baseQueryObject, order_desc, legacy_order_by });
     const { metrics } = queryObject;
-    const orderBy = ensureIsArray(timeseries_limit_metric);
+    const orderBy = ensureIsArray(legacy_order_by);
     if (
       orderBy.length &&
       !metrics?.find(metric => getMetricLabel(metric) === getMetricLabel(orderBy[0]))

--- a/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.ts
@@ -24,6 +24,7 @@ import {
   sections,
   sharedControls,
   emitFilterControl,
+  legacySortBy,
 } from '@superset-ui/chart-controls';
 import { MetricsLayoutEnum } from '../types';
 
@@ -89,20 +90,7 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        ['timeseries_limit_metric'],
-        [
-          {
-            name: 'order_desc',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Sort descending'),
-              default: true,
-              description: t(
-                'Whether to sort descending or ascending. Takes effect only when "Sort by" is set',
-              ),
-            },
-          },
-        ],
+        ...legacySortBy,
       ],
     },
     {

--- a/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/plugins/plugin-chart-pivot-table/src/types.ts
@@ -67,7 +67,7 @@ interface PivotTableCustomizeProps {
   metricsLayout?: MetricsLayoutEnum;
   metricColorFormatters: ColorFormatters;
   dateFormatters: Record<string, DateFormatter | undefined>;
-  timeseries_limit_metric: QueryFormMetric[] | QueryFormMetric | null;
+  legacy_order_by: QueryFormMetric[] | QueryFormMetric | null;
   order_desc: boolean;
 }
 

--- a/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
@@ -25,7 +25,7 @@ describe('PivotTableChart buildQuery', () => {
     metricColorFormatters: [],
     dateFormatters: {},
     setDataMask: () => {},
-    timeseries_limit_metric: 'count',
+    legacy_order_by: 'count',
     order_desc: true,
   };
 

--- a/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -25,7 +25,7 @@ describe('PivotTableChart transformProps', () => {
     datasource: '',
     conditionalFormatting: [],
     dateFormat: '',
-    timeseries_limit_metric: 'count',
+    legacy_order_by: 'count',
     order_desc: true,
   };
   const chartProps = new ChartProps<QueryFormData>({


### PR DESCRIPTION
🏆 Enhancements
backend changes at: https://github.com/apache/superset/pull/16849

currently, Superset use `timeseries_limit_metric` control for main query orderby. While this is actually prepared for the inner query when viz is timeseries-like.

To fix the original incorrect use, so this PR introduce a `legacy_order_by` control.

This PR only migrate `pivot table v2`.
