### PR TITLE
chore(plugin-chart-echarts): bump to ECharts 5.2.1

### DIFF
--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -30,7 +30,7 @@
     "@superset-ui/core": "0.18.5",
     "@types/math-expression-evaluator": "^1.2.1",
     "d3-array": "^1.2.0",
-    "echarts": "^5.2.0",
+    "echarts": "^5.2.1",
     "lodash": "^4.17.15",
     "math-expression-evaluator": "^1.3.8"
   },

--- a/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
@@ -23,7 +23,7 @@ import {
   getNumberFormatter,
   getTimeFormatter,
 } from '@superset-ui/core';
-import { EChartsOption, BoxplotSeriesOption } from 'echarts';
+import { EChartsCoreOption, BoxplotSeriesOption } from 'echarts';
 import { CallbackDataParams } from 'echarts/types/src/util/types';
 import {
   BoxPlotChartTransformedProps,
@@ -206,7 +206,7 @@ export default function transformProps(
     yAxisTitleMargin,
     xAxisTitleMargin,
   );
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     grid: {
       ...defaultGrid,
       ...chartPadding,

--- a/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
+++ b/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
@@ -23,7 +23,7 @@ import {
   QueryFormData,
   SetDataMaskHook,
 } from '@superset-ui/core';
-import { EChartsOption } from 'echarts';
+import { EChartsCoreOption } from 'echarts';
 import { EchartsTitleFormData, DEFAULT_TITLE_FORM_DATA } from '../types';
 
 export type BoxPlotQueryFormData = QueryFormData & {
@@ -56,7 +56,7 @@ export interface BoxPlotChartTransformedProps {
   formData: BoxPlotQueryFormData;
   height: number;
   width: number;
-  echartOptions: EChartsOption;
+  echartOptions: EChartsCoreOption;
   emitFilter: boolean;
   setDataMask: SetDataMaskHook;
   labelMap: Record<string, DataRecordValue[]>;

--- a/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -181,6 +181,7 @@ export default function transformProps(
           fontWeight: 'bold',
         },
       },
+      // @ts-ignore
       data: transformedData,
     },
   ];

--- a/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -26,7 +26,7 @@ import {
   NumberFormatter,
 } from '@superset-ui/core';
 import { CallbackDataParams } from 'echarts/types/src/util/types';
-import { EChartsOption, FunnelSeriesOption } from 'echarts';
+import { EChartsCoreOption, FunnelSeriesOption } from 'echarts';
 import {
   DEFAULT_FORM_DATA as DEFAULT_FUNNEL_FORM_DATA,
   EchartsFunnelChartProps,
@@ -185,7 +185,7 @@ export default function transformProps(
     },
   ];
 
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     grid: {
       ...defaultGrid,
     },

--- a/plugins/plugin-chart-echarts/src/Funnel/types.ts
+++ b/plugins/plugin-chart-echarts/src/Funnel/types.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { EChartsOption } from 'echarts';
+import { EChartsCoreOption } from 'echarts';
 import {
   ChartDataResponseResult,
   ChartProps,
@@ -80,7 +80,7 @@ export interface FunnelChartTransformedProps {
   formData: EchartsFunnelFormData;
   height: number;
   width: number;
-  echartOptions: EChartsOption;
+  echartOptions: EChartsCoreOption;
   emitFilter: boolean;
   setDataMask: SetDataMaskHook;
   labelMap: Record<string, DataRecordValue[]>;

--- a/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
@@ -25,7 +25,7 @@ import {
   getMetricLabel,
   DataRecordValue,
 } from '@superset-ui/core';
-import { EChartsOption, GaugeSeriesOption } from 'echarts';
+import { EChartsCoreOption, GaugeSeriesOption } from 'echarts';
 import { GaugeDataItemOption } from 'echarts/types/src/chart/gauge/GaugeSeries';
 import range from 'lodash/range';
 import { parseNumbersList } from '../utils/controls';
@@ -253,7 +253,7 @@ export default function transformProps(
     },
   ];
 
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     series,
   };
 

--- a/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
@@ -23,7 +23,7 @@ import {
   DataRecord,
   DataRecordValue,
 } from '@superset-ui/core';
-import { EChartsOption, GraphSeriesOption } from 'echarts';
+import { EChartsCoreOption, GraphSeriesOption } from 'echarts';
 import { extent as d3Extent } from 'd3-array';
 import { GraphEdgeItemOption } from 'echarts/types/src/chart/graph/GraphSeries';
 import {
@@ -265,7 +265,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     },
   ];
 
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     animationDuration: DEFAULT_GRAPH_SERIES_OPTION.animationDuration,
     animationEasing: DEFAULT_GRAPH_SERIES_OPTION.animationEasing,
     tooltip: {

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -28,7 +28,7 @@ import {
   isIntervalAnnotationLayer,
   isTimeseriesAnnotationLayer,
 } from '@superset-ui/core';
-import { EChartsOption, SeriesOption } from 'echarts';
+import { EChartsCoreOption, SeriesOption } from 'echarts';
 import {
   DEFAULT_FORM_DATA,
   EchartsMixedTimeseriesFormData,
@@ -227,7 +227,7 @@ export default function transformProps(
 
   const { setDataMask = () => {} } = hooks;
 
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     useUTC: true,
     grid: {
       ...defaultGrid,

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { EChartsOption } from 'echarts';
+import { EChartsCoreOption } from 'echarts';
 import {
   AnnotationLayer,
   TimeGranularity,
@@ -140,7 +140,7 @@ export type EchartsMixedTimeseriesChartTransformedProps = {
   formData: EchartsMixedTimeseriesFormData;
   height: number;
   width: number;
-  echartOptions: EChartsOption;
+  echartOptions: EChartsCoreOption;
   emitFilter: boolean;
   emitFilterB: boolean;
   setDataMask: SetDataMaskHook;

--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -26,7 +26,7 @@ import {
   NumberFormatter,
 } from '@superset-ui/core';
 import { CallbackDataParams } from 'echarts/types/src/util/types';
-import { EChartsOption, PieSeriesOption } from 'echarts';
+import { EChartsCoreOption, PieSeriesOption } from 'echarts';
 import {
   DEFAULT_FORM_DATA as DEFAULT_PIE_FORM_DATA,
   EchartsPieChartProps,
@@ -211,7 +211,7 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
     },
   ];
 
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     grid: {
       ...defaultGrid,
     },

--- a/plugins/plugin-chart-echarts/src/Pie/types.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/types.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { EChartsOption } from 'echarts';
+import { EChartsCoreOption } from 'echarts';
 import {
   ChartDataResponseResult,
   ChartProps,
@@ -88,7 +88,7 @@ export interface PieChartTransformedProps {
   formData: EchartsPieFormData;
   height: number;
   width: number;
-  echartOptions: EChartsOption;
+  echartOptions: EChartsCoreOption;
   emitFilter: boolean;
   setDataMask: SetDataMaskHook;
   labelMap: Record<string, DataRecordValue[]>;

--- a/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
@@ -27,7 +27,7 @@ import {
 } from '@superset-ui/core';
 import { CallbackDataParams } from 'echarts/types/src/util/types';
 import { RadarSeriesDataItemOption } from 'echarts/types/src/chart/radar/RadarSeries';
-import { EChartsOption, RadarSeriesOption } from 'echarts';
+import { EChartsCoreOption, RadarSeriesOption } from 'echarts';
 import {
   DEFAULT_FORM_DATA as DEFAULT_RADAR_FORM_DATA,
   EchartsRadarChartProps,
@@ -195,7 +195,7 @@ export default function transformProps(
     },
   ];
 
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     grid: {
       ...defaultGrid,
     },

--- a/plugins/plugin-chart-echarts/src/Radar/types.ts
+++ b/plugins/plugin-chart-echarts/src/Radar/types.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { EChartsOption } from 'echarts';
+import { EChartsCoreOption } from 'echarts';
 import {
   ChartDataResponseResult,
   ChartProps,
@@ -82,7 +82,7 @@ export interface RadarChartTransformedProps {
   formData: EchartsRadarFormData;
   height: number;
   width: number;
-  echartOptions: EChartsOption;
+  echartOptions: EChartsCoreOption;
   setDataMask: SetDataMaskHook;
   labelMap: Record<string, DataRecordValue[]>;
   groupby: string[];

--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -71,9 +71,7 @@ export default function EchartsTimeseries({
 
   const eventHandlers: EventHandlers = {
     click: props => {
-      const { seriesName: name, value } = props;
-      const xValue = value[0].getTime?.() || value[0];
-      console.log(props, name, xValue);
+      const { seriesName: name } = props;
       const values = Object.values(selectedValues);
       if (values.includes(name)) {
         handleChange(values.filter(v => v !== name));

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -28,7 +28,7 @@ import {
   TimeseriesChartDataResponseResult,
   DataRecordValue,
 } from '@superset-ui/core';
-import { EChartsOption, SeriesOption } from 'echarts';
+import { EChartsCoreOption, SeriesOption } from 'echarts';
 import {
   DEFAULT_FORM_DATA,
   EchartsTimeseriesChartProps,
@@ -221,7 +221,7 @@ export default function transformProps(
     yAxisTitleMargin,
     xAxisTitleMargin,
   );
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     useUTC: true,
     grid: {
       ...defaultGrid,
@@ -233,6 +233,7 @@ export default function transformProps(
       nameGap: xAxisTitleMargin,
       nameLocation: 'middle',
       axisLabel: {
+        hideOverlap: true,
         formatter: xAxisFormatter,
         rotate: xAxisLabelRotation,
       },

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -36,7 +36,7 @@ import {
 import { SeriesOption } from 'echarts';
 import {
   CallbackDataParams,
-  DefaultExtraStateOpts,
+  DefaultStatesMixin,
   ItemStyleOption,
   LineStyleOption,
   OptionName,
@@ -301,7 +301,7 @@ export function transformEventAnnotation(
       },
     ];
 
-    const lineStyle: LineStyleOption & DefaultExtraStateOpts['emphasis'] = {
+    const lineStyle: LineStyleOption & DefaultStatesMixin['emphasis'] = {
       width,
       type: style as ZRLineType,
       color: color || colorScale(name),

--- a/plugins/plugin-chart-echarts/src/Tree/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Tree/transformProps.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { ChartProps, getMetricLabel, DataRecordValue } from '@superset-ui/core';
-import { EChartsOption, TreeSeriesOption } from 'echarts';
+import { EChartsCoreOption, TreeSeriesOption } from 'echarts';
 import {
   TreeSeriesCallbackDataParams,
   TreeSeriesNodeItemOption,
@@ -190,7 +190,7 @@ export default function transformProps(chartProps: ChartProps): EchartsProps {
     },
   ];
 
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     animationDuration: DEFAULT_TREE_SERIES_OPTION.animationDuration,
     animationEasing: DEFAULT_TREE_SERIES_OPTION.animationEasing,
     series,

--- a/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
@@ -28,7 +28,7 @@ import {
 } from '@superset-ui/core';
 import { groupBy, isNumber, transform } from 'lodash';
 import { TreemapSeriesNodeItemOption } from 'echarts/types/src/chart/treemap/TreemapSeries';
-import { EChartsOption, TreemapSeriesOption } from 'echarts';
+import { EChartsCoreOption, TreemapSeriesOption } from 'echarts';
 import {
   DEFAULT_FORM_DATA as DEFAULT_TREEMAP_FORM_DATA,
   EchartsTreemapChartProps,
@@ -279,7 +279,7 @@ export default function transformProps(
     },
   ];
 
-  const echartOptions: EChartsOption = {
+  const echartOptions: EChartsCoreOption = {
     tooltip: {
       ...defaultTooltip,
       trigger: 'item',

--- a/plugins/plugin-chart-echarts/src/Treemap/types.ts
+++ b/plugins/plugin-chart-echarts/src/Treemap/types.ts
@@ -24,7 +24,7 @@ import {
   QueryFormMetric,
   SetDataMaskHook,
 } from '@superset-ui/core';
-import { EChartsOption } from 'echarts';
+import { EChartsCoreOption } from 'echarts';
 import { CallbackDataParams } from 'echarts/types/src/util/types';
 import { LabelPositionEnum } from '../types';
 
@@ -77,7 +77,7 @@ export interface TreemapTransformedProps {
   formData: EchartsTreemapFormData;
   height: number;
   width: number;
-  echartOptions: EChartsOption;
+  echartOptions: EChartsCoreOption;
   emitFilter: boolean;
   setDataMask: SetDataMaskHook;
   labelMap: Record<string, DataRecordValue[]>;

--- a/plugins/plugin-chart-echarts/src/types.ts
+++ b/plugins/plugin-chart-echarts/src/types.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { DataRecordValue, SetDataMaskHook } from '@superset-ui/core';
-import { EChartsOption } from 'echarts';
+import { EChartsCoreOption } from 'echarts';
 import { TooltipMarker } from 'echarts/types/src/util/format';
 
 export type EchartsStylesProps = {
@@ -28,7 +28,7 @@ export type EchartsStylesProps = {
 export interface EchartsProps {
   height: number;
   width: number;
-  echartOptions: EChartsOption;
+  echartOptions: EChartsCoreOption;
   eventHandlers?: EventHandlers;
   selectedValues?: Record<number, string>;
   forceClear?: boolean;
@@ -102,7 +102,7 @@ export interface EChartTransformedProps<F> {
   formData: F;
   height: number;
   width: number;
-  echartOptions: EChartsOption;
+  echartOptions: EChartsCoreOption;
   emitFilter: boolean;
   setDataMask: SetDataMaskHook;
   labelMap: Record<string, DataRecordValue[]>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4802,6 +4802,11 @@
   dependencies:
     "@types/react" "*"
 
+"@types/math-expression-evaluator@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/math-expression-evaluator/-/math-expression-evaluator-1.2.1.tgz#081f339b4fad815d2049f6a1dabbc9ee5e43f189"
+  integrity sha512-H6IG9R0jU16nR3N24UpL7X40aDcUl5eTncBSd/itwz6rWI4nNzMcNYreHj0MnKlHSga1Iq1AqjSuY67EhiN+Zw==
+
 "@types/micromatch@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.1.tgz#9381449dd659fc3823fd2a4190ceacc985083bc7"
@@ -10034,13 +10039,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.2.0.tgz#9f1fbfbf048c15ab630bf0a74525c4c534d6cebc"
-  integrity sha512-7CrCKGRjFdpLIJ/Yt1gpHeqs5PiCem2GHPdWZPwKl7WSYeZu0Qzm1bcCFe9/b4dfVaL1zlY4JmdzaVwKksVeqg==
+echarts@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.2.1.tgz#bd58ec011cd82def4a714e4038ef4b73b8417bc3"
+  integrity sha512-OJ79b22eqRfbSV8vYmDKmA+XWfNbr0Uk/OafWcFNIGDWti2Uw9A6eVCiJLmqPa9Sk+EWL+t5v26aak0z3gxiZw==
   dependencies:
     tslib "2.3.0"
-    zrender "5.2.0"
+    zrender "5.2.1"
 
 editions@^2.2.0:
   version "2.3.1"
@@ -23433,9 +23438,9 @@ yosay@^2.0.2:
     taketalk "^1.0.0"
     wrap-ansi "^2.0.0"
 
-zrender@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.2.0.tgz#f8abc484ac4a8a51b04c3ccd37beabe1def342cd"
-  integrity sha512-87v3gvB0lcWy48ObA/DwrhQ95ADMMRhECVrXmHDFCBNvbxHFfEDZtrZh4VmVjLAeFAjimY4PyZ65rbLCivdszA==
+zrender@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.2.1.tgz#5f4bbda915ba6d412b0b19dc2431beaad05417bb"
+  integrity sha512-M3bPGZuyLTNBC6LiNKXJwSCtglMp8XUEqEBG+2MdICDI3d1s500Y4P0CzldQGsqpRVB7fkvf3BKQQRxsEaTlsw==
   dependencies:
     tslib "2.3.0"


### PR DESCRIPTION
🐛 Bug Fix

Bump to latest version of ECharts. Also set `axisLabel.hideOverlap` to `true` to get rid of overlapping x-axis labels. See https://github.com/apache/echarts/pull/15712 and https://github.com/apache/echarts/pull/15583 for details.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/134109181-3b860d21-8dfe-4839-ac61-13488f74890a.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/134108799-c2f73ca3-de96-4391-ab3e-626e2b0e5d7a.png)
