### PR TITLE
fix: replace absolute difference with difference in echart

### DIFF
--- a/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
+++ b/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
@@ -114,13 +114,13 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
           default: 'values',
           choices: [
             [ComparisionType.Values, 'Actual values'],
-            [ComparisionType.Absolute, 'Absolute difference'],
+            [ComparisionType.Difference, 'Difference'],
             [ComparisionType.Percentage, 'Percentage change'],
             [ComparisionType.Ratio, 'Ratio'],
           ],
           description: t(
             'How to display time shifts: as individual lines; as the ' +
-              'absolute difference between the main time series and each time shift; ' +
+              'difference between the main time series and each time shift; ' +
               'as the percentage change; or as the ratio between series and time shifts.',
           ),
         },

--- a/packages/superset-ui-chart-controls/test/utils/operators/rollingWindowOperator.test.ts
+++ b/packages/superset-ui-chart-controls/test/utils/operators/rollingWindowOperator.test.ts
@@ -118,8 +118,8 @@ test('rolling window and "actual values" in the time compare', () => {
   });
 });
 
-test('rolling window and "absolute / percentage / ratio" in the time compare', () => {
-  const comparisionTypes = ['absolute', 'percentage', 'ratio'];
+test('rolling window and "difference / percentage / ratio" in the time compare', () => {
+  const comparisionTypes = ['difference', 'percentage', 'ratio'];
   comparisionTypes.forEach(cType => {
     expect(
       rollingWindowOperator(

--- a/packages/superset-ui-chart-controls/test/utils/operators/timeCompareOperator.test.ts
+++ b/packages/superset-ui-chart-controls/test/utils/operators/timeCompareOperator.test.ts
@@ -71,8 +71,8 @@ test('time compare: skip transformation', () => {
   ).toEqual(undefined);
 });
 
-test('time compare: absolute/percentage/ratio', () => {
-  const comparisionTypes = ['absolute', 'percentage', 'ratio'];
+test('time compare: difference/percentage/ratio', () => {
+  const comparisionTypes = ['difference', 'percentage', 'ratio'];
   comparisionTypes.forEach(cType => {
     expect(
       timeCompareOperator(

--- a/packages/superset-ui-chart-controls/test/utils/operators/timeCompareOperator.test.ts
+++ b/packages/superset-ui-chart-controls/test/utils/operators/timeCompareOperator.test.ts
@@ -125,8 +125,8 @@ test('time compare pivot: values', () => {
   });
 });
 
-test('time compare pivot: absolute/percentage/ratio', () => {
-  const comparisionTypes = ['absolute', 'percentage', 'ratio'];
+test('time compare pivot: difference/percentage/ratio', () => {
+  const comparisionTypes = ['difference', 'percentage', 'ratio'];
   comparisionTypes.forEach(cType => {
     expect(
       timeComparePivotOperator(

--- a/packages/superset-ui-core/src/query/types/AdvancedAnalytics.ts
+++ b/packages/superset-ui-core/src/query/types/AdvancedAnalytics.ts
@@ -31,7 +31,7 @@ export interface RollingWindow {
 
 export enum ComparisionType {
   Values = 'values',
-  Absolute = 'absolute',
+  Difference = 'difference',
   Percentage = 'percentage',
   Ratio = 'ratio',
 }


### PR DESCRIPTION
🐛 Bug Fix

Currently, incorrect type of calculation in `time comparsion`, should replace absolute difference with difference.

backend codes at: https://github.com/apache/superset/pull/16930

related issue: https://github.com/apache/superset/issues/16766
