### PR TITLE
fix: replace absolute difference with difference in legacy charts

### DIFF
--- a/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx
+++ b/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx
@@ -315,13 +315,13 @@ const config: ControlPanelConfig = {
               default: 'values',
               choices: [
                 ['values', 'Actual Values'],
-                ['absolute', 'Absolute difference'],
+                ['absolute', 'Difference'],
                 ['percentage', 'Percentage change'],
                 ['ratio', 'Ratio'],
               ],
               description: t(
                 'How to display time shifts: as individual lines; as the ' +
-                  'absolute difference between the main time series and each time shift; ' +
+                  'difference between the main time series and each time shift; ' +
                   'as the percentage change; or as the ratio between series and time shifts.',
               ),
             },

--- a/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx
+++ b/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx
@@ -210,13 +210,13 @@ const config: ControlPanelConfig = {
               default: 'values',
               choices: [
                 ['values', 'Actual Values'],
-                ['absolute', 'Absolute difference'],
+                ['absolute', 'Difference'],
                 ['percentage', 'Percentage change'],
                 ['ratio', 'Ratio'],
               ],
               description: t(
                 'How to display time shifts: as individual lines; as the ' +
-                  'absolute difference between the main time series and each time shift; ' +
+                  'difference between the main time series and each time shift; ' +
                   'as the percentage change; or as the ratio between series and time shifts.',
               ),
             },

--- a/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
+++ b/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
@@ -458,13 +458,13 @@ export const timeSeriesSection: ControlPanelSectionConfig[] = [
             default: 'values',
             choices: [
               ['values', 'Actual Values'],
-              ['absolute', 'Absolute difference'],
+              ['absolute', 'Difference'],
               ['percentage', 'Percentage change'],
               ['ratio', 'Ratio'],
             ],
             description: t(
               'How to display time shifts: as individual lines; as the ' +
-                'absolute difference between the main time series and each time shift; ' +
+                'difference between the main time series and each time shift; ' +
                 'as the percentage change; or as the ratio between series and time shifts.',
             ),
           },


### PR DESCRIPTION
🐛 Bug Fix
replace `absolute difference` with `difference` in legacy charts

#### After:

![image](https://user-images.githubusercontent.com/2016594/135566938-a2299b32-e0a9-4fc4-a6e1-c78d850914f6.png)

related issue: https://github.com/apache/superset/issues/16766
