### PR TITLE
chore: hide rolling_periods and min_periods

### DIFF
--- a/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
+++ b/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
@@ -59,7 +59,7 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
           ),
           visibility: ({ controls }) =>
             Boolean(controls?.rolling_type?.value) &&
-            controls?.rolling_type?.value !== RollingType.Cumsum,
+            controls.rolling_type.value !== RollingType.Cumsum,
         },
       },
     ],

--- a/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
+++ b/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
@@ -79,7 +79,7 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
           ),
           visibility: ({ controls }) =>
             Boolean(controls?.rolling_type?.value) &&
-            controls?.rolling_type?.value !== RollingType.Cumsum,
+            controls.rolling_type.value !== RollingType.Cumsum,
         },
       },
     ],

--- a/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
+++ b/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
@@ -57,6 +57,9 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
             'Defines the size of the rolling window function, ' +
               'relative to the time granularity selected',
           ),
+          visibility: ({ controls }) =>
+            Boolean(controls?.rolling_type?.value) &&
+            controls?.rolling_type?.value !== RollingType.Cumsum,
         },
       },
     ],
@@ -74,6 +77,9 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
               'shown are the total of 7 periods. This will hide the "ramp up" ' +
               'taking place over the first 7 periods',
           ),
+          visibility: ({ controls }) =>
+            Boolean(controls?.rolling_type?.value) &&
+            controls?.rolling_type?.value !== RollingType.Cumsum,
         },
       },
     ],


### PR DESCRIPTION
🏆 Enhancements
hide `periods` and `min periods` when unselect rolling function or cumsum 

![image](https://user-images.githubusercontent.com/2016594/136172289-897d1f88-bbfa-479a-b0ce-6e1047aaa8e0.png)
