### PR TITLE
chore(legacy-preset-chart-nvd3): deprecate MultiLine chart

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/LineMulti/index.js
@@ -35,6 +35,7 @@ const metadata = new ChartMetadata({
     t('Comparison'),
     t('Time'),
     t('Multi-Layers'),
+    t('Deprecated'),
   ],
   thumbnail,
   useLegacyApi: true,


### PR DESCRIPTION
📜 Documentation

Marking NVD3 MultiLine as deprecated.