### PR TITLE
fix: npm registry connection set to ssl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Configure npm and git
         run: |
           yarn logout
-          echo "@superset-ui:registry=http://registry.npmjs.org/" > .npmrc
-          echo "registry=http://registry.npmjs.org/" >> .npmrc
+          echo "@superset-ui:registry=https://registry.npmjs.org/" > .npmrc
+          echo "registry=https://registry.npmjs.org/" >> .npmrc
           echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
           npm whoami
           git config --local user.email "action@github.com"


### PR DESCRIPTION
🐛 Bug Fix

Currently release workflow blocked by npm security policy. Beginning October 4, 2021, all connections to npm websites and the npm registry must use SSL 1.2+.


https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/

<img width="1286" alt="image" src="https://user-images.githubusercontent.com/2016594/136359003-3b318235-1f45-4820-8dbd-126fa65af90e.png">

