### PR TITLE
chore: Adaptation of storybook 6.x params

### DIFF
--- a/packages/superset-ui-demo/.storybook/preview.js
+++ b/packages/superset-ui-demo/.storybook/preview.js
@@ -21,6 +21,7 @@ addDecorator(jsxDecorator);
 addDecorator(themeDecorator);
 
 addParameters({
+  passArgsFirst: false,
   options: {
     name: '✨ Superset UI',
     addonPanelInRight: false,


### PR DESCRIPTION
🐛 Bug Fix
Fix the problem that the chart's width and height of storybook 6 cannot be correctly adapted.

![image](https://user-images.githubusercontent.com/11830681/138049468-0146bb94-598d-4d41-a15f-bb18621202e9.png)

### after

https://user-images.githubusercontent.com/11830681/138049608-3572db69-5d1a-438b-a7b8-ba2c2145a140.mov


