### PR TITLE
fix: Set default series limit to zero

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -330,7 +330,7 @@ const limit: SharedControlConfig<'SelectControl'> = {
   freeForm: true,
   label: t('Series limit'),
   validators: [legacyValidateInteger],
-  default: 100,
+  default: 0,
   choices: formatSelectOptions(SERIES_LIMITS),
   description: t(
     'Limits the number of time series that get displayed. A sub query ' +


### PR DESCRIPTION
💔 Breaking Changes
🏠 Internal

I'm not sure if the series limit logic changed as part of https://github.com/apache/superset/pull/16660 (personally I couldn't find anything abnormal which gets invoked if the series limit is truthy, i.e., not `None` or `0` unless perviously there was also a requirement for a sort-by metric) but it seems like either a sub-query or two-phase query runs even if they user didn't explicitly define a series limit per the UI as it falls back to the default (100). 

Per the attached screenshot, when clearing the limit there's no indication that a limit is being defined—I would speculate that the user would sense the limit is undefined, i.e., `None` (which is equivalent to `0`):

<img width="1081" alt="Screen Shot 2021-10-25 at 8 43 19 AM" src="https://user-images.githubusercontent.com/4567245/138728430-306b87a1-e02d-42ce-9293-ab3fed883538.png">

however the form-data falls back to the default, resulting in an unexpected sub-query or two-phase query,

```sql
SELECT year AS __timestamp,
               genre AS genre,
               COUNT(*) AS count
FROM video_game_sales
JOIN
  (SELECT genre AS genre__,
          COUNT(*) AS mme_inner__
   FROM video_game_sales
   GROUP BY genre
   ORDER BY mme_inner__ DESC
   LIMIT 100
   OFFSET 0) AS anon_1 ON genre = genre__
GROUP BY genre,
         year
ORDER BY count DESC
LIMIT 50000
OFFSET 0;
```

The TL;DR is I'm not sure if there's been a regression in the backend but it does feel like a UX issue. The "fix" is merely to set the default to `0` which is consistent with the Python logic.

The other change is merely to revert https://github.com/apache-superset/superset-ui/pull/1033, i.e., remove the default, as it seems like said change broke the UX.

Note @etr2460 and @villebro I'm not sure if this is considered a breaking change given it could impact some  charts, i.e., in theory there were charts which previously showed 100 series due to the limit but now will show an unbounded number. It does seem we having been gating the Apache Superset releases with these types of breaking changes.
