### PR TITLE
fix: revert default series limit and update eligible choices

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -331,6 +331,7 @@ const limit: SharedControlConfig<'SelectControl'> = {
   label: t('Series limit'),
   validators: [legacyValidateInteger],
   choices: formatSelectOptions(SERIES_LIMITS),
+  clearable: true,
   description: t(
     'Limits the number of time series that get displayed. A sub query ' +
       '(or an extra phase where sub queries are not supported) is applied to limit ' +


### PR DESCRIPTION
🏠 Internal

This PR is one of a slew to the [apache/superset](https://github.com/apache/superset) and [apache-superset/superset-ui](https://github.com/apache-superset/superset-ui) repos to revert pseudo recent changes to the series restrictions for high cardinality groupings. For more context please refer to [this](https://apache-superset.slack.com/archives/G013HAE6Y0K/p1635192289021500) Slack thread in the #committers channel.

Specifically this PR reverts apache-superset/superset-ui#1033 (and more) to ensure there is no default if undefined given that:

-  It is not apparent from the UX when the current default is cleared, i.e., `Select ...` is rendered, that a default is set.
- The only way to previously disable the joined subquery is to set the series limit to `0` which is misleading (and thus removed as an option) given that in actually it is akin to having no limits as the joined subquery logic is not invoked.

Furthermore said change was actually a breaking change but was not protected with a feature flag.

Related PRs:

- https://github.com/apache/superset/pull/17236
- https://github.com/apache-superset/superset-ui/pull/1436