### PR TITLE
fix: add .npmrc to .gitignore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,6 @@ jobs:
 
       - name: Bump version and publish package(s)
         run: |
-          git update-index --assume-unchanged .npmrc
           git tag -d `git tag | grep -E '^trigger-'`
           npm run ci:release-from-tag
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ logs/
 .idea
 *.iml
 .npm
+.npmrc
 .vscode
 .yarnclean
 


### PR DESCRIPTION
🐛 Bug Fix
Due to `.npmrc` being removed in #1405, it should be added to `.gitignore` and consequently not be removed from the git index in the release workflow as it no longer exists in the index.