### PR TITLE
fix: update chart sorting control labels/descriptions

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -25,7 +25,10 @@ export const dndGroupByControl: SharedControlConfig<'DndColumnSelect'> = {
   type: 'DndColumnSelect',
   label: t('Group by'),
   default: [],
-  description: t('One or many columns to group by'),
+  description: t(
+    'One or many columns to group by. High cardinality groupings should include a sort by metric ' +
+      'and series limit to limit the number of fetched and rendered series.',
+  ),
   mapStateToProps(state, { includeTime }) {
     const newState: ExtraControlProps = {};
     if (state.datasource) {
@@ -112,7 +115,10 @@ export const dnd_sort_by: SharedControlConfig<'DndMetricSelect'> = {
   type: 'DndMetricSelect',
   label: t('Sort by'),
   default: null,
-  description: t('Metric used to define the top series'),
+  description: t(
+    'Metric used to define the top series. Should be used in conjunction with the series or row ' +
+      'limit.',
+  ),
   mapStateToProps: ({ datasource }) => ({
     columns: datasource?.columns || [],
     savedMetrics: datasource?.metrics || [],

--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -102,7 +102,10 @@ const groupByControl: SharedControlConfig<'SelectControl', ColumnMeta> = {
   clearable: true,
   default: [],
   includeTime: false,
-  description: t('One or many columns to group by'),
+  description: t(
+    'One or many columns to group by. High cardinality groupings should include a sort by metric ' +
+      'and series limit to limit the number of fetched and rendered series.',
+  ),
   optionRenderer: c => <ColumnOption showType column={c} />,
   valueRenderer: c => <ColumnOption column={c} />,
   valueKey: 'column_name',
@@ -323,6 +326,10 @@ const row_limit: SharedControlConfig<'SelectControl'> = {
   validators: [legacyValidateInteger],
   default: 10000,
   choices: formatSelectOptions(ROW_LIMIT_OPTIONS),
+  description: t(
+    'Limits the number of rows that get displayed. Should be used in conjunction with a sort ' +
+      'by metric.',
+  ),
 };
 
 const limit: SharedControlConfig<'SelectControl'> = {
@@ -333,10 +340,11 @@ const limit: SharedControlConfig<'SelectControl'> = {
   default: 100,
   choices: formatSelectOptions(SERIES_LIMITS),
   description: t(
-    'Limits the number of time series that get displayed. A sub query ' +
-      '(or an extra phase where sub queries are not supported) is applied to limit ' +
-      'the number of time series that get fetched and displayed. This feature is useful ' +
-      'when grouping by high cardinality dimension(s).',
+    'Limits the number of series that get displayed. Should be used in conjunction with a sort ' +
+      'by metric. A joined subquery (or an extra phase where subqueries are not supported) is ' +
+      'applied to limit the number of series that get fetched and rendered. This feature is ' +
+      'useful when grouping by high cardinality column(s) though does increase the query ' +
+      'complexity and cost.',
   ),
 };
 
@@ -347,18 +355,22 @@ const series_limit: SharedControlConfig<'SelectControl'> = {
   validators: [legacyValidateInteger],
   choices: formatSelectOptions(SERIES_LIMITS),
   description: t(
-    'Limits the number of series that get displayed. A sub query ' +
-      '(or an extra phase where sub queries are not supported) is applied to limit ' +
-      'the number of series that get fetched and displayed. This feature is useful ' +
-      'when grouping by high cardinality dimension(s).',
+    'Limits the number of series that get displayed. Should be used in conjunction with a sort ' +
+      'by metric. A joined subquery (or an extra phase where subqueries are not supported) is ' +
+      'applied to limit the number of series that get fetched and rendered. This feature is ' +
+      'useful when grouping by high cardinality column(s) though does increase the query ' +
+      'complexity and cost.',
   ),
 };
 
 const sort_by: SharedControlConfig<'MetricsControl'> = {
   type: 'MetricsControl',
-  label: t('Sort By'),
+  label: t('Sort by'),
   default: null,
-  description: t('Metric used to define the top series'),
+  description: t(
+    'Metric used to define the top series. Should be used in conjunction with the series or row ' +
+      'limit',
+  ),
   mapStateToProps: ({ datasource }) => ({
     columns: datasource?.columns || [],
     savedMetrics: datasource?.metrics || [],


### PR DESCRIPTION
🏠 Internal

This PR is one of a slew to the [apache/superset](https://github.com/apache/superset) and [apache-superset/superset-ui](https://github.com/apache-superset/superset-ui) repos to revert pseudo recent changes to the series restrictions for high cardinality groupings. For more context please refer to [this](https://apache-superset.slack.com/archives/G013HAE6Y0K/p1635192289021500) Slack thread in the #committers channel. 

Specifically this PR updates the `Group by`, `Sort by`, `Series limit`, and `Row limit` descriptions to provide more context, recommended behaviors, and standardizes the language.

Related PRs:

- https://github.com/apache/superset/pull/17236
- https://github.com/apache-superset/superset-ui/pull/1430