### PR TITLE
chore(plugin-chart-echarts): bump echarts to 5.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21428,8 +21428,9 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.2.1",
-      "integrity": "sha512-OJ79b22eqRfbSV8vYmDKmA+XWfNbr0Uk/OafWcFNIGDWti2Uw9A6eVCiJLmqPa9Sk+EWL+t5v26aak0z3gxiZw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.2.2.tgz",
+      "integrity": "sha512-yxuBfeIH5c+0FsoRP60w4De6omXhA06c7eUYBsC1ykB6Ys2yK5fSteIYWvkJ4xJVLQgCvAdO8C4mN6MLeJpBaw==",
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "5.2.1"
@@ -46963,7 +46964,7 @@
         "@superset-ui/chart-controls": "0.18.17",
         "@superset-ui/core": "0.18.17",
         "d3-array": "^1.2.0",
-        "echarts": "^5.2.1",
+        "echarts": "^5.2.2",
         "lodash": "^4.17.15"
       },
       "peerDependencies": {
@@ -57203,7 +57204,7 @@
         "@superset-ui/chart-controls": "0.18.17",
         "@superset-ui/core": "0.18.17",
         "d3-array": "^1.2.0",
-        "echarts": "^5.2.1",
+        "echarts": "^5.2.2",
         "lodash": "^4.17.15"
       }
     },
@@ -64102,8 +64103,9 @@
       }
     },
     "echarts": {
-      "version": "5.2.1",
-      "integrity": "sha512-OJ79b22eqRfbSV8vYmDKmA+XWfNbr0Uk/OafWcFNIGDWti2Uw9A6eVCiJLmqPa9Sk+EWL+t5v26aak0z3gxiZw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.2.2.tgz",
+      "integrity": "sha512-yxuBfeIH5c+0FsoRP60w4De6omXhA06c7eUYBsC1ykB6Ys2yK5fSteIYWvkJ4xJVLQgCvAdO8C4mN6MLeJpBaw==",
       "requires": {
         "tslib": "2.3.0",
         "zrender": "5.2.1"

--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -29,7 +29,7 @@
     "@superset-ui/chart-controls": "0.18.17",
     "@superset-ui/core": "0.18.17",
     "d3-array": "^1.2.0",
-    "echarts": "^5.2.1",
+    "echarts": "^5.2.2",
     "lodash": "^4.17.15"
   },
   "peerDependencies": {

--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -139,11 +139,11 @@ export default function EchartsTimeseries({
         }
       }, TIMER_DURATION);
     },
-    mousemove: params => {
-      currentSeries.name = params.seriesName;
-    },
     mouseout: () => {
       currentSeries.name = '';
+    },
+    mouseover: params => {
+      currentSeries.name = params.seriesName;
     },
     legendselectchanged: payload => {
       const currentTime = Date.now();

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -173,6 +173,7 @@ export function transformSeries(
     // @ts-ignore
     type: plotType,
     smooth: seriesType === 'smooth',
+    triggerLineEvent: true,
     // @ts-ignore
     step: ['start', 'middle', 'end'].includes(seriesType as string) ? seriesType : undefined,
     stack: stackId,


### PR DESCRIPTION
🐛 Bug Fix

Bump ECharts to 5.2.2 (changelog: https://dist.apache.org/repos/dist/dev/echarts/5.2.2-rc.1/RELEASE_NOTE.txt) which adds mouseover functionality to line/area charts. See how hovering now triggers the `mouseover` event, where previously only the marker triggered it. This will make the tooltip highlighting and cross-filtering more intuitive.

### AFTER
https://user-images.githubusercontent.com/33317356/139024390-9b396b97-9490-4aaa-be7e-644c40294842.mp4


### BEFORE
https://user-images.githubusercontent.com/33317356/139025543-6aba15a3-397f-4662-9b38-b31a197b6aa9.mp4
