### PR TITLE
chore: Redirect to /login on 401

### DIFF
--- a/packages/superset-ui-core/src/connection/callApi/callApiAndParseWithTimeout.ts
+++ b/packages/superset-ui-core/src/connection/callApi/callApiAndParseWithTimeout.ts
@@ -20,11 +20,17 @@
 import callApi from './callApi';
 import rejectAfterTimeout from './rejectAfterTimeout';
 import parseResponse from './parseResponse';
-import { CallApi, ClientTimeout, ParseMethod } from '../types';
+import { CallApi, ClientTimeout, ParseMethod, Url } from '../types';
+
+function redirectUnauthorized(redirectUrl: Url) {
+  // the next param will be picked by flask to redirect the user after the login
+  window.location.href = `${redirectUrl}?next=${window.location.href}`;
+}
 
 export default async function callApiAndParseWithTimeout<T extends ParseMethod = 'json'>({
   timeout,
   parseMethod,
+  unauthorizedUrl = '/login',
   ...rest
 }: { timeout?: ClientTimeout; parseMethod?: T } & CallApi) {
   const apiPromise = callApi(rest);
@@ -32,6 +38,11 @@ export default async function callApiAndParseWithTimeout<T extends ParseMethod =
     typeof timeout === 'number' && timeout > 0
       ? Promise.race([apiPromise, rejectAfterTimeout<Response>(timeout)])
       : apiPromise;
+  const response = await racedPromise;
 
-  return parseResponse(racedPromise, parseMethod);
+  if (response && response.status === 401) {
+    return redirectUnauthorized(unauthorizedUrl);
+  }
+
+  return parseResponse(response, parseMethod);
 }

--- a/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
+++ b/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
@@ -20,7 +20,7 @@
 import { ParseMethod, TextResponse, JsonResponse } from '../types';
 
 export default async function parseResponse<T extends ParseMethod = 'json'>(
-  apiPromise: Promise<Response>,
+  response: Response,
   parseMethod?: T,
 ) {
   type ReturnType = T extends 'raw' | null
@@ -30,7 +30,6 @@ export default async function parseResponse<T extends ParseMethod = 'json'>(
     : T extends 'text'
     ? TextResponse
     : never;
-  const response = await apiPromise;
   // reject failed HTTP requests with the raw response
   if (!response.ok) {
     return Promise.reject(response);

--- a/packages/superset-ui-core/src/connection/types.ts
+++ b/packages/superset-ui-core/src/connection/types.ts
@@ -85,6 +85,7 @@ export interface RequestBase {
 }
 
 export interface CallApi extends RequestBase {
+  unauthorizedUrl?: Url;
   url: Url;
   cache?: Cache;
   redirect?: Redirect;


### PR DESCRIPTION
### SUMMARY
This PR redirects the user to the /login page when a 401 is detected as a response to a request. It also adds the `next` parameter that should then be picked by flask to redirect the user to the previous URL after login.


