### PR TITLE
fix(plugin-chart-echarts): fix tick labels and tooltip

### DIFF
--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
@@ -95,11 +95,11 @@ export default function EchartsMixedTimeseries({
         handleChange([seriesName], seriesIndex);
       }
     },
-    mousemove: params => {
-      currentSeries.name = params.seriesName;
-    },
     mouseout: () => {
       currentSeries.name = '';
+    },
+    mouseover: params => {
+      currentSeries.name = params.seriesName;
     },
   };
 

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -285,30 +285,6 @@ const config: ControlPanelConfig = {
         ['x_axis_time_format'],
         [
           {
-            name: 'xAxisShowMinLabel',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Show Min Label'),
-              default: true,
-              renderTrigger: true,
-              description: t('Show Min Label'),
-            },
-          },
-        ],
-        [
-          {
-            name: 'xAxisShowMaxLabel',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Show Max Label'),
-              default: true,
-              renderTrigger: true,
-              description: t('Show Max Label'),
-            },
-          },
-        ],
-        [
-          {
             name: 'xAxisLabelRotation',
             config: {
               type: 'SelectControl',

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -99,8 +99,6 @@ export default function transformProps(
     tooltipTimeFormat,
     yAxisFormat,
     yAxisFormatSecondary,
-    xAxisShowMinLabel,
-    xAxisShowMaxLabel,
     xAxisTimeFormat,
     yAxisBounds,
     yAxisIndex,
@@ -244,8 +242,6 @@ export default function transformProps(
       nameGap: xAxisTitleMargin,
       nameLocation: 'middle',
       axisLabel: {
-        showMinLabel: xAxisShowMinLabel,
-        showMaxLabel: xAxisShowMaxLabel,
         formatter: xAxisFormatter,
         rotate: xAxisLabelRotation,
       },
@@ -282,14 +278,14 @@ export default function transformProps(
       appendToBody: true,
       trigger: richTooltip ? 'axis' : 'item',
       formatter: (params: any) => {
-        const value: number = !richTooltip ? params.value : params[0].value[0];
-        const prophetValue: any[] = !richTooltip ? [params] : params;
+        const xValue: number = richTooltip ? params[0].value[0] : params.value[0];
+        const prophetValue: any[] = richTooltip ? params : [params];
 
         if (richTooltip && tooltipSortByMetric) {
           prophetValue.sort((a, b) => b.data[1] - a.data[1]);
         }
 
-        const rows: Array<string> = [`${tooltipTimeFormatter(value)}`];
+        const rows: Array<string> = [`${tooltipTimeFormatter(xValue)}`];
         const prophetValues = extractProphetValuesFromTooltipParams(prophetValue);
 
         Object.keys(prophetValues).forEach(key => {

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -57,8 +57,6 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   zoomable: boolean;
   richTooltip: boolean;
   xAxisLabelRotation: number;
-  xAxisShowMinLabel?: boolean;
-  xAxisShowMaxLabel?: boolean;
   colorScheme?: string;
   // types specific to Query A and Query B
   area: boolean;
@@ -127,8 +125,6 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   yAxisIndexB: 0,
   groupby: [],
   groupbyB: [],
-  xAxisShowMinLabel: TIMESERIES_DEFAULTS.xAxisShowMinLabel,
-  xAxisShowMaxLabel: TIMESERIES_DEFAULTS.xAxisShowMaxLabel,
   zoomable: TIMESERIES_DEFAULTS.zoomable,
   richTooltip: TIMESERIES_DEFAULTS.richTooltip,
   xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -268,14 +268,14 @@ export default function transformProps(
       appendToBody: true,
       trigger: richTooltip ? 'axis' : 'item',
       formatter: (params: any) => {
-        const value: number = !richTooltip ? params.value : params[0].value[0];
-        const prophetValue: any[] = !richTooltip ? [params] : params;
+        const xValue: number = richTooltip ? params[0].value[0] : params.value[0];
+        const prophetValue: any[] = richTooltip ? params : [params];
 
         if (richTooltip && tooltipSortByMetric) {
           prophetValue.sort((a, b) => b.data[1] - a.data[1]);
         }
 
-        const rows: Array<string> = [`${tooltipFormatter(value)}`];
+        const rows: Array<string> = [`${tooltipFormatter(xValue)}`];
         const prophetValues: Record<string, ProphetValue> =
           extractProphetValuesFromTooltipParams(prophetValue);
 

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -178,12 +178,14 @@ export function transformSeries(
     step: ['start', 'middle', 'end'].includes(seriesType as string) ? seriesType : undefined,
     stack: stackId,
     lineStyle,
-    areaStyle: {
-      opacity:
-        forecastSeries.type === ForecastSeriesEnum.ForecastUpper || area
-          ? opacity * areaOpacity
-          : 0,
-    },
+    areaStyle: area
+      ? {
+          opacity:
+            forecastSeries.type === ForecastSeriesEnum.ForecastUpper || area
+              ? opacity * areaOpacity
+              : 0,
+        }
+      : undefined,
     emphasis,
     showSymbol,
     symbolSize: markerSize,

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -181,9 +181,7 @@ export function transformSeries(
     areaStyle: area
       ? {
           opacity:
-            forecastSeries.type === ForecastSeriesEnum.ForecastUpper || area
-              ? opacity * areaOpacity
-              : 0,
+            forecastSeries.type === ForecastSeriesEnum.ForecastUpper ? opacity * areaOpacity : 0,
         }
       : undefined,
     emphasis,

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -70,8 +70,6 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   tooltipTimeFormat?: string;
   truncateYAxis: boolean;
   yAxisFormat?: string;
-  xAxisShowMinLabel?: boolean;
-  xAxisShowMaxLabel?: boolean;
   xAxisTimeFormat?: string;
   timeGrainSqla?: TimeGranularity;
   yAxisBounds: [number | undefined | null, number | undefined | null];


### PR DESCRIPTION
🐛 Bug Fix

Fixes multiple issues on the Mixed Timeseries chart:
- Tooltip x-axis value shows `0NaN` when rich tooltip is disabled and the value is a decimal.
- On the case of a mixed line+bar chart, the bars below the line won't show in the tooltip.
- Remove bogus min and max x-axis values (these have been deprecated from the main Timeseries chart some time ago).

### AFTER
Tooltip correctly shows the x-axis value when the y-value is a decimal:
![image](https://user-images.githubusercontent.com/33317356/139654973-dc862215-2227-4acb-8625-5599d2bcef15.png)

The erroneous min and max x-axis values are removed, and hovering on a bar underneath a line works as intended:
https://user-images.githubusercontent.com/33317356/139655494-8ab0257a-2ece-4821-a41e-727437cd8490.mp4

### BEFORE

Tooltip shows `0NaN` when the metric value is a decimal value:
![image](https://user-images.githubusercontent.com/33317356/139654579-0164ad89-c76a-4859-8e2f-8a2c656971a7.png)

The x-axis shows incorrect min and max values, and hovering on a bar underneath a line doesn't display the bar value correctly:
https://user-images.githubusercontent.com/33317356/139655424-20628415-b6a2-46a7-81e7-fb310e894e19.mp4
