### PR TITLE
feat:  remove the default Y-axis truncate in bar chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -93,7 +93,7 @@ const config: ControlPanelConfig = {
       label: t('Chart Options'),
       expanded: true,
       controlSetRows: [
-        ['color_scheme', 'label_colors'],
+        ['color_scheme'],
         ...showValueSection,
         [
           {

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -37,6 +37,7 @@ const {
   markerSize,
   minorSplitLine,
   rowLimit,
+  truncateYAxis,
   yAxisBounds,
   zoomable,
   xAxisLabelRotation,
@@ -202,7 +203,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'CheckboxControl',
               label: t('Truncate Y Axis'),
-              default: false,
+              default: truncateYAxis,
               renderTrigger: true,
               description: t('It’s not recommended to truncate y-axis in Bar chart.'),
             },

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -1,0 +1,240 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { t } from '@superset-ui/core';
+import {
+  ControlPanelConfig,
+  ControlPanelsContainerProps,
+  D3_TIME_FORMAT_DOCS,
+  emitFilterControl,
+  sections,
+  sharedControls,
+} from '@superset-ui/chart-controls';
+
+import { DEFAULT_FORM_DATA, EchartsTimeseriesContributionType } from '../../types';
+import { legendSection, richTooltipSection, showValueSection } from '../../../controls';
+
+const {
+  contributionMode,
+  logAxis,
+  markerEnabled,
+  markerSize,
+  minorSplitLine,
+  rowLimit,
+  yAxisBounds,
+  zoomable,
+  xAxisLabelRotation,
+} = DEFAULT_FORM_DATA;
+const config: ControlPanelConfig = {
+  controlPanelSections: [
+    sections.legacyTimeseriesTime,
+    {
+      label: t('Query'),
+      expanded: true,
+      controlSetRows: [
+        ['metrics'],
+        ['groupby'],
+        [
+          {
+            name: 'contributionMode',
+            config: {
+              type: 'SelectControl',
+              label: t('Contribution Mode'),
+              default: contributionMode,
+              choices: [
+                [null, 'None'],
+                [EchartsTimeseriesContributionType.Row, 'Total'],
+                [EchartsTimeseriesContributionType.Column, 'Series'],
+              ],
+              description: t('Calculate contribution per series or total'),
+            },
+          },
+        ],
+        ['adhoc_filters'],
+        emitFilterControl,
+        ['limit'],
+        ['timeseries_limit_metric'],
+        [
+          {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort Descending'),
+              default: true,
+              description: t('Whether to sort descending or ascending'),
+            },
+          },
+        ],
+        ['row_limit'],
+      ],
+    },
+    sections.advancedAnalyticsControls,
+    sections.annotationsAndLayersControls,
+    sections.forecastIntervalControls,
+    sections.titleControls,
+    {
+      label: t('Chart Options'),
+      expanded: true,
+      controlSetRows: [
+        ['color_scheme', 'label_colors'],
+        ...showValueSection,
+        [
+          {
+            name: 'markerEnabled',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Marker'),
+              renderTrigger: true,
+              default: markerEnabled,
+              description: t('Draw a marker on data points. Only applicable for line types.'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'markerSize',
+            config: {
+              type: 'SliderControl',
+              label: t('Marker Size'),
+              renderTrigger: true,
+              min: 0,
+              max: 20,
+              default: markerSize,
+              description: t('Size of marker. Also applies to forecast observations.'),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.markerEnabled?.value),
+            },
+          },
+        ],
+        [
+          {
+            name: 'zoomable',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Data Zoom'),
+              default: zoomable,
+              renderTrigger: true,
+              description: t('Enable data zooming controls'),
+            },
+          },
+        ],
+        ...legendSection,
+        [<h1 className="section-header">{t('X Axis')}</h1>],
+        [
+          {
+            name: 'x_axis_time_format',
+            config: {
+              ...sharedControls.x_axis_time_format,
+              default: 'smart_date',
+              description: `${D3_TIME_FORMAT_DOCS}. ${t(
+                'When using other than adaptive formatting, labels may overlap.',
+              )}`,
+            },
+          },
+        ],
+        [
+          {
+            name: 'xAxisLabelRotation',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              clearable: false,
+              label: t('Rotate x axis label'),
+              choices: [
+                [0, '0°'],
+                [45, '45°'],
+              ],
+              default: xAxisLabelRotation,
+              renderTrigger: true,
+              description: t('Input field supports custom rotation. e.g. 30 for 30°'),
+            },
+          },
+        ],
+        // eslint-disable-next-line react/jsx-key
+        ...richTooltipSection,
+        // eslint-disable-next-line react/jsx-key
+        [<h1 className="section-header">{t('Y Axis')}</h1>],
+
+        ['y_axis_format'],
+        [
+          {
+            name: 'logAxis',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Logarithmic y-axis'),
+              renderTrigger: true,
+              default: logAxis,
+              description: t('Logarithmic y-axis'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'minorSplitLine',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Minor Split Line'),
+              renderTrigger: true,
+              default: minorSplitLine,
+              description: t('Draw split lines for minor y-axis ticks'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'truncateYAxis',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Truncate Y Axis'),
+              default: false,
+              renderTrigger: true,
+              description: t('It’s not recommended to truncate y-axis in Bar chart.'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'y_axis_bounds',
+            config: {
+              type: 'BoundsControl',
+              label: t('Y Axis Bounds'),
+              renderTrigger: true,
+              default: yAxisBounds,
+              description: t(
+                'Bounds for the Y-axis. When left empty, the bounds are ' +
+                  'dynamically defined based on the min/max of the data. Note that ' +
+                  "this feature will only expand the axis range. It won't " +
+                  "narrow the data's extent.",
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.truncateYAxis?.value),
+            },
+          },
+        ],
+      ],
+    },
+  ],
+  controlOverrides: {
+    row_limit: {
+      default: rowLimit,
+    },
+  },
+};
+
+export default config;

--- a/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
@@ -18,7 +18,7 @@
  */
 import { t, ChartMetadata, ChartPlugin, AnnotationType, Behavior } from '@superset-ui/core';
 import buildQuery from '../../buildQuery';
-import controlPanel from '../controlPanel';
+import controlPanel from './controlPanel';
 import transformProps from '../../transformProps';
 import thumbnail from './images/thumbnail.png';
 import {

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -104,7 +104,7 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   seriesType: EchartsTimeseriesSeriesType.Line,
   stack: false,
   tooltipTimeFormat: 'smart_date',
-  truncateYAxis: true,
+  truncateYAxis: false,
   yAxisBounds: [null, null],
   zoomable: false,
   richTooltip: true,


### PR DESCRIPTION
remove the default Y-axis truncate check box to “unchecked” and add a tooltip next to the checkbox saying “It’s not recommended to truncate y-axis in Bar chart”

![image](https://user-images.githubusercontent.com/11830681/139785132-9e9af629-6369-4b75-b020-3118403bb2f0.png)

