### PR TITLE
feat(legacy-plugin-chart-calendar): increase the contrast of calendar heatmap color and label

### DIFF
--- a/packages/superset-ui-core/src/color/index.ts
+++ b/packages/superset-ui-core/src/color/index.ts
@@ -27,5 +27,6 @@ export { default as getSequentialSchemeRegistry } from './SequentialSchemeRegist
 export { default as SequentialScheme } from './SequentialScheme';
 export { default as ColorSchemeRegistry } from './ColorSchemeRegistry';
 export * from './colorSchemes';
+export * from './utils';
 
 export const BRAND_COLOR = '#00A699';

--- a/packages/superset-ui-core/src/color/utils.ts
+++ b/packages/superset-ui-core/src/color/utils.ts
@@ -49,9 +49,5 @@ export function getContrastingColor(color: string, thresholds = 186) {
     b = parseInt(hex.slice(4, 6), 16);
   }
 
-  if ([r, g, b].some(x => Number.isNaN(x))) {
-    throw new Error(`Invalid color: ${color}`);
-  }
-
   return r * 0.299 + g * 0.587 + b * 0.114 > thresholds ? '#000' : '#FFF';
 }

--- a/packages/superset-ui-core/src/color/utils.ts
+++ b/packages/superset-ui-core/src/color/utils.ts
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const rgbRegex = /^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/;
+export function getContrastingColor(color: string, thresholds = 186) {
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (color.length > 7) {
+    // rgb
+    const matchColor = rgbRegex.exec(color);
+    if (!matchColor) {
+      throw new Error(`Invalid color: ${color}`);
+    }
+    r = parseInt(matchColor[1], 10);
+    g = parseInt(matchColor[2], 10);
+    b = parseInt(matchColor[3], 10);
+  } else {
+    // hex
+    let hex = color;
+    if (hex.startsWith('#')) {
+      hex = hex.substring(1);
+    }
+    // #FFF
+    if (hex.length === 3) {
+      hex = [hex[0], hex[0], hex[1], hex[1], hex[2], hex[2]].join('');
+    }
+    if (hex.length !== 6) {
+      throw new Error(`Invalid color: ${color}`);
+    }
+    r = parseInt(hex.slice(0, 2), 16);
+    g = parseInt(hex.slice(2, 4), 16);
+    b = parseInt(hex.slice(4, 6), 16);
+  }
+
+  if ([r, g, b].some(x => Number.isNaN(x))) {
+    throw new Error(`Invalid color: ${color}`);
+  }
+
+  return r * 0.299 + g * 0.587 + b * 0.114 > thresholds ? '#000' : '#FFF';
+}

--- a/packages/superset-ui-core/test/color/utils.test.ts
+++ b/packages/superset-ui-core/test/color/utils.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getContrastingColor } from '@superset-ui/core/src/color';
+
+describe('color utils', () => {
+  describe('getContrastingColor', () => {
+    it('when called with 3-digit hex color', () => {
+      const color = getContrastingColor('#000');
+      expect(color).toBe('#FFF');
+    });
+
+    it('when called with 6-digit hex color', () => {
+      const color = getContrastingColor('#000000');
+      expect(color).toBe('#FFF');
+    });
+
+    it('when called with rgb color', () => {
+      const color = getContrastingColor('rgb(0, 0, 0)');
+      expect(color).toBe('#FFF');
+    });
+
+    it('when called with thresholds', () => {
+      const color1 = getContrastingColor('rgb(255, 255, 255)');
+      const color2 = getContrastingColor('rgb(255, 255, 255)', 255);
+      expect(color1).toBe('#000');
+      expect(color2).toBe('#FFF');
+    });
+
+    it('when called with rgba color, throw error', () => {
+      expect(() => {
+        getContrastingColor('rgba(0, 0, 0, 0.1)');
+      }).toThrow();
+    });
+
+    it('when called with invalid color, throw error', () => {
+      expect(() => {
+        getContrastingColor('#0000');
+      }).toThrow();
+    });
+  });
+});

--- a/packages/superset-ui-core/test/color/utils.test.ts
+++ b/packages/superset-ui-core/test/color/utils.test.ts
@@ -31,6 +31,11 @@ describe('color utils', () => {
       expect(color).toBe('#FFF');
     });
 
+    it('when called with no # prefix hex color', () => {
+      const color = getContrastingColor('000000');
+      expect(color).toBe('#FFF');
+    });
+
     it('when called with rgb color', () => {
       const color = getContrastingColor('rgb(0, 0, 0)');
       expect(color).toBe('#FFF');

--- a/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.css
+++ b/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.css
@@ -26,7 +26,6 @@
 
 .cal-heatmap-container .subdomain-text {
   font-size: 8px;
-  fill: #999;
   pointer-events: none;
 }
 

--- a/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
+++ b/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
@@ -9,6 +9,7 @@
 /* eslint-disable */
 
 import d3tip from 'd3-tip';
+import { getContrastingColor } from '@superset-ui/core';
 import './d3tip.css';
 
 var d3 = typeof require === 'function' ? require('d3') : window.d3;
@@ -1652,20 +1653,6 @@ CalHeatMap.prototype = {
       }
     }
 
-    function formatTextFill(value) {
-      if (!value) return 'black';
-      const rgb = parent.legendScale(Math.min(value, options.legend[options.legend.length - 1]));
-      // rgb(2,2,2) => [2,2,2]
-      const rgbRegex = /^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/;
-      const rgbArrs = rgb.match(rgbRegex);
-      if (!rgbArrs) return 'black';
-      const r = rgbArrs[1];
-      const g = rgbArrs[2];
-      const b = rgbArrs[3];
-      const gray = r * 0.299 + g * 0.587 + b * 0.114;
-      return gray > 135 ? 'black' : 'white';
-    }
-
     /**
      * Change the subDomainText class if necessary
      * Also change the text, e.g when text is representing the value
@@ -1679,7 +1666,11 @@ CalHeatMap.prototype = {
         return 'subdomain-text' + parent.getHighlightClassName(d.t);
       })
       .call(formatSubDomainText)
-      .attr('fill', d => formatTextFill(d.v));
+      .attr('fill', d => {
+        if (!d.v) return '#000';
+        const rgb = parent.legendScale(Math.min(d.v, options.legend[options.legend.length - 1]));
+        return getContrastingColor(rgb, 135);
+      });
   },
 
   /**

--- a/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
+++ b/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
@@ -1652,6 +1652,20 @@ CalHeatMap.prototype = {
       }
     }
 
+    function formatTextFill(value) {
+      if (!value) return 'black';
+      const rgb = parent.legendScale(Math.min(value, options.legend[options.legend.length - 1]));
+      // rgb(2,2,2) => [2,2,2]
+      const rgbRegex = /^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/;
+      const rgbArrs = rgb.match(rgbRegex);
+      if (!rgbArrs) return 'black';
+      const r = rgbArrs[1];
+      const g = rgbArrs[2];
+      const b = rgbArrs[3];
+      const gray = r * 0.299 + g * 0.587 + b * 0.114;
+      return gray > 135 ? 'black' : 'white';
+    }
+
     /**
      * Change the subDomainText class if necessary
      * Also change the text, e.g when text is representing the value
@@ -1664,7 +1678,8 @@ CalHeatMap.prototype = {
       .attr('class', function (d) {
         return 'subdomain-text' + parent.getHighlightClassName(d.t);
       })
-      .call(formatSubDomainText);
+      .call(formatSubDomainText)
+      .attr('fill', d => formatTextFill(d.v));
   },
 
   /**


### PR DESCRIPTION
🏆 Enhancements
The algorithm is to decide label color in white or black depending on background color (refer to https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color)

![image](https://user-images.githubusercontent.com/11830681/139907087-23a99f14-ca22-47b9-b785-e678f27252b6.png)

