### PR TITLE
fix(core): simplify babel config for emotion css

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -39,11 +39,5 @@ config.plugins = [
   ['babel-plugin-typescript-to-proptypes', { loose: true }],
   ['@babel/plugin-proposal-class-properties', { loose: true }],
 ];
-config.presets.push([
-  '@emotion/babel-preset-css-prop',
-  {
-    autoLabel: 'dev-only',
-    labelFormat: '[local]',
-  },
-]);
+config.presets.push('@emotion/babel-preset-css-prop');
 module.exports = config;


### PR DESCRIPTION
When we tried to link superset-ui/core to main superset codebase, there was an error related to theme fields being undefined. After some investigation it turned out that the culprit was the `theme` used in `css` prop. `css` emotion prop is enabled by a babel preset `@emotion/babel-preset-css-prop`. This PR simplifies the babel config by removing additional configuration of the preset.
Related PR: https://github.com/apache/superset/pull/17374