### PR TITLE
fix(plugin-chart-echarts): fix opacity on area chart

### DIFF
--- a/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -190,14 +190,12 @@ export function transformSeries(
       : undefined,
     stack: stackId,
     lineStyle,
-    areaStyle: area
-      ? {
-          opacity:
-            forecastSeries.type === ForecastSeriesEnum.ForecastUpper
-              ? opacity * areaOpacity
-              : 0,
-        }
-      : undefined,
+    areaStyle:
+      area || forecastSeries.type === ForecastSeriesEnum.ForecastUpper
+        ? {
+            opacity: opacity * areaOpacity,
+          }
+        : undefined,
     emphasis,
     showSymbol,
     symbolSize: markerSize,


### PR DESCRIPTION
🐛 Bug Fix

#1447 introduced a regression to area charts which broke both area and confidence bands. The reason for the original change was to remove area if it's not needed (a 0 opacity made it impossible to hover series underneath the series).

### AFTER
![image](https://user-images.githubusercontent.com/33317356/141147741-a2126432-3dd6-40ce-938a-caa0bbc44b2c.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/141147860-4888cc5b-721d-4742-98ef-aedf2e7b9b72.png)
