### PR TITLE
chore: Pass dashboardId to ColorSchemeControl

### DIFF
--- a/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -477,6 +477,9 @@ const color_scheme: SharedControlConfig<'ColorSchemeControl'> = {
   choices: () => categoricalSchemeRegistry.keys().map(s => [s, s]),
   description: t('The color scheme for rendering chart'),
   schemes: () => categoricalSchemeRegistry.getMap(),
+  mapStateToProps: state => ({
+    dashboardId: state?.form_data?.dashboardId,
+  }),
 };
 
 const enableExploreDnd = isFeatureEnabled(


### PR DESCRIPTION
### SUMMARY

This PR is a dependency for the PR https://github.com/apache/superset/pull/17422. It passes the `dashboardId` to the `ColorSchemeControl`

See https://github.com/apache/superset/pull/17422 for more information