### PR TITLE
fix: missing $ in histogram popover for percentile value

### DIFF
--- a/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
+++ b/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
@@ -122,7 +122,7 @@ class CustomHistogram extends React.PureComponent {
                 </div>
                 <div>
                   <strong>{t('percentile (exclusive)')} </strong>
-                  {`{((datum.cumulativeDensity - datum.density) * 100).toPrecision(4)}th`}
+                  {`${((datum.cumulativeDensity - datum.density) * 100).toPrecision(4)}th`}
                 </div>
               </div>
             )}

--- a/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
+++ b/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
@@ -122,7 +122,9 @@ class CustomHistogram extends React.PureComponent {
                 </div>
                 <div>
                   <strong>{t('percentile (exclusive)')} </strong>
-                  {`${((datum.cumulativeDensity - datum.density) * 100).toPrecision(4)}th`}
+                  {`${(
+                    (datum.cumulativeDensity - datum.density) *
+                    100).toPrecision(4)}th`}
                 </div>
               </div>
             )}

--- a/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
+++ b/plugins/legacy-plugin-chart-histogram/src/Histogram.jsx
@@ -124,7 +124,8 @@ class CustomHistogram extends React.PureComponent {
                   <strong>{t('percentile (exclusive)')} </strong>
                   {`${(
                     (datum.cumulativeDensity - datum.density) *
-                    100).toPrecision(4)}th`}
+                    100
+                  ).toPrecision(4)}th`}
                 </div>
               </div>
             )}


### PR DESCRIPTION
Fix: missing $ in popover for percentile value

🐛 Bug Fix

Sorry, I missed this in my earlier PR