### PR TITLE
Emit filters for metric

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
+@superset-ui:registry=https://pkgs.dev.azure.com/cccs-analytical-platform/99130e50-b4e3-4d7d-873e-2a947f564b87/_packaging/analytical-platform/npm/registry/
+always-auth=true
 package-lock=false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,67 @@
+trigger:
+  branches:
+    include:
+      - cccs-*
+
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+  tag: $(Build.BuildId)
+
+stages:
+- stage: Build_and_Publish_Npm_Artifacts
+  displayName: Build, package and publish npm artifacts.
+  jobs:
+  - job: BuildNpmArtifacts
+    displayName: Build, package and publish npm artifacts.
+    steps:
+    - task: NodeTool@0
+      inputs:
+        versionSpec: 14.x
+    - script: |
+        yarn install --frozen-lockfile
+      displayName: Install dependencies
+    - script: |
+        yarn build
+      displayName: Build packages
+    - script: |
+        yarn test
+      displayName: Run unit tests
+  - job: PublishArtifactsToFeed
+    dependsOn: BuildNpmArtifacts
+    steps:
+    - template : publish-template.yml
+      parameters:
+        workingDirs:
+          - packages/generator-superset
+          - packages/superset-ui-chart-controls
+          - packages/superset-ui-core
+          - packages/superset-ui-demo
+          - plugins/legacy-plugin-chart-calendar
+          - plugins/legacy-plugin-chart-chord
+          - plugins/legacy-plugin-chart-country-map
+          - plugins/legacy-plugin-chart-event-flow
+          - plugins/legacy-plugin-chart-force-directed
+          - plugins/legacy-plugin-chart-heatmap
+          - plugins/legacy-plugin-chart-histogram
+          - plugins/legacy-plugin-chart-horizon
+          - plugins/legacy-plugin-chart-map-box
+          - plugins/legacy-plugin-chart-paired-t-test
+          - plugins/legacy-plugin-chart-parallel-coordinates
+          - plugins/legacy-plugin-chart-partition
+          - plugins/legacy-plugin-chart-pivot-table
+          - plugins/legacy-plugin-chart-rose
+          - plugins/legacy-plugin-chart-sankey
+          - plugins/legacy-plugin-chart-sankey-loop
+          - plugins/legacy-plugin-chart-sunburst
+          - plugins/legacy-plugin-chart-time-table
+          - plugins/legacy-plugin-chart-treemap
+          - plugins/legacy-plugin-chart-world-map
+          - plugins/legacy-preset-chart-big-number
+          - plugins/legacy-preset-chart-nvd3
+          - plugins/plugin-chart-echarts
+          - plugins/plugin-chart-pivot-table
+          - plugins/plugin-chart-table
+          - plugins/plugin-chart-word-cloud
+          - plugins/preset-chart-xy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@ pool:
   vmImage: ubuntu-latest
 
 variables:
+  npmrc: $(Build.SourcesDirectory)/.npmrc
   tag: $(Build.BuildId)
 
 stages:
@@ -16,6 +17,10 @@ stages:
   - job: BuildNpmArtifacts
     displayName: Build, package and publish npm artifacts.
     steps:
+    - task: npmAuthenticate@0
+      inputs:
+        workingFile: $(npmrc)
+      displayName: Authenticate to npm feed
     - task: NodeTool@0
       inputs:
         versionSpec: 14.x
@@ -28,9 +33,6 @@ stages:
     - script: |
         yarn test
       displayName: Run unit tests
-  - job: PublishArtifactsToFeed
-    dependsOn: BuildNpmArtifacts
-    steps:
     - template : publish-template.yml
       parameters:
         workingDirs:

--- a/packages/generator-superset/package.json
+++ b/packages/generator-superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/generator-superset",
-  "version": "0.17.42",
+  "version": "0.17.42-cccs.0",
   "description": "Scaffolder for Superset",
   "bugs": {
     "url": "https://github.com/apache-superset/superset-ui/issues"

--- a/packages/superset-ui-chart-controls/package.json
+++ b/packages/superset-ui-chart-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/chart-controls",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.0",
   "description": "Superset UI control-utils",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2"
   },

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/core",
-  "version": "0.17.81",
+  "version": "0.17.81-cccs.1",
   "description": "Superset UI core",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/packages/superset-ui-core/src/query/buildQueryContext.ts
+++ b/packages/superset-ui-core/src/query/buildQueryContext.ts
@@ -48,5 +48,6 @@ export default function buildQueryContext(
     }),
     result_format: formData.result_format || 'json',
     result_type: formData.result_type || 'full',
+    viz_type: formData.viz_type || '',
   };
 }

--- a/packages/superset-ui-core/src/query/types/Query.ts
+++ b/packages/superset-ui-core/src/query/types/Query.ts
@@ -150,6 +150,7 @@ export interface QueryContext {
   /** Response format */
   result_format: string;
   queries: QueryObject[];
+  viz_type: string;
 }
 
 export default {};

--- a/packages/superset-ui-demo/package.json
+++ b/packages/superset-ui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/demo",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.0",
   "description": "Storybook for Superset UI ✨",
   "private": true,
   "main": "index.js",

--- a/plugins/legacy-plugin-chart-calendar/package.json
+++ b/plugins/legacy-plugin-chart-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-calendar",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Calendar Heatmap",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3-array": "^2.0.3",
     "d3-selection": "^1.4.0",
     "d3-tip": "^0.9.1",

--- a/plugins/legacy-plugin-chart-chord/package.json
+++ b/plugins/legacy-plugin-chart-chord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-chord",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Chord Diagram",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "prop-types": "^15.6.2",
     "react": "^16.13.1"

--- a/plugins/legacy-plugin-chart-country-map/package.json
+++ b/plugins/legacy-plugin-chart-country-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-country-map",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Country Map",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "d3-array": "^2.0.3",
     "prop-types": "^15.6.2"

--- a/plugins/legacy-plugin-chart-event-flow/package.json
+++ b/plugins/legacy-plugin-chart-event-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-event-flow",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Event Flow",
   "sideEffects": [
     "*.css"
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@data-ui/event-flow": "^0.0.84",
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {

--- a/plugins/legacy-plugin-chart-force-directed/package.json
+++ b/plugins/legacy-plugin-chart-force-directed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-force-directed",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Force-directed Graph",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "prop-types": "^15.7.2"
   },

--- a/plugins/legacy-plugin-chart-heatmap/package.json
+++ b/plugins/legacy-plugin-chart-heatmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-heatmap",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Heatmap",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "d3-svg-legend": "^1.x",
     "d3-tip": "^0.9.1",

--- a/plugins/legacy-plugin-chart-histogram/package.json
+++ b/plugins/legacy-plugin-chart-histogram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-histogram",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Histogram",
   "sideEffects": [
     "*.css"
@@ -30,8 +30,8 @@
   "dependencies": {
     "@data-ui/histogram": "^0.0.84",
     "@data-ui/theme": "^0.0.84",
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "@vx/legend": "^0.0.198",
     "@vx/responsive": "^0.0.199",
     "@vx/scale": "^0.0.197",

--- a/plugins/legacy-plugin-chart-horizon/package.json
+++ b/plugins/legacy-plugin-chart-horizon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-horizon",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Horizon",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3-array": "^2.0.3",
     "d3-scale": "^3.0.1",
     "prop-types": "^15.6.2"

--- a/plugins/legacy-plugin-chart-map-box/package.json
+++ b/plugins/legacy-plugin-chart-map-box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-map-box",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - MapBox",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "immutable": "^3.8.2",
     "mapbox-gl": "^0.53.0",
     "prop-types": "^15.6.2",

--- a/plugins/legacy-plugin-chart-paired-t-test/package.json
+++ b/plugins/legacy-plugin-chart-paired-t-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-paired-t-test",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Paired T Test",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "distributions": "^1.0.0",
     "prop-types": "^15.6.2",
     "reactable": "^1.1.0"

--- a/plugins/legacy-plugin-chart-parallel-coordinates/package.json
+++ b/plugins/legacy-plugin-chart-parallel-coordinates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-parallel-coordinates",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Parallel Coordinates",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "prop-types": "^15.7.2"
   },

--- a/plugins/legacy-plugin-chart-partition/package.json
+++ b/plugins/legacy-plugin-chart-partition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-partition",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Partition",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "d3-hierarchy": "^1.1.8",
     "prop-types": "^15.6.2"

--- a/plugins/legacy-plugin-chart-pivot-table/package.json
+++ b/plugins/legacy-plugin-chart-pivot-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-pivot-table",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Pivot Table",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "datatables.net-bs": "^1.10.15",
     "prop-types": "^15.6.2"

--- a/plugins/legacy-plugin-chart-rose/package.json
+++ b/plugins/legacy-plugin-chart-rose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-rose",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Nightingale Rose Diagram",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "nvd3": "1.8.6",
     "prop-types": "^15.6.2"

--- a/plugins/legacy-plugin-chart-sankey-loop/package.json
+++ b/plugins/legacy-plugin-chart-sankey-loop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-sankey-loop",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Sankey Diagram with Loops",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3-sankey-diagram": "^0.7.3",
     "d3-selection": "^1.4.0",
     "prop-types": "^15.6.2"

--- a/plugins/legacy-plugin-chart-sankey/package.json
+++ b/plugins/legacy-plugin-chart-sankey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-sankey",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Sankey Diagram",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "d3-sankey": "^0.4.2",
     "prop-types": "^15.6.2"

--- a/plugins/legacy-plugin-chart-sunburst/package.json
+++ b/plugins/legacy-plugin-chart-sunburst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-sunburst",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Sunburst",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "prop-types": "^15.6.2"
   }

--- a/plugins/legacy-plugin-chart-time-table/package.json
+++ b/plugins/legacy-plugin-chart-time-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-time-table",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Chart Plugin - Time Table",
   "sideEffects": [
     "*.css"
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@data-ui/sparkline": "^0.0.84",
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "@types/d3-scale": "^2.0.2",
     "d3-scale": "^3.2.1",
     "moment": "^2.26.0",

--- a/plugins/legacy-plugin-chart-treemap/package.json
+++ b/plugins/legacy-plugin-chart-treemap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-treemap",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Treemap",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3-hierarchy": "^1.1.8",
     "d3-selection": "^1.4.0",
     "prop-types": "^15.6.2"

--- a/plugins/legacy-plugin-chart-world-map/package.json
+++ b/plugins/legacy-plugin-chart-world-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-plugin-chart-world-map",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - World Map",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "d3-array": "^2.4.0",
     "d3-color": "^1.4.1",

--- a/plugins/legacy-preset-chart-big-number/package.json
+++ b/plugins/legacy-preset-chart-big-number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-preset-chart-big-number",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - Big Number",
   "sideEffects": [
     "*.css"
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@data-ui/xy-chart": "^0.0.84",
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "@types/d3-color": "^1.2.2",
     "@types/shortid": "^0.0.29",
     "d3-color": "^1.2.3",

--- a/plugins/legacy-preset-chart-nvd3/package.json
+++ b/plugins/legacy-preset-chart-nvd3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-preset-chart-nvd3",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Legacy Chart - NVD3",
   "sideEffects": [
     "*.css"
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@data-ui/xy-chart": "^0.0.84",
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "d3": "^3.5.17",
     "d3-tip": "^0.9.1",
     "dompurify": "^2.0.6",

--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/plugin-chart-echarts",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Chart - Echarts",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -26,8 +26,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "@types/mathjs": "^6.0.7",
     "d3-array": "^1.2.0",
     "echarts": "^5.1.2",

--- a/plugins/plugin-chart-pivot-table/package.json
+++ b/plugins/plugin-chart-pivot-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/plugin-chart-pivot-table",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Chart - Pivot Table",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -26,8 +26,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "@superset-ui/react-pivottable": "^0.12.12"
   },
   "peerDependencies": {

--- a/plugins/plugin-chart-table/package.json
+++ b/plugins/plugin-chart-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/plugin-chart-table",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Chart - Table",
   "main": "lib/index.js",
   "module": "esm/index.js",
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "@types/d3-array": "^2.9.0",
     "@types/react-table": "^7.0.29",
     "d3-array": "^2.4.0",

--- a/plugins/plugin-chart-word-cloud/package.json
+++ b/plugins/plugin-chart-word-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/plugin-chart-word-cloud",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Chart Plugin - Word Cloud",
   "sideEffects": [
     "*.css"
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "@types/d3-cloud": "^1.2.1",
     "@types/d3-scale": "^2.0.2",
     "d3-cloud": "^1.2.5",

--- a/plugins/preset-chart-xy/package.json
+++ b/plugins/preset-chart-xy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/preset-chart-xy",
-  "version": "0.17.84",
+  "version": "0.17.84-cccs.1",
   "description": "Superset Chart - XY",
   "sideEffects": [
     "*.css"
@@ -31,8 +31,8 @@
   "dependencies": {
     "@data-ui/theme": "^0.0.84",
     "@data-ui/xy-chart": "^0.0.84",
-    "@superset-ui/chart-controls": "0.17.84",
-    "@superset-ui/core": "0.17.81",
+    "@superset-ui/chart-controls": "0.17.84-cccs.0",
+    "@superset-ui/core": "0.17.81-cccs.1",
     "@vx/axis": "^0.0.198",
     "@vx/legend": "^0.0.198",
     "@vx/scale": "^0.0.197",

--- a/publish-template.yml
+++ b/publish-template.yml
@@ -1,0 +1,13 @@
+parameters:
+  workingDirs: []
+
+steps:
+- ${{ each dir in parameters.workingDirs }}:
+  - task: Npm@1
+    inputs:
+      command: publish
+      publishRegistry: useFeed
+      publishFeed: Analytical Platform/analytical-platform
+      workingDir: ${{ dir }}
+    continueOnError: true
+    displayName: "Publish package ${{ dir }}"


### PR DESCRIPTION
The table chart is able to emit filters when you click on a cell. For example a cell with 2007 in the year column.

However when you click on a cell from a metric column nothing happens. This PR adds the ability to click on a metric and emit a filter for every column of the row which contributes to the chosen metric. 